### PR TITLE
map: bound retries when iterating

### DIFF
--- a/map.go
+++ b/map.go
@@ -481,23 +481,32 @@ func (m *Map) MarshalBinary() ([]byte, error) {
 //
 // See Map.Iterate.
 type MapIterator struct {
-	target    *Map
-	prevKey   interface{}
-	prevBytes []byte
-	done      bool
-	err       error
+	target            *Map
+	prevKey           interface{}
+	prevBytes         []byte
+	count, maxEntries uint32
+	done              bool
+	err               error
 }
 
 func newMapIterator(target *Map) *MapIterator {
 	return &MapIterator{
-		target:    target,
-		prevBytes: make([]byte, int(target.abi.KeySize)),
+		target:     target,
+		maxEntries: target.abi.MaxEntries,
+		prevBytes:  make([]byte, int(target.abi.KeySize)),
 	}
 }
 
+var errIterationAborted = errors.New("iteration aborted")
+
 // Next decodes the next key and value.
 //
-// Returns false if there are no more entries.
+// Iterating a hash map from which keys are being deleted is not
+// safe. You may see the same key multiple times. Iteration may
+// also abort with an error, see IsIterationAborted.
+//
+// Returns false if there are no more entries. You must check
+// the result of Err afterwards.
 //
 // See Map.Get for further caveats around valueOut.
 func (mi *MapIterator) Next(keyOut, valueOut interface{}) bool {
@@ -505,7 +514,7 @@ func (mi *MapIterator) Next(keyOut, valueOut interface{}) bool {
 		return false
 	}
 
-	for {
+	for ; mi.count < mi.maxEntries; mi.count++ {
 		var nextBytes []byte
 		nextBytes, mi.err = mi.target.NextKeyBytes(mi.prevKey)
 		if mi.err != nil {
@@ -529,11 +538,11 @@ func (mi *MapIterator) Next(keyOut, valueOut interface{}) bool {
 			// Even though the key should be valid, we couldn't look up
 			// its value. If we're iterating a hash map this is probably
 			// because a concurrent delete removed the value before we
-			// could get it. If we're iterating one of the fd maps like
+			// could get it. This means that the next call to NextKeyBytes
+			// is very likely to restart iteration.
+			// If we're iterating one of the fd maps like
 			// ProgramArray it means that a given slot doesn't have
-			// a valid fd associated.
-			// In either case there isn't much we can do, so just
-			// continue to the next key.
+			// a valid fd associated. It's OK to continue to the next slot.
 			continue
 		}
 		if mi.err != nil {
@@ -543,6 +552,9 @@ func (mi *MapIterator) Next(keyOut, valueOut interface{}) bool {
 		mi.err = unmarshalBytes(keyOut, nextBytes)
 		return mi.err == nil
 	}
+
+	mi.err = errIterationAborted
+	return false
 }
 
 // Err returns any encountered error.
@@ -556,4 +568,11 @@ func (mi *MapIterator) Err() error {
 // key doesn't exist.
 func IsNotExist(err error) bool {
 	return errors.Cause(err) == unix.ENOENT
+}
+
+// IsIterationAborted returns true if the iteration was aborted.
+//
+// This occurs when keys are deleted from a hash map during iteration.
+func IsIterationAborted(err error) bool {
+	return errors.Cause(err) == errIterationAborted
 }

--- a/map_test.go
+++ b/map_test.go
@@ -290,7 +290,15 @@ func TestIterateEmptyMap(t *testing.T) {
 }
 
 func TestMapIterate(t *testing.T) {
-	hash := createHash()
+	hash, err := NewMap(&MapSpec{
+		Type:       Hash,
+		KeySize:    5,
+		ValueSize:  4,
+		MaxEntries: 2,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer hash.Close()
 
 	if err := hash.Put("hello", uint32(21)); err != nil {
@@ -316,6 +324,9 @@ func TestMapIterate(t *testing.T) {
 
 	sort.Strings(keys)
 
+	if n := len(keys); n != 2 {
+		t.Fatal("Expected to get 2 keys, have", n)
+	}
 	if keys[0] != "hello" {
 		t.Error("Expected index 0 to be hello, got", keys[0])
 	}


### PR DESCRIPTION
MapIterator.Next uses BPF_MAP_GET_NEXT_KEY to iterate a map. However,
there is no guarantee that a lookup makes forward progress through a
map. This is a problem with the kernel API, for which there is
currently no fix.

The problem manifests with heavily modified hashmaps, where the
race between MAP_GET_NEXT_KEY and MAP_LOOKUP_ELEM can lead to the
iterator code retrying an unbounded number of times.

Limit the iterator to MaxElems calls.

Fixes #9