### PR TITLE
fix compilation on 32-bit targets

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -19,9 +19,11 @@ blocks:
           - sudo apt-get -y update
           - sudo apt-get install -y qemu-system-x86
       jobs:
-      - name: Test build on non-Linux
+      - name: Test building on other OS and arch
         commands:
           - GOOS=darwin go build ./...
+          - GOARCH=arm GOARM=6 go build ./...
+          - GOARCH=arm64 go build ./...
       - name: Test on 5.0.13
         commands:
           - timeout -s KILL 60s ./run-tests.sh 5.0.13

--- a/syscalls.go
+++ b/syscalls.go
@@ -282,7 +282,7 @@ func bpfPinObject(fileName string, fd *bpfFD) error {
 	if err := unix.Statfs(dirName, &statfs); err != nil {
 		return err
 	}
-	if statfs.Type != bpfFSType {
+	if uint64(statfs.Type) != bpfFSType {
 		return errors.Errorf("%s is not on a bpf filesystem", fileName)
 	}
 


### PR DESCRIPTION
The magic number for bpffs doesn't fit in Statfs_t.Type on 32bit arch,
which leads to a compilation error. Looking at the kernel source, the
thing to do is to treat the magic number as unsigned.

Fixes #18