### PR TITLE
syscalls: fix pointer padding on 32bit big endian arches

### DIFF
--- a/ptr_32_be.go
+++ b/ptr_32_be.go
@@ -9,6 +9,6 @@ import (
 // ptr wraps an unsafe.Pointer to be 64bit to
 // conform to the syscall specification.
 type syscallPtr struct {
-	ptr unsafe.Pointer
 	pad uint32
+	ptr unsafe.Pointer
 }


### PR DESCRIPTION
Given a 32 bit big endian pointer {01, 02, 03, 04}, it's 64 bit
representation should be {00, 00, 00, 00, 01, 02, 03, 04}. Therefore
the current order of syscallPtr is wrong.

Fixes #17