### PR TITLE
Update kernels and use 2 CPUs on CI

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -24,9 +24,9 @@ blocks:
           - GOOS=darwin go build ./...
           - GOARCH=arm GOARM=6 go build ./...
           - GOARCH=arm64 go build ./...
-      - name: Test on 5.0.13
+      - name: Test on 5.3.8
         commands:
-          - timeout -s KILL 60s ./run-tests.sh 5.0.13
-      - name: Test on 4.19.40
+          - timeout -s KILL 60s ./run-tests.sh 5.3.8
+      - name: Test on 4.19.81
         commands:
-          - timeout -s KILL 60s ./run-tests.sh 4.19.40
+          - timeout -s KILL 60s ./run-tests.sh 4.19.81

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -50,7 +50,7 @@ test -e "${tmp_dir}/${kernel}" || {
 }
 
 echo Testing on ${kernel_version}
-$sudo virtme-run --kimg "${tmp_dir}/${kernel}" --memory 256M --pwd --rwdir=/run/output="${output}" --script-sh "$(realpath "$0") --in-vm /run/output"
+$sudo virtme-run --kimg "${tmp_dir}/${kernel}" --memory 256M --pwd --rwdir=/run/output="${output}" --script-sh "$(realpath "$0") --in-vm /run/output" --qemu-opts -smp 2
 
 if [[ ! -e "${output}/success" ]]; then
   echo "Test failed on ${kernel_version}"


### PR DESCRIPTION
Sockmaps require BPF_STREAM_PARSER to be enabled for the kernel,
which wasn't the case so far. Also run QEMU with two CPUs, so
that the per-CPU marshalling test can run.