### PR TITLE
Add support for pausing/resuming perf readers

### DIFF
--- a/internal/unix/types_linux.go
+++ b/internal/unix/types_linux.go
@@ -30,6 +30,7 @@ const (
 	PerfBitWatermark         = linux.PerfBitWatermark
 	PERF_SAMPLE_RAW          = linux.PERF_SAMPLE_RAW
 	PERF_FLAG_FD_CLOEXEC     = linux.PERF_FLAG_FD_CLOEXEC
+	RLIM_INFINITY            = linux.RLIM_INFINITY
 )
 
 // Statfs_t is a wrapper

--- a/perf/reader.go
+++ b/perf/reader.go
@@ -133,6 +133,9 @@ func readRawSample(rd io.Reader) ([]byte, error) {
 // Reader allows reading bpf_perf_event_output
 // from user space.
 type Reader struct {
+	// mu protects read/write access to the Reader structure with the
+	// exception of 'pauseFds', which is protected by 'pauseMu'.
+	// If locking both 'mu' and 'pauseMu', 'mu' must be locked first.
 	mu sync.Mutex
 
 	// Closing a PERF_EVENT_ARRAY removes all event fds
@@ -147,6 +150,12 @@ type Reader struct {
 	closeFd int
 	// Ensure we only close once
 	closeOnce sync.Once
+
+	// pauseFds are a copy of the fds in 'rings', protected by 'pauseMu'.
+	// These allow Pause/Resume to be executed independently of any ongoing
+	// Read calls, which would otherwise need to be interrupted.
+	pauseMu  sync.Mutex
+	pauseFds []int
 }
 
 // ReaderOptions control the behaviour of the user
@@ -179,9 +188,10 @@ func NewReaderWithOptions(array *ebpf.Map, perCPUBuffer int, opts ReaderOptions)
 	}
 
 	var (
-		fds   = []int{epollFd}
-		nCPU  = int(array.ABI().MaxEntries)
-		rings = make([]*perfEventRing, 0, nCPU)
+		fds      = []int{epollFd}
+		nCPU     = int(array.ABI().MaxEntries)
+		rings    = make([]*perfEventRing, 0, nCPU)
+		pauseFds = make([]int, 0, nCPU)
 	)
 
 	defer func() {
@@ -204,6 +214,7 @@ func NewReaderWithOptions(array *ebpf.Map, perCPUBuffer int, opts ReaderOptions)
 			return nil, errors.Wrapf(err, "failed to create perf ring for CPU %d", i)
 		}
 		rings = append(rings, ring)
+		pauseFds = append(pauseFds, ring.fd)
 
 		if err := addToEpoll(epollFd, ring.fd, len(rings)-1); err != nil {
 			return nil, err
@@ -233,6 +244,10 @@ func NewReaderWithOptions(array *ebpf.Map, perCPUBuffer int, opts ReaderOptions)
 		epollEvents: make([]unix.EpollEvent, len(rings)+1),
 		epollRings:  make([]*perfEventRing, 0, len(rings)),
 		closeFd:     closeFd,
+		pauseFds:    pauseFds,
+	}
+	if err = pr.Resume(); err != nil {
+		return nil, err
 	}
 	if err = pr.Resume(); err != nil {
 		return nil, err
@@ -261,10 +276,12 @@ func (pr *Reader) Close() error {
 			return
 		}
 
-		// Acquire the lock. This ensures that Read
-		// isn't running.
+		// Acquire the locks. This ensures that Read, Pause and Resume
+		// aren't running.
 		pr.mu.Lock()
 		defer pr.mu.Unlock()
+		pr.pauseMu.Lock()
+		defer pr.pauseMu.Unlock()
 
 		unix.Close(pr.epollFd)
 		unix.Close(pr.closeFd)
@@ -275,6 +292,7 @@ func (pr *Reader) Close() error {
 			ring.Close()
 		}
 		pr.rings = nil
+		pr.pauseFds = nil
 
 		pr.array.Close()
 	})
@@ -340,14 +358,21 @@ func (pr *Reader) Read() (Record, error) {
 	}
 }
 
-// Pause stops all notifications from this perf reader.
+// Pause stops all notifications from this Reader.
+//
+// While the Reader is paused, any attempts to write to the event buffer from
+// BPF programs will return -ENOENT.
 //
 // Subsequent calls to Read will block until a call to Resume.
 func (pr *Reader) Pause() error {
-	pr.mu.Lock()
-	defer pr.mu.Unlock()
+	pr.pauseMu.Lock()
+	defer pr.pauseMu.Unlock()
 
-	for i := 0; i < len(pr.rings); i++ {
+	if pr.pauseFds == nil {
+		return errClosed
+	}
+
+	for i := 0; i < len(pr.pauseFds); i++ {
 		if err := pr.array.Delete(uint32(i)); err != nil && !ebpf.IsNotExist(err) {
 			return errors.Wrapf(err, "could't delete event fd for CPU %d", i)
 		}
@@ -360,12 +385,17 @@ func (pr *Reader) Pause() error {
 //
 // Subsequent calls to Read will block until the next event notification.
 func (pr *Reader) Resume() error {
-	pr.mu.Lock()
-	defer pr.mu.Unlock()
+	pr.pauseMu.Lock()
+	defer pr.pauseMu.Unlock()
 
-	for i := 0; i < len(pr.rings); i++ {
-		if err := pr.array.Put(uint32(i), uint32(pr.rings[i].fd)); err != nil {
-			return errors.Wrapf(err, "could't put event fd for CPU %d", i)
+	if pr.pauseFds == nil {
+		return errClosed
+	}
+
+	for i := 0; i < len(pr.pauseFds); i++ {
+		fd := uint32(pr.pauseFds[i])
+		if err := pr.array.Put(uint32(i), fd); err != nil {
+			return errors.Wrapf(err, "could't put event fd %d for CPU %d", fd, i)
 		}
 	}
 

--- a/perf/reader_test.go
+++ b/perf/reader_test.go
@@ -15,6 +15,17 @@ import (
 	"github.com/cilium/ebpf/internal/unix"
 )
 
+func TestMain(m *testing.M) {
+	err := unix.Setrlimit(8, &unix.Rlimit{
+		Cur: unix.RLIM_INFINITY,
+		Max: unix.RLIM_INFINITY,
+	})
+	if err != nil {
+		fmt.Println("WARNING: Failed to adjust rlimit, tests may fail")
+	}
+	os.Exit(m.Run())
+}
+
 func TestPerfReader(t *testing.T) {
 	prog, events := mustOutputSamplesProg(t, 5)
 	defer prog.Close()

--- a/perf/reader_test.go
+++ b/perf/reader_test.go
@@ -378,11 +378,11 @@ func TestPause(t *testing.T) {
 	}
 
 	// Pause/Resume after close should be no-op.
-	if err = rd.Pause(); err != nil {
-		t.Fatal(err)
+	if err = rd.Pause(); err != errClosed {
+		t.Fatalf("Unexpected error: %s", err)
 	}
-	if err = rd.Resume(); err != nil {
-		t.Fatal(err)
+	if err = rd.Resume(); err != errClosed {
+		t.Fatalf("Unexpected error: %s", err)
 	}
 }
 

--- a/perf/reader_test.go
+++ b/perf/reader_test.go
@@ -15,6 +15,10 @@ import (
 	"github.com/cilium/ebpf/internal/unix"
 )
 
+var (
+	readTimeout = 250 * time.Millisecond
+)
+
 func TestMain(m *testing.M) {
 	err := unix.Setrlimit(8, &unix.Rlimit{
 		Cur: unix.RLIM_INFINITY,
@@ -295,6 +299,90 @@ func TestReadRecord(t *testing.T) {
 	_, err = readRecord(&buf, 0)
 	if !IsUnknownEvent(err) {
 		t.Error("readRecord should return unknown event error, got", err)
+	}
+}
+
+func TestPause(t *testing.T) {
+	t.Parallel()
+
+	prog, events := mustOutputSamplesProg(t, 5)
+	defer prog.Close()
+	defer events.Close()
+
+	rd, err := NewReader(events, 4096)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rd.Close()
+
+	// Reader is already unpaused by default. It should be idempotent.
+	if err = rd.Resume(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write a sample. The reader should read it.
+	ret, _, err := prog.Test(make([]byte, 14))
+	if err != nil || ret != 0 {
+		t.Fatal("Can't write sample")
+	}
+	if _, err := rd.Read(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Pause. No notification should trigger.
+	if err = rd.Pause(); err != nil {
+		t.Fatal(err)
+	}
+	errChan := make(chan error, 1)
+	go func() {
+		// Read one notification then send any errors and exit.
+		_, err := rd.Read()
+		errChan <- err
+	}()
+	ret, _, err = prog.Test(make([]byte, 14))
+	if err == nil && ret == 0 {
+		t.Fatal("Unexpectedly wrote sample while paused")
+	} // else Success
+	select {
+	case err := <-errChan:
+		// Failure: Pause was unsuccessful.
+		t.Fatalf("received notification on paused reader: %s", err)
+	case <-time.After(readTimeout):
+		// Success
+	}
+
+	// Pause should be idempotent.
+	if err = rd.Pause(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Resume. Now notifications should continue.
+	if err = rd.Resume(); err != nil {
+		t.Fatal(err)
+	}
+	ret, _, err = prog.Test(make([]byte, 14))
+	if err != nil || ret != 0 {
+		t.Fatal("Can't write sample")
+	}
+	select {
+	case err := <-errChan:
+		if err != nil {
+			t.Fatal(err)
+		} // else Success
+	case <-time.After(readTimeout):
+		t.Fatal("timed out waiting for notification after resume")
+	}
+
+	if err = rd.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Pause/Resume after close should be no-op.
+	if err = rd.Pause(); err != nil {
+		t.Fatal(err)
+	}
+	if err = rd.Resume(); err != nil {
+		t.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
This implementation is inspired by the upstream Cilium commit
[ce6244109bd0](http://github.com/cilium/cilium/commit/ce6244109bd0) ("cilium: add Mute/Unmute function for perf RB") by Daniel
Borkmann, to support enabling and disabling perf ringbuffer
notifications at runtime.

On the way, I fixed running the perf unit tests via `sudo go test ./...`.