### PR TITLE
CI: test on 5.4 instead of 5.3

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -24,9 +24,9 @@ blocks:
           - GOOS=darwin go build ./...
           - GOARCH=arm GOARM=6 go build ./...
           - GOARCH=arm64 go build ./...
-      - name: Test on 5.3.8
+      - name: Test on 5.4.5
         commands:
-          - timeout -s KILL 60s ./run-tests.sh 5.3.8
+          - timeout -s KILL 60s ./run-tests.sh 5.4.5
       - name: Test on 4.19.81
         commands:
           - timeout -s KILL 60s ./run-tests.sh 4.19.81

--- a/internal/btf/btf_test.go
+++ b/internal/btf/btf_test.go
@@ -44,6 +44,32 @@ func TestParseVmlinux(t *testing.T) {
 	}
 }
 
+func TestParseCurrentKernelBTF(t *testing.T) {
+	if _, err := os.Stat("/sys/kernel/btf/vmlinux"); os.IsNotExist(err) {
+		t.Skip("/sys/kernel/btf/vmlinux is not available")
+	}
+
+	fh, err := os.Open("/sys/kernel/btf/vmlinux")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer fh.Close()
+
+	s, err := parseBTF(fh, binary.LittleEndian)
+	if err != nil {
+		t.Fatal("Can't load BTF:", err)
+	}
+
+	var bpfAttr Union
+	if err := s.FindType("bpf_attr", &bpfAttr); err != nil {
+		t.Fatal("Can't find btf_attr:", err)
+	}
+
+	if name := bpfAttr.Name; name != "bpf_attr" {
+		t.Error("struct bpf_attr has incorrect name:", name)
+	}
+}
+
 func TestLoadSpecFromElf(t *testing.T) {
 	fh, err := os.Open("../../testdata/loader-clang-9.elf")
 	if err != nil {


### PR DESCRIPTION
5.4 is the current LTS, while 5.3 is going to be unsupported soon.
Move testing to 5.4 and run the BTF tests against the new kernel's
builtin BTF.