### PR TITLE
Add ExistingMaps to CollectionOptions to provide possibility of map reuse when creating a collection, and slight change to PerfEventArray keysize valuesize validation

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -9,6 +9,7 @@ import (
 // CollectionOptions control loading a collection into the kernel.
 type CollectionOptions struct {
 	Programs ProgramOptions
+	ExistingMaps map[string]*Map
 }
 
 // CollectionSpec describes a collection.
@@ -96,6 +97,12 @@ func NewCollectionWithOptions(spec *CollectionSpec, opts CollectionOptions) (col
 	}
 
 	for mapName, mapSpec := range spec.Maps {
+		if opts.ExistingMaps[mapName] != nil {
+			// if an existing map of the same name is present (i.e. a map we want to reuse),
+			// we will use that one instead of creating a new one from the spec.
+			maps[mapName] = opts.ExistingMaps[mapName]
+			continue
+		}
 		var handle *btf.Handle
 		if mapSpec.BTF != nil {
 			handle, err = loadBTF(btf.MapSpec(mapSpec.BTF))

--- a/map.go
+++ b/map.go
@@ -20,7 +20,6 @@ type MapSpec struct {
 	ValueSize  uint32
 	MaxEntries uint32
 	Flags      uint32
-	Pinning    uint32
 
 	// InnerMap is used as a template for ArrayOfMaps and HashOfMaps
 	InnerMap *MapSpec

--- a/map.go
+++ b/map.go
@@ -137,16 +137,15 @@ func createMap(spec *MapSpec, inner *internal.FD, handle *btf.Handle) (*Map, err
 			if spec.ValueSize != 0 {
 				return nil, errors.Errorf("ValueSize must be zero for perf event array")
 			}
-			if spec.MaxEntries == 0 {
-				n, err := internal.OnlineCPUs()
-				if err != nil {
-					return nil, errors.Wrap(err, "perf event array")
-				}
-				spec.MaxEntries = uint32(n)
-			}
-
 			spec.KeySize = 4
 			spec.ValueSize = 4
+		}
+		if spec.MaxEntries == 0 {
+			n, err := internal.OnlineCPUs()
+			if err != nil {
+				return nil, errors.Wrap(err, "perf event array")
+			}
+			spec.MaxEntries = uint32(n)
 		}
 	}
 


### PR DESCRIPTION
This adds an optional field, ExistingMaps, to the CollectionOptions struct such that if a user wants to reuse an existing BPF map when creating a new collection, the user can add Map objects to ExistingMaps, and if there is a MapSpec at collection creation time with the same key as a Map in ExistingMaps, the existing map will be used instead of creating a new map. 

The use case that brought this on was for loading eBPF programs that each shared 4 "global" maps and 2 "local" maps per each interface involved. This change allows for using LoadPinnedMap to get the global maps and use them in a collection so that it only creates the local maps and reuses the global maps. 

The 2nd fix is simply allowing perf event array to not be set to 0 for keysize and valuesize since it is being hardcoded to 4 anyways; if the fields are already set to 4, we just skip the validation block. The issue is while using 0/0 works here, usage or 0/0 in other places like iproute2 and tc start throwing errors. 