### PR TITLE
migrate error handling from github.com/pkg/errors to golang.org/x/xerrors

### DIFF
--- a/abi.go
+++ b/abi.go
@@ -179,7 +179,7 @@ func scanFdInfoReader(r io.Reader, fields map[string]interface{}) error {
 		}
 
 		if n, err := fmt.Fscanln(bytes.NewReader(parts[1]), field); err != nil || n != 1 {
-			return xerrors.Errorf("can't parse field %s: %w", name, err)
+			return xerrors.Errorf("can't parse field %s: %v", name, err)
 		}
 
 		scanned++

--- a/abi.go
+++ b/abi.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/cilium/ebpf/internal"
 
-	"github.com/pkg/errors"
+	"golang.org/x/xerrors"
 )
 
 // MapABI are the attributes of a Map which are available across all supported kernels.
@@ -35,7 +35,7 @@ func newMapABIFromSpec(spec *MapSpec) *MapABI {
 func newMapABIFromFd(fd *internal.FD) (string, *MapABI, error) {
 	info, err := bpfGetMapInfoByFD(fd)
 	if err != nil {
-		if errors.Cause(err) == syscall.EINVAL {
+		if xerrors.Is(err, syscall.EINVAL) {
 			abi, err := newMapABIFromProc(fd)
 			return "", abi, err
 		}
@@ -98,7 +98,7 @@ func newProgramABIFromSpec(spec *ProgramSpec) *ProgramABI {
 func newProgramABIFromFd(fd *internal.FD) (string, *ProgramABI, error) {
 	info, err := bpfGetProgInfoByFD(fd)
 	if err != nil {
-		if errors.Cause(err) == syscall.EINVAL {
+		if xerrors.Is(err, syscall.EINVAL) {
 			return newProgramABIFromProc(fd)
 		}
 
@@ -127,7 +127,7 @@ func newProgramABIFromProc(fd *internal.FD) (string, *ProgramABI, error) {
 		"prog_type": &abi.Type,
 		"prog_tag":  &name,
 	})
-	if errors.Cause(err) == errMissingFields {
+	if xerrors.Is(err, errMissingFields) {
 		return "", nil, &internal.UnsupportedFeatureError{
 			Name:           "reading ABI from /proc/self/fdinfo",
 			MinimumVersion: internal.Version{4, 11, 0},
@@ -152,10 +152,13 @@ func scanFdInfo(fd *internal.FD, fields map[string]interface{}) error {
 	}
 	defer fh.Close()
 
-	return errors.Wrap(scanFdInfoReader(fh, fields), fh.Name())
+	if err := scanFdInfoReader(fh, fields); err != nil {
+		return xerrors.Errorf("%s: %w", fh.Name(), err)
+	}
+	return nil
 }
 
-var errMissingFields = errors.New("missing fields")
+var errMissingFields = xerrors.New("missing fields")
 
 func scanFdInfoReader(r io.Reader, fields map[string]interface{}) error {
 	var (
@@ -176,7 +179,7 @@ func scanFdInfoReader(r io.Reader, fields map[string]interface{}) error {
 		}
 
 		if n, err := fmt.Fscanln(bytes.NewReader(parts[1]), field); err != nil || n != 1 {
-			return errors.Wrapf(err, "can't parse field %s", name)
+			return xerrors.Errorf("can't parse field %s: %w", name, err)
 		}
 
 		scanned++

--- a/collection.go
+++ b/collection.go
@@ -3,7 +3,7 @@ package ebpf
 import (
 	"github.com/cilium/ebpf/asm"
 	"github.com/cilium/ebpf/internal/btf"
-	"github.com/pkg/errors"
+	"golang.org/x/xerrors"
 )
 
 // CollectionOptions control loading a collection into the kernel.
@@ -106,7 +106,7 @@ func NewCollectionWithOptions(spec *CollectionSpec, opts CollectionOptions) (col
 
 		m, err := newMapWithBTF(mapSpec, handle)
 		if err != nil {
-			return nil, errors.Wrapf(err, "map %s", mapName)
+			return nil, xerrors.Errorf("map %s: %w", mapName, err)
 		}
 		maps[mapName] = m
 	}
@@ -132,7 +132,7 @@ func NewCollectionWithOptions(spec *CollectionSpec, opts CollectionOptions) (col
 			}
 
 			if err := ins.RewriteMapPtr(m.FD()); err != nil {
-				return nil, errors.Wrapf(err, "progam %s: map %s", progName, ins.Reference)
+				return nil, xerrors.Errorf("progam %s: map %s: %w", progName, ins.Reference, err)
 			}
 		}
 
@@ -146,7 +146,7 @@ func NewCollectionWithOptions(spec *CollectionSpec, opts CollectionOptions) (col
 
 		prog, err := newProgramWithBTF(progSpec, handle, opts.Programs)
 		if err != nil {
-			return nil, errors.Wrapf(err, "program %s", progName)
+			return nil, xerrors.Errorf("program %s: %w", progName, err)
 		}
 		progs[progName] = prog
 	}

--- a/elf_reader.go
+++ b/elf_reader.go
@@ -48,7 +48,7 @@ func LoadCollectionSpecFromReader(rd io.ReaderAt) (*CollectionSpec, error) {
 
 	symbols, err := f.Symbols()
 	if err != nil {
-		return nil, xerrors.Errorf("load symbols: %w", err)
+		return nil, xerrors.Errorf("load symbols: %v", err)
 	}
 
 	ec := &elfCode{f, symbols, symbolsPerSection(symbols), "", 0}

--- a/elf_reader.go
+++ b/elf_reader.go
@@ -12,7 +12,7 @@ import (
 	"github.com/cilium/ebpf/internal"
 	"github.com/cilium/ebpf/internal/btf"
 
-	"github.com/pkg/errors"
+	"golang.org/x/xerrors"
 )
 
 type elfCode struct {
@@ -32,7 +32,10 @@ func LoadCollectionSpec(file string) (*CollectionSpec, error) {
 	defer f.Close()
 
 	spec, err := LoadCollectionSpecFromReader(f)
-	return spec, errors.Wrapf(err, "file %s", file)
+	if err != nil {
+		return &CollectionSpec{}, xerrors.Errorf("file %s: %w", file, err)
+	}
+	return spec, nil
 }
 
 // LoadCollectionSpecFromReader parses an ELF file into a CollectionSpec.
@@ -45,7 +48,7 @@ func LoadCollectionSpecFromReader(rd io.ReaderAt) (*CollectionSpec, error) {
 
 	symbols, err := f.Symbols()
 	if err != nil {
-		return nil, errors.Wrap(err, "load symbols")
+		return nil, xerrors.Errorf("load symbols: %w", err)
 	}
 
 	ec := &elfCode{f, symbols, symbolsPerSection(symbols), "", 0}
@@ -71,13 +74,13 @@ func LoadCollectionSpecFromReader(rd io.ReaderAt) (*CollectionSpec, error) {
 			btfMaps[elf.SectionIndex(i)] = sec
 		case sec.Type == elf.SHT_REL:
 			if int(sec.Info) >= len(ec.Sections) {
-				return nil, errors.Errorf("found relocation section %v for missing section %v", i, sec.Info)
+				return nil, xerrors.Errorf("found relocation section %v for missing section %v", i, sec.Info)
 			}
 
 			// Store relocations under the section index of the target
 			idx := elf.SectionIndex(sec.Info)
 			if relSections[idx] != nil {
-				return nil, errors.Errorf("section %d has multiple relocation sections", sec.Info)
+				return nil, xerrors.Errorf("section %d has multiple relocation sections", sec.Info)
 			}
 			relSections[idx] = sec
 		case sec.Type == elf.SHT_PROGBITS && (sec.Flags&elf.SHF_EXECINSTR) != 0 && sec.Size > 0:
@@ -87,34 +90,34 @@ func LoadCollectionSpecFromReader(rd io.ReaderAt) (*CollectionSpec, error) {
 
 	ec.license, err = loadLicense(licenseSection)
 	if err != nil {
-		return nil, errors.Wrap(err, "load license")
+		return nil, xerrors.Errorf("load license: %w", err)
 	}
 
 	ec.version, err = loadVersion(versionSection, ec.ByteOrder)
 	if err != nil {
-		return nil, errors.Wrap(err, "load version")
+		return nil, xerrors.Errorf("load version: %w", err)
 	}
 
 	btf, err := btf.LoadSpecFromReader(rd)
 	if err != nil {
-		return nil, errors.Wrap(err, "load BTF")
+		return nil, xerrors.Errorf("load BTF: %w", err)
 	}
 
 	maps := make(map[string]*MapSpec)
 
 	if err := ec.loadMaps(maps, mapSections); err != nil {
-		return nil, errors.Wrap(err, "load maps")
+		return nil, xerrors.Errorf("load maps: %w", err)
 	}
 
 	if len(btfMaps) > 0 {
 		if err := ec.loadBTFMaps(maps, btfMaps, btf); err != nil {
-			return nil, errors.Wrap(err, "load BTF maps")
+			return nil, xerrors.Errorf("load BTF maps: %w", err)
 		}
 	}
 
 	progs, err := ec.loadPrograms(progSections, relSections, btf)
 	if err != nil {
-		return nil, errors.Wrap(err, "load programs")
+		return nil, xerrors.Errorf("load programs: %w", err)
 	}
 
 	return &CollectionSpec{maps, progs}, nil
@@ -122,11 +125,11 @@ func LoadCollectionSpecFromReader(rd io.ReaderAt) (*CollectionSpec, error) {
 
 func loadLicense(sec *elf.Section) (string, error) {
 	if sec == nil {
-		return "", errors.Errorf("missing license section")
+		return "", xerrors.Errorf("missing license section")
 	}
 	data, err := sec.Data()
 	if err != nil {
-		return "", errors.Wrapf(err, "section %s", sec.Name)
+		return "", xerrors.Errorf("section %s: %w", sec.Name, err)
 	}
 	return string(bytes.TrimRight(data, "\000")), nil
 }
@@ -137,8 +140,10 @@ func loadVersion(sec *elf.Section, bo binary.ByteOrder) (uint32, error) {
 	}
 
 	var version uint32
-	err := binary.Read(sec.Open(), bo, &version)
-	return version, errors.Wrapf(err, "section %s", sec.Name)
+	if err := binary.Read(sec.Open(), bo, &version); err != nil {
+		return version, xerrors.Errorf("section %s: %w", sec.Name, err)
+	}
+	return version, nil
 }
 
 func (ec *elfCode) loadPrograms(progSections, relSections map[elf.SectionIndex]*elf.Section, btf *btf.Spec) (map[string]*ProgramSpec, error) {
@@ -150,22 +155,22 @@ func (ec *elfCode) loadPrograms(progSections, relSections map[elf.SectionIndex]*
 	for idx, prog := range progSections {
 		syms := ec.symbolsPerSection[idx]
 		if len(syms) == 0 {
-			return nil, errors.Errorf("section %v: missing symbols", prog.Name)
+			return nil, xerrors.Errorf("section %v: missing symbols", prog.Name)
 		}
 
 		funcSym := syms[0]
 		if funcSym == "" {
-			return nil, errors.Errorf("section %v: no label at start", prog.Name)
+			return nil, xerrors.Errorf("section %v: no label at start", prog.Name)
 		}
 
 		rels, err := ec.loadRelocations(relSections[idx])
 		if err != nil {
-			return nil, errors.Wrapf(err, "program %s: can't load relocations", funcSym)
+			return nil, xerrors.Errorf("program %s: can't load relocations: %w", funcSym, err)
 		}
 
 		insns, length, err := ec.loadInstructions(prog, syms, rels)
 		if err != nil {
-			return nil, errors.Wrapf(err, "program %s: can't unmarshal instructions", funcSym)
+			return nil, xerrors.Errorf("program %s: can't unmarshal instructions: %w", funcSym, err)
 		}
 
 		progType, attachType := getProgType(prog.Name)
@@ -182,7 +187,7 @@ func (ec *elfCode) loadPrograms(progSections, relSections map[elf.SectionIndex]*
 		if btf != nil {
 			spec.BTF, err = btf.Program(prog.Name, length)
 			if err != nil {
-				return nil, errors.Wrapf(err, "BTF for section %s (program %s)", prog.Name, funcSym)
+				return nil, xerrors.Errorf("BTF for section %s (program %s): %w", prog.Name, funcSym, err)
 			}
 		}
 
@@ -200,7 +205,7 @@ func (ec *elfCode) loadPrograms(progSections, relSections map[elf.SectionIndex]*
 	for _, prog := range progs {
 		err := link(prog, libs)
 		if err != nil {
-			return nil, errors.Wrapf(err, "program %s", prog.Name)
+			return nil, xerrors.Errorf("program %s: %w", prog.Name, err)
 		}
 		res[prog.Name] = prog
 	}
@@ -221,7 +226,7 @@ func (ec *elfCode) loadInstructions(section *elf.Section, symbols, relocations m
 			return insns, offset, nil
 		}
 		if err != nil {
-			return nil, 0, errors.Wrapf(err, "offset %d", offset)
+			return nil, 0, xerrors.Errorf("offset %d: %w", offset, err)
 		}
 
 		ins.Symbol = symbols[offset]
@@ -236,11 +241,11 @@ func (ec *elfCode) loadMaps(maps map[string]*MapSpec, mapSections map[elf.Sectio
 	for idx, sec := range mapSections {
 		syms := ec.symbolsPerSection[idx]
 		if len(syms) == 0 {
-			return errors.Errorf("section %v: no symbols", sec.Name)
+			return xerrors.Errorf("section %v: no symbols", sec.Name)
 		}
 
 		if sec.Size%uint64(len(syms)) != 0 {
-			return errors.Errorf("section %v: map descriptors are not of equal size", sec.Name)
+			return xerrors.Errorf("section %v: map descriptors are not of equal size", sec.Name)
 		}
 
 		var (
@@ -250,11 +255,11 @@ func (ec *elfCode) loadMaps(maps map[string]*MapSpec, mapSections map[elf.Sectio
 		for i, offset := 0, uint64(0); i < len(syms); i, offset = i+1, offset+size {
 			mapSym := syms[offset]
 			if mapSym == "" {
-				return errors.Errorf("section %s: missing symbol for map at offset %d", sec.Name, offset)
+				return xerrors.Errorf("section %s: missing symbol for map at offset %d", sec.Name, offset)
 			}
 
 			if maps[mapSym] != nil {
-				return errors.Errorf("section %v: map %v already exists", sec.Name, mapSym)
+				return xerrors.Errorf("section %v: map %v already exists", sec.Name, mapSym)
 			}
 
 			lr := io.LimitReader(r, int64(size))
@@ -262,19 +267,19 @@ func (ec *elfCode) loadMaps(maps map[string]*MapSpec, mapSections map[elf.Sectio
 			var spec MapSpec
 			switch {
 			case binary.Read(lr, ec.ByteOrder, &spec.Type) != nil:
-				return errors.Errorf("map %v: missing type", mapSym)
+				return xerrors.Errorf("map %v: missing type", mapSym)
 			case binary.Read(lr, ec.ByteOrder, &spec.KeySize) != nil:
-				return errors.Errorf("map %v: missing key size", mapSym)
+				return xerrors.Errorf("map %v: missing key size", mapSym)
 			case binary.Read(lr, ec.ByteOrder, &spec.ValueSize) != nil:
-				return errors.Errorf("map %v: missing value size", mapSym)
+				return xerrors.Errorf("map %v: missing value size", mapSym)
 			case binary.Read(lr, ec.ByteOrder, &spec.MaxEntries) != nil:
-				return errors.Errorf("map %v: missing max entries", mapSym)
+				return xerrors.Errorf("map %v: missing max entries", mapSym)
 			case binary.Read(lr, ec.ByteOrder, &spec.Flags) != nil:
-				return errors.Errorf("map %v: missing flags", mapSym)
+				return xerrors.Errorf("map %v: missing flags", mapSym)
 			}
 
 			if _, err := io.Copy(internal.DiscardZeroes{}, lr); err != nil {
-				return errors.Errorf("map %v: unknown and non-zero fields in definition", mapSym)
+				return xerrors.Errorf("map %v: unknown and non-zero fields in definition", mapSym)
 			}
 
 			maps[mapSym] = &spec
@@ -287,28 +292,28 @@ func (ec *elfCode) loadMaps(maps map[string]*MapSpec, mapSections map[elf.Sectio
 func (ec *elfCode) loadBTFMaps(maps map[string]*MapSpec, mapSections map[elf.SectionIndex]*elf.Section, spec *btf.Spec) error {
 
 	if spec == nil {
-		return errors.Errorf("missing BTF")
+		return xerrors.Errorf("missing BTF")
 	}
 
 	for idx, sec := range mapSections {
 		syms := ec.symbolsPerSection[idx]
 		if len(syms) == 0 {
-			return errors.Errorf("section %v: no symbols", sec.Name)
+			return xerrors.Errorf("section %v: no symbols", sec.Name)
 		}
 
 		for _, sym := range syms {
 			if maps[sym] != nil {
-				return errors.Errorf("section %v: map %v already exists", sec.Name, sym)
+				return xerrors.Errorf("section %v: map %v already exists", sec.Name, sym)
 			}
 
 			btfMap, err := spec.Map(sym)
 			if err != nil {
-				return errors.Wrapf(err, "map %v: can't get BTF", sym)
+				return xerrors.Errorf("map %v: can't get BTF: %w", sym, err)
 			}
 
 			spec, err := mapSpecFromBTF(btfMap)
 			if err != nil {
-				return errors.Wrapf(err, "map %v", sym)
+				return xerrors.Errorf("map %v: %w", sym, err)
 			}
 
 			maps[sym] = spec
@@ -328,36 +333,36 @@ func mapSpecFromBTF(btfMap *btf.Map) (*MapSpec, error) {
 		case "type":
 			mapType, err = uintFromBTF(member.Type)
 			if err != nil {
-				return nil, errors.Wrap(err, "can't get type")
+				return nil, xerrors.Errorf("can't get type: %w", err)
 			}
 
 		case "map_flags":
 			flags, err = uintFromBTF(member.Type)
 			if err != nil {
-				return nil, errors.Wrap(err, "can't get BTF map flags")
+				return nil, xerrors.Errorf("can't get BTF map flags: %w", err)
 			}
 
 		case "max_entries":
 			maxEntries, err = uintFromBTF(member.Type)
 			if err != nil {
-				return nil, errors.Wrap(err, "can't get BTF map max entries")
+				return nil, xerrors.Errorf("can't get BTF map max entries: %w", err)
 			}
 
 		case "key":
 		case "value":
 		default:
-			return nil, errors.Errorf("unrecognized field %s in BTF map definition", member.Name)
+			return nil, xerrors.Errorf("unrecognized field %s in BTF map definition", member.Name)
 		}
 	}
 
 	keySize, err := btf.Sizeof(btf.MapKey(btfMap))
 	if err != nil {
-		return nil, errors.Wrap(err, "can't get size of BTF key")
+		return nil, xerrors.Errorf("can't get size of BTF key: %w", err)
 	}
 
 	valueSize, err := btf.Sizeof(btf.MapValue(btfMap))
 	if err != nil {
-		return nil, errors.Wrap(err, "can't get size of BTF value")
+		return nil, xerrors.Errorf("can't get size of BTF value: %w", err)
 	}
 
 	return &MapSpec{
@@ -375,12 +380,12 @@ func mapSpecFromBTF(btfMap *btf.Map) (*MapSpec, error) {
 func uintFromBTF(typ btf.Type) (uint32, error) {
 	ptr, ok := typ.(*btf.Pointer)
 	if !ok {
-		return 0, errors.Errorf("not a pointer: %v", typ)
+		return 0, xerrors.Errorf("not a pointer: %v", typ)
 	}
 
 	arr, ok := ptr.Target.(*btf.Array)
 	if !ok {
-		return 0, errors.Errorf("not a pointer to array: %v", typ)
+		return 0, xerrors.Errorf("not a pointer to array: %v", typ)
 	}
 
 	return arr.Nelems, nil
@@ -471,7 +476,7 @@ func (ec *elfCode) loadRelocations(sec *elf.Section) (map[uint64]string, error) 
 	}
 
 	if sec.Entsize < 16 {
-		return nil, errors.New("rels are less than 16 bytes")
+		return nil, xerrors.New("rels are less than 16 bytes")
 	}
 
 	r := sec.Open()
@@ -480,12 +485,12 @@ func (ec *elfCode) loadRelocations(sec *elf.Section) (map[uint64]string, error) 
 
 		var rel elf.Rel64
 		if binary.Read(ent, ec.ByteOrder, &rel) != nil {
-			return nil, errors.Errorf("can't parse relocation at offset %v", off)
+			return nil, xerrors.Errorf("can't parse relocation at offset %v", off)
 		}
 
 		symNo := int(elf.R_SYM64(rel.Info) - 1)
 		if symNo >= len(ec.symbols) {
-			return nil, errors.Errorf("relocation at offset %d: symbol %v doesnt exist", off, symNo)
+			return nil, xerrors.Errorf("relocation at offset %d: symbol %v doesnt exist", off, symNo)
 		}
 
 		rels[rel.Off] = ec.symbols[symNo].Name

--- a/elf_reader.go
+++ b/elf_reader.go
@@ -141,7 +141,7 @@ func loadVersion(sec *elf.Section, bo binary.ByteOrder) (uint32, error) {
 
 	var version uint32
 	if err := binary.Read(sec.Open(), bo, &version); err != nil {
-		return version, xerrors.Errorf("section %s: %w", sec.Name, err)
+		return version, xerrors.Errorf("section %s: %v", sec.Name, err)
 	}
 	return version, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/cilium/ebpf
 go 1.12
 
 require (
-	github.com/pkg/errors v0.8.1
 	golang.org/x/sys v0.0.0-20191022100944-742c48ecaeb7
+	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
-github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 golang.org/x/sys v0.0.0-20191022100944-742c48ecaeb7 h1:HmbHVPwrPEKPGLAcHSrMe6+hqSUlvZU0rab6x5EXfGU=
 golang.org/x/sys v0.0.0-20191022100944-742c48ecaeb7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/internal/btf/btf.go
+++ b/internal/btf/btf.go
@@ -13,7 +13,7 @@ import (
 	"github.com/cilium/ebpf/internal"
 	"github.com/cilium/ebpf/internal/unix"
 
-	"github.com/pkg/errors"
+	"golang.org/x/xerrors"
 )
 
 const btfMagic = 0xeB9F
@@ -75,7 +75,7 @@ func LoadSpecFromReader(rd io.ReaderAt) (*Spec, error) {
 	if btfExtSection != nil {
 		spec.funcInfos, spec.lineInfos, err = parseExtInfos(btfExtSection.Open(), file.ByteOrder, spec.strings)
 		if err != nil {
-			return nil, errors.Wrap(err, "can't read ext info")
+			return nil, xerrors.Errorf("can't read ext info: %w", err)
 		}
 	}
 
@@ -85,53 +85,53 @@ func LoadSpecFromReader(rd io.ReaderAt) (*Spec, error) {
 func parseBTF(btf io.ReadSeeker, bo binary.ByteOrder) (*Spec, error) {
 	rawBTF, err := ioutil.ReadAll(btf)
 	if err != nil {
-		return nil, errors.Wrap(err, "can't read BTF")
+		return nil, xerrors.Errorf("can't read BTF: %w", err)
 	}
 
 	rd := bytes.NewReader(rawBTF)
 
 	var header btfHeader
 	if err := binary.Read(rd, bo, &header); err != nil {
-		return nil, errors.Wrap(err, "can't read header")
+		return nil, xerrors.Errorf("can't read header: %w", err)
 	}
 
 	if header.Magic != btfMagic {
-		return nil, errors.Errorf("incorrect magic value %v", header.Magic)
+		return nil, xerrors.Errorf("incorrect magic value %v", header.Magic)
 	}
 
 	if header.Version != 1 {
-		return nil, errors.Errorf("unexpected version %v", header.Version)
+		return nil, xerrors.Errorf("unexpected version %v", header.Version)
 	}
 
 	if header.Flags != 0 {
-		return nil, errors.Errorf("unsupported flags %v", header.Flags)
+		return nil, xerrors.Errorf("unsupported flags %v", header.Flags)
 	}
 
 	remainder := int64(header.HdrLen) - int64(binary.Size(&header))
 	if remainder < 0 {
-		return nil, errors.New("header is too short")
+		return nil, xerrors.New("header is too short")
 	}
 
 	if _, err := io.CopyN(internal.DiscardZeroes{}, rd, remainder); err != nil {
-		return nil, errors.Wrap(err, "header padding")
+		return nil, xerrors.Errorf("header padding: %w", err)
 	}
 
 	if _, err := rd.Seek(int64(header.HdrLen+header.StringOff), io.SeekStart); err != nil {
-		return nil, errors.Wrap(err, "can't seek to start of string section")
+		return nil, xerrors.Errorf("can't seek to start of string section: %w", err)
 	}
 
 	strings, err := readStringTable(io.LimitReader(rd, int64(header.StringLen)))
 	if err != nil {
-		return nil, errors.Wrap(err, "can't read type names")
+		return nil, xerrors.Errorf("can't read type names")
 	}
 
 	if _, err := rd.Seek(int64(header.HdrLen+header.TypeOff), io.SeekStart); err != nil {
-		return nil, errors.Wrap(err, "can't seek to start of type section")
+		return nil, xerrors.Errorf("can't seek to start of type section")
 	}
 
 	rawTypes, err := readTypes(io.LimitReader(rd, int64(header.TypeLen)), bo)
 	if err != nil {
-		return nil, errors.Wrap(err, "can't read types")
+		return nil, xerrors.Errorf("can't read types")
 	}
 
 	types, err := inflateRawTypes(rawTypes, strings)
@@ -170,7 +170,7 @@ func (s *Spec) marshal(bo binary.ByteOrder) ([]byte, error) {
 		}
 
 		if err := typ.Marshal(&buf, bo); err != nil {
-			return nil, errors.Wrap(err, "can't marshal BTF")
+			return nil, xerrors.Errorf("can't marshal BTF")
 		}
 	}
 
@@ -194,7 +194,7 @@ func (s *Spec) marshal(bo binary.ByteOrder) ([]byte, error) {
 	raw := buf.Bytes()
 	err := binary.Write(sliceWriter(raw[:headerLen]), bo, header)
 	if err != nil {
-		return nil, errors.Wrap(err, "can't write header")
+		return nil, xerrors.Errorf("can't write header")
 	}
 
 	return raw, nil
@@ -204,7 +204,7 @@ type sliceWriter []byte
 
 func (sw sliceWriter) Write(p []byte) (int, error) {
 	if len(p) != len(sw) {
-		return 0, errors.New("size doesn't match")
+		return 0, xerrors.New("size doesn't match")
 	}
 
 	return copy(sw, p), nil
@@ -217,14 +217,14 @@ func (sw sliceWriter) Write(p []byte) (int, error) {
 // Returns an error if there is no BTF.
 func (s *Spec) Program(name string, length uint64) (*Program, error) {
 	if length == 0 {
-		return nil, errors.New("length musn't be zero")
+		return nil, xerrors.New("length musn't be zero")
 	}
 
 	funcInfos, funcOK := s.funcInfos[name]
 	lineInfos, lineOK := s.lineInfos[name]
 
 	if !funcOK && !lineOK {
-		return nil, errors.Errorf("no BTF for program %s", name)
+		return nil, xerrors.Errorf("no BTF for program %s", name)
 	}
 
 	return &Program{s, length, funcInfos, lineInfos}, nil
@@ -241,7 +241,7 @@ func (s *Spec) Map(name string) (*Map, error) {
 
 	mapStruct, ok := mapVar.Type.(*Struct)
 	if !ok {
-		return nil, errors.Errorf("expected struct, have %s", mapVar.Type)
+		return nil, xerrors.Errorf("expected struct, have %s", mapVar.Type)
 	}
 
 	var key, value Type
@@ -256,17 +256,17 @@ func (s *Spec) Map(name string) (*Map, error) {
 	}
 
 	if key == nil {
-		return nil, errors.Errorf("map %s: missing 'key' in type", name)
+		return nil, xerrors.Errorf("map %s: missing 'key' in type", name)
 	}
 
 	if value == nil {
-		return nil, errors.Errorf("map %s: missing 'value' in type", name)
+		return nil, xerrors.Errorf("map %s: missing 'value' in type", name)
 	}
 
 	return &Map{mapStruct, s, key, value}, nil
 }
 
-var errNotFound = errors.New("not found")
+var errNotFound = xerrors.New("not found")
 
 // FindType searches for a type with a specific name.
 //
@@ -285,14 +285,14 @@ func (s *Spec) FindType(name string, typ Type) error {
 		}
 
 		if candidate != nil {
-			return errors.Errorf("type %s: multiple candidates for %T", name, typ)
+			return xerrors.Errorf("type %s: multiple candidates for %T", name, typ)
 		}
 
 		candidate = typ
 	}
 
 	if candidate == nil {
-		return errors.WithMessagef(errNotFound, "type %s", name)
+		return xerrors.Errorf("type %s: %w", name, errNotFound)
 	}
 
 	value := reflect.Indirect(reflect.ValueOf(copyType(candidate)))
@@ -316,11 +316,11 @@ func NewHandle(spec *Spec) (*Handle, error) {
 
 	btf, err := spec.marshal(internal.NativeEndian)
 	if err != nil {
-		return nil, errors.Wrap(err, "can't marshal BTF")
+		return nil, xerrors.Errorf("can't marshal BTF")
 	}
 
 	if uint64(len(btf)) > math.MaxUint32 {
-		return nil, errors.New("BTF exceeds the maximum size")
+		return nil, xerrors.New("BTF exceeds the maximum size")
 	}
 
 	attr := &bpfLoadBTFAttr{
@@ -411,12 +411,12 @@ func ProgramSpec(s *Program) *Spec {
 func ProgramAppend(s, other *Program) error {
 	funcInfos, err := s.funcInfos.append(other.funcInfos, s.length)
 	if err != nil {
-		return errors.Wrap(err, "func infos")
+		return xerrors.Errorf("func infos")
 	}
 
 	lineInfos, err := s.lineInfos.append(other.lineInfos, s.length)
 	if err != nil {
-		return errors.Wrap(err, "line infos")
+		return xerrors.Errorf("line infos")
 	}
 
 	s.length += other.length
@@ -454,8 +454,10 @@ func ProgramLineInfos(s *Program) (recordSize uint32, bytes []byte, err error) {
 // IsNotSupported returns true if the error indicates that the kernel
 // doesn't support BTF.
 func IsNotSupported(err error) bool {
-	ufe, ok := errors.Cause(err).(*internal.UnsupportedFeatureError)
-	return ok && ufe.Name == "BTF"
+	if xerrors.Is(err, (err).(*internal.UnsupportedFeatureError)) {
+		return (err).(*internal.UnsupportedFeatureError).Name == "BTF"
+	}
+	return false
 }
 
 type bpfLoadBTFAttr struct {
@@ -526,5 +528,5 @@ var haveBTF = internal.FeatureTest("BTF", "5.1", func() bool {
 	}
 	// Check for EINVAL specifically, rather than err != nil since we
 	// otherwise misdetect due to insufficient permissions.
-	return errors.Cause(err) != unix.EINVAL
+	return !xerrors.Is(err, unix.EINVAL)
 })

--- a/internal/btf/btf.go
+++ b/internal/btf/btf.go
@@ -92,7 +92,7 @@ func parseBTF(btf io.ReadSeeker, bo binary.ByteOrder) (*Spec, error) {
 
 	var header btfHeader
 	if err := binary.Read(rd, bo, &header); err != nil {
-		return nil, xerrors.Errorf("can't read header: %w", err)
+		return nil, xerrors.Errorf("can't read header: %v", err)
 	}
 
 	if header.Magic != btfMagic {

--- a/internal/btf/btf.go
+++ b/internal/btf/btf.go
@@ -316,7 +316,7 @@ func NewHandle(spec *Spec) (*Handle, error) {
 
 	btf, err := spec.marshal(internal.NativeEndian)
 	if err != nil {
-		return nil, xerrors.Errorf("can't marshal BTF")
+		return nil, xerrors.Errorf("can't marshal BTF: %w")
 	}
 
 	if uint64(len(btf)) > math.MaxUint32 {

--- a/internal/btf/btf.go
+++ b/internal/btf/btf.go
@@ -117,7 +117,7 @@ func parseBTF(btf io.ReadSeeker, bo binary.ByteOrder) (*Spec, error) {
 	}
 
 	if _, err := rd.Seek(int64(header.HdrLen+header.StringOff), io.SeekStart); err != nil {
-		return nil, xerrors.Errorf("can't seek to start of string section: %w", err)
+		return nil, xerrors.Errorf("can't seek to start of string section: %v", err)
 	}
 
 	strings, err := readStringTable(io.LimitReader(rd, int64(header.StringLen)))

--- a/internal/btf/btf.go
+++ b/internal/btf/btf.go
@@ -126,7 +126,7 @@ func parseBTF(btf io.ReadSeeker, bo binary.ByteOrder) (*Spec, error) {
 	}
 
 	if _, err := rd.Seek(int64(header.HdrLen+header.TypeOff), io.SeekStart); err != nil {
-		return nil, xerrors.Errorf("can't seek to start of type section")
+		return nil, xerrors.Errorf("can't seek to start of type section: %v", err)
 	}
 
 	rawTypes, err := readTypes(io.LimitReader(rd, int64(header.TypeLen)), bo)

--- a/internal/btf/btf.go
+++ b/internal/btf/btf.go
@@ -122,7 +122,7 @@ func parseBTF(btf io.ReadSeeker, bo binary.ByteOrder) (*Spec, error) {
 
 	strings, err := readStringTable(io.LimitReader(rd, int64(header.StringLen)))
 	if err != nil {
-		return nil, xerrors.Errorf("can't read type names")
+		return nil, xerrors.Errorf("can't read type names: %w", err)
 	}
 
 	if _, err := rd.Seek(int64(header.HdrLen+header.TypeOff), io.SeekStart); err != nil {

--- a/internal/btf/btf.go
+++ b/internal/btf/btf.go
@@ -113,7 +113,7 @@ func parseBTF(btf io.ReadSeeker, bo binary.ByteOrder) (*Spec, error) {
 	}
 
 	if _, err := io.CopyN(internal.DiscardZeroes{}, rd, remainder); err != nil {
-		return nil, xerrors.Errorf("header padding: %w", err)
+		return nil, xerrors.Errorf("header padding: %v", err)
 	}
 
 	if _, err := rd.Seek(int64(header.HdrLen+header.StringOff), io.SeekStart); err != nil {

--- a/internal/btf/btf.go
+++ b/internal/btf/btf.go
@@ -454,7 +454,8 @@ func ProgramLineInfos(s *Program) (recordSize uint32, bytes []byte, err error) {
 // IsNotSupported returns true if the error indicates that the kernel
 // doesn't support BTF.
 func IsNotSupported(err error) bool {
-	if xerrors.Is(err, (err).(*internal.UnsupportedFeatureError)) {
+	var ufe internal.UnsupportedFeatureError
+	return xerrors.As(err, &ufe) && ufe.Name == "BTF"
 		return (err).(*internal.UnsupportedFeatureError).Name == "BTF"
 	}
 	return false

--- a/internal/btf/btf.go
+++ b/internal/btf/btf.go
@@ -416,7 +416,7 @@ func ProgramAppend(s, other *Program) error {
 
 	lineInfos, err := s.lineInfos.append(other.lineInfos, s.length)
 	if err != nil {
-		return xerrors.Errorf("line infos")
+		return xerrors.Errorf("line infos: %w", err)
 	}
 
 	s.length += other.length

--- a/internal/btf/btf.go
+++ b/internal/btf/btf.go
@@ -131,7 +131,7 @@ func parseBTF(btf io.ReadSeeker, bo binary.ByteOrder) (*Spec, error) {
 
 	rawTypes, err := readTypes(io.LimitReader(rd, int64(header.TypeLen)), bo)
 	if err != nil {
-		return nil, xerrors.Errorf("can't read types")
+		return nil, xerrors.Errorf("can't read types: %w", err)
 	}
 
 	types, err := inflateRawTypes(rawTypes, strings)

--- a/internal/btf/btf.go
+++ b/internal/btf/btf.go
@@ -85,7 +85,7 @@ func LoadSpecFromReader(rd io.ReaderAt) (*Spec, error) {
 func parseBTF(btf io.ReadSeeker, bo binary.ByteOrder) (*Spec, error) {
 	rawBTF, err := ioutil.ReadAll(btf)
 	if err != nil {
-		return nil, xerrors.Errorf("can't read BTF: %w", err)
+		return nil, xerrors.Errorf("can't read BTF: %v", err)
 	}
 
 	rd := bytes.NewReader(rawBTF)

--- a/internal/btf/btf.go
+++ b/internal/btf/btf.go
@@ -170,7 +170,7 @@ func (s *Spec) marshal(bo binary.ByteOrder) ([]byte, error) {
 		}
 
 		if err := typ.Marshal(&buf, bo); err != nil {
-			return nil, xerrors.Errorf("can't marshal BTF")
+			return nil, xerrors.Errorf("can't marshal BTF: %w", err)
 		}
 	}
 

--- a/internal/btf/btf.go
+++ b/internal/btf/btf.go
@@ -194,7 +194,7 @@ func (s *Spec) marshal(bo binary.ByteOrder) ([]byte, error) {
 	raw := buf.Bytes()
 	err := binary.Write(sliceWriter(raw[:headerLen]), bo, header)
 	if err != nil {
-		return nil, xerrors.Errorf("can't write header")
+		return nil, xerrors.Errorf("can't write header: %v", err)
 	}
 
 	return raw, nil

--- a/internal/btf/btf.go
+++ b/internal/btf/btf.go
@@ -411,7 +411,7 @@ func ProgramSpec(s *Program) *Spec {
 func ProgramAppend(s, other *Program) error {
 	funcInfos, err := s.funcInfos.append(other.funcInfos, s.length)
 	if err != nil {
-		return xerrors.Errorf("func infos")
+		return xerrors.Errorf("func infos: %w", err)
 	}
 
 	lineInfos, err := s.lineInfos.append(other.lineInfos, s.length)

--- a/internal/btf/btf_types.go
+++ b/internal/btf/btf_types.go
@@ -4,7 +4,7 @@ import (
 	"encoding/binary"
 	"io"
 
-	"github.com/pkg/errors"
+	"golang.org/x/xerrors"
 )
 
 // btfKind describes a Type.
@@ -139,7 +139,7 @@ func readTypes(r io.Reader, bo binary.ByteOrder) ([]rawType, error) {
 		if err := binary.Read(r, bo, &header); err == io.EOF {
 			return types, nil
 		} else if err != nil {
-			return nil, errors.Wrapf(err, "can't read type info for id %v", id)
+			return nil, xerrors.Errorf("can't read type info for id %v: %w", id, err)
 		}
 
 		var data interface{}
@@ -173,7 +173,7 @@ func readTypes(r io.Reader, bo binary.ByteOrder) ([]rawType, error) {
 			// sizeof(struct btf_var_secinfo)
 			data = make([]byte, header.Vlen()*4*3)
 		default:
-			return nil, errors.Errorf("type id %v: unknown kind: %v", id, header.Kind())
+			return nil, xerrors.Errorf("type id %v: unknown kind: %v", id, header.Kind())
 		}
 
 		if data == nil {
@@ -182,7 +182,7 @@ func readTypes(r io.Reader, bo binary.ByteOrder) ([]rawType, error) {
 		}
 
 		if err := binary.Read(r, bo, data); err != nil {
-			return nil, errors.Wrapf(err, "type id %d: kind %v: can't read %T", id, header.Kind(), data)
+			return nil, xerrors.Errorf("type id %d: kind %v: can't read %T: %w", id, header.Kind(), data, err)
 		}
 
 		types = append(types, rawType{header, data})

--- a/internal/btf/btf_types.go
+++ b/internal/btf/btf_types.go
@@ -182,7 +182,7 @@ func readTypes(r io.Reader, bo binary.ByteOrder) ([]rawType, error) {
 		}
 
 		if err := binary.Read(r, bo, data); err != nil {
-			return nil, xerrors.Errorf("type id %d: kind %v: can't read %T: %w", id, header.Kind(), data, err)
+			return nil, xerrors.Errorf("type id %d: kind %v: can't read %T: %v", id, header.Kind(), data, err)
 		}
 
 		types = append(types, rawType{header, data})

--- a/internal/btf/btf_types.go
+++ b/internal/btf/btf_types.go
@@ -139,7 +139,7 @@ func readTypes(r io.Reader, bo binary.ByteOrder) ([]rawType, error) {
 		if err := binary.Read(r, bo, &header); err == io.EOF {
 			return types, nil
 		} else if err != nil {
-			return nil, xerrors.Errorf("can't read type info for id %v: %w", id, err)
+			return nil, xerrors.Errorf("can't read type info for id %v: %v", id, err)
 		}
 
 		var data interface{}

--- a/internal/btf/ext_info.go
+++ b/internal/btf/ext_info.go
@@ -9,7 +9,7 @@ import (
 	"github.com/cilium/ebpf/asm"
 	"github.com/cilium/ebpf/internal"
 
-	"github.com/pkg/errors"
+	"golang.org/x/xerrors"
 )
 
 type btfExtHeader struct {
@@ -29,49 +29,49 @@ func parseExtInfos(r io.ReadSeeker, bo binary.ByteOrder, strings stringTable) (f
 
 	var header btfExtHeader
 	if err := binary.Read(r, bo, &header); err != nil {
-		return nil, nil, errors.Wrap(err, "can't read header")
+		return nil, nil, xerrors.Errorf("can't read header: %w", err)
 	}
 
 	if header.Magic != expectedMagic {
-		return nil, nil, errors.Errorf("incorrect magic value %v", header.Magic)
+		return nil, nil, xerrors.Errorf("incorrect magic value %v", header.Magic)
 	}
 
 	if header.Version != 1 {
-		return nil, nil, errors.Errorf("unexpected version %v", header.Version)
+		return nil, nil, xerrors.Errorf("unexpected version %v", header.Version)
 	}
 
 	if header.Flags != 0 {
-		return nil, nil, errors.Errorf("unsupported flags %v", header.Flags)
+		return nil, nil, xerrors.Errorf("unsupported flags %v", header.Flags)
 	}
 
 	remainder := int64(header.HdrLen) - int64(binary.Size(&header))
 	if remainder < 0 {
-		return nil, nil, errors.New("header is too short")
+		return nil, nil, xerrors.New("header is too short")
 	}
 
 	// Of course, the .BTF.ext header has different semantics than the
 	// .BTF ext header. We need to ignore non-null values.
 	_, err = io.CopyN(ioutil.Discard, r, remainder)
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "header padding")
+		return nil, nil, xerrors.Errorf("header padding: %w", err)
 	}
 
 	if _, err := r.Seek(int64(header.HdrLen+header.FuncInfoOff), io.SeekStart); err != nil {
-		return nil, nil, errors.Wrap(err, "can't seek to function info section")
+		return nil, nil, xerrors.Errorf("can't seek to function info section: %w", err)
 	}
 
 	funcInfo, err = parseExtInfo(io.LimitReader(r, int64(header.FuncInfoLen)), bo, strings)
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "function info")
+		return nil, nil, xerrors.Errorf("function info: %w", err)
 	}
 
 	if _, err := r.Seek(int64(header.HdrLen+header.LineInfoOff), io.SeekStart); err != nil {
-		return nil, nil, errors.Wrap(err, "can't seek to line info section")
+		return nil, nil, xerrors.Errorf("can't seek to line info section: %w", err)
 	}
 
 	lineInfo, err = parseExtInfo(io.LimitReader(r, int64(header.LineInfoLen)), bo, strings)
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "line info")
+		return nil, nil, xerrors.Errorf("line info: %w")
 	}
 
 	return funcInfo, lineInfo, nil
@@ -94,7 +94,7 @@ type extInfo struct {
 
 func (ei extInfo) append(other extInfo, offset uint64) (extInfo, error) {
 	if other.recordSize != ei.recordSize {
-		return extInfo{}, errors.Errorf("ext_info record size mismatch, want %d (got %d)", ei.recordSize, other.recordSize)
+		return extInfo{}, xerrors.Errorf("ext_info record size mismatch, want %d (got %d)", ei.recordSize, other.recordSize)
 	}
 
 	records := make([]extInfoRecord, 0, len(ei.records)+len(other.records))
@@ -119,7 +119,7 @@ func (ei extInfo) MarshalBinary() ([]byte, error) {
 		// while the ELF tracks it in bytes.
 		insnOff := uint32(info.InsnOff / asm.InstructionSize)
 		if err := binary.Write(buf, internal.NativeEndian, insnOff); err != nil {
-			return nil, errors.Wrap(err, "can't write instruction offset")
+			return nil, xerrors.Errorf("can't write instruction offset: %w", err)
 		}
 
 		buf.Write(info.Opaque)
@@ -131,12 +131,12 @@ func (ei extInfo) MarshalBinary() ([]byte, error) {
 func parseExtInfo(r io.Reader, bo binary.ByteOrder, strings stringTable) (map[string]extInfo, error) {
 	var recordSize uint32
 	if err := binary.Read(r, bo, &recordSize); err != nil {
-		return nil, errors.Wrap(err, "can't read record size")
+		return nil, xerrors.Errorf("can't read record size: %w", err)
 	}
 
 	if recordSize < 4 {
 		// Need at least insnOff
-		return nil, errors.New("record size too short")
+		return nil, xerrors.New("record size too short")
 	}
 
 	result := make(map[string]extInfo)
@@ -145,32 +145,32 @@ func parseExtInfo(r io.Reader, bo binary.ByteOrder, strings stringTable) (map[st
 		if err := binary.Read(r, bo, &infoHeader); err == io.EOF {
 			return result, nil
 		} else if err != nil {
-			return nil, errors.Wrap(err, "can't read ext info header")
+			return nil, xerrors.Errorf("can't read ext info header: %w", err)
 		}
 
 		secName, err := strings.Lookup(infoHeader.SecNameOff)
 		if err != nil {
-			return nil, errors.Wrap(err, "can't get section name")
+			return nil, xerrors.Errorf("can't get section name: %w", err)
 		}
 
 		if infoHeader.NumInfo == 0 {
-			return nil, errors.Errorf("section %s has invalid number of records", secName)
+			return nil, xerrors.Errorf("section %s has invalid number of records", secName)
 		}
 
 		var records []extInfoRecord
 		for i := uint32(0); i < infoHeader.NumInfo; i++ {
 			var byteOff uint32
 			if err := binary.Read(r, bo, &byteOff); err != nil {
-				return nil, errors.Wrapf(err, "section %v: can't read extended info offset", secName)
+				return nil, xerrors.Errorf("section %v: can't read extended info offset: %w", secName, err)
 			}
 
 			buf := make([]byte, int(recordSize-4))
 			if _, err := io.ReadFull(r, buf); err != nil {
-				return nil, errors.Wrapf(err, "section %v: can't read record", secName)
+				return nil, xerrors.Errorf("section %v: can't read record: %w", secName, err)
 			}
 
 			if byteOff%asm.InstructionSize != 0 {
-				return nil, errors.Errorf("section %v: offset %v is not aligned with instruction size", secName, byteOff)
+				return nil, xerrors.Errorf("section %v: offset %v is not aligned with instruction size", secName, byteOff)
 			}
 
 			records = append(records, extInfoRecord{uint64(byteOff), buf})

--- a/internal/btf/ext_info.go
+++ b/internal/btf/ext_info.go
@@ -166,7 +166,7 @@ func parseExtInfo(r io.Reader, bo binary.ByteOrder, strings stringTable) (map[st
 
 			buf := make([]byte, int(recordSize-4))
 			if _, err := io.ReadFull(r, buf); err != nil {
-				return nil, xerrors.Errorf("section %v: can't read record: %w", secName, err)
+				return nil, xerrors.Errorf("section %v: can't read record: %v", secName, err)
 			}
 
 			if byteOff%asm.InstructionSize != 0 {

--- a/internal/btf/ext_info.go
+++ b/internal/btf/ext_info.go
@@ -53,7 +53,7 @@ func parseExtInfos(r io.ReadSeeker, bo binary.ByteOrder, strings stringTable) (f
 	// .BTF ext header. We need to ignore non-null values.
 	_, err = io.CopyN(ioutil.Discard, r, remainder)
 	if err != nil {
-		return nil, nil, xerrors.Errorf("header padding: %w", err)
+		return nil, nil, xerrors.Errorf("header padding: %v", err)
 	}
 
 	if _, err := r.Seek(int64(header.HdrLen+header.FuncInfoOff), io.SeekStart); err != nil {

--- a/internal/btf/ext_info.go
+++ b/internal/btf/ext_info.go
@@ -57,7 +57,7 @@ func parseExtInfos(r io.ReadSeeker, bo binary.ByteOrder, strings stringTable) (f
 	}
 
 	if _, err := r.Seek(int64(header.HdrLen+header.FuncInfoOff), io.SeekStart); err != nil {
-		return nil, nil, xerrors.Errorf("can't seek to function info section: %w", err)
+		return nil, nil, xerrors.Errorf("can't seek to function info section: %v", err)
 	}
 
 	funcInfo, err = parseExtInfo(io.LimitReader(r, int64(header.FuncInfoLen)), bo, strings)

--- a/internal/btf/ext_info.go
+++ b/internal/btf/ext_info.go
@@ -145,7 +145,7 @@ func parseExtInfo(r io.Reader, bo binary.ByteOrder, strings stringTable) (map[st
 		if err := binary.Read(r, bo, &infoHeader); err == io.EOF {
 			return result, nil
 		} else if err != nil {
-			return nil, xerrors.Errorf("can't read ext info header: %w", err)
+			return nil, xerrors.Errorf("can't read ext info header: %v", err)
 		}
 
 		secName, err := strings.Lookup(infoHeader.SecNameOff)

--- a/internal/btf/ext_info.go
+++ b/internal/btf/ext_info.go
@@ -131,7 +131,7 @@ func (ei extInfo) MarshalBinary() ([]byte, error) {
 func parseExtInfo(r io.Reader, bo binary.ByteOrder, strings stringTable) (map[string]extInfo, error) {
 	var recordSize uint32
 	if err := binary.Read(r, bo, &recordSize); err != nil {
-		return nil, xerrors.Errorf("can't read record size: %w", err)
+		return nil, xerrors.Errorf("can't read record size: %v", err)
 	}
 
 	if recordSize < 4 {

--- a/internal/btf/ext_info.go
+++ b/internal/btf/ext_info.go
@@ -119,7 +119,7 @@ func (ei extInfo) MarshalBinary() ([]byte, error) {
 		// while the ELF tracks it in bytes.
 		insnOff := uint32(info.InsnOff / asm.InstructionSize)
 		if err := binary.Write(buf, internal.NativeEndian, insnOff); err != nil {
-			return nil, xerrors.Errorf("can't write instruction offset: %w", err)
+			return nil, xerrors.Errorf("can't write instruction offset: %v", err)
 		}
 
 		buf.Write(info.Opaque)

--- a/internal/btf/ext_info.go
+++ b/internal/btf/ext_info.go
@@ -29,7 +29,7 @@ func parseExtInfos(r io.ReadSeeker, bo binary.ByteOrder, strings stringTable) (f
 
 	var header btfExtHeader
 	if err := binary.Read(r, bo, &header); err != nil {
-		return nil, nil, xerrors.Errorf("can't read header: %w", err)
+		return nil, nil, xerrors.Errorf("can't read header: %v", err)
 	}
 
 	if header.Magic != expectedMagic {

--- a/internal/btf/ext_info.go
+++ b/internal/btf/ext_info.go
@@ -66,7 +66,7 @@ func parseExtInfos(r io.ReadSeeker, bo binary.ByteOrder, strings stringTable) (f
 	}
 
 	if _, err := r.Seek(int64(header.HdrLen+header.LineInfoOff), io.SeekStart); err != nil {
-		return nil, nil, xerrors.Errorf("can't seek to line info section: %w", err)
+		return nil, nil, xerrors.Errorf("can't seek to line info section: %v", err)
 	}
 
 	lineInfo, err = parseExtInfo(io.LimitReader(r, int64(header.LineInfoLen)), bo, strings)

--- a/internal/btf/ext_info.go
+++ b/internal/btf/ext_info.go
@@ -161,7 +161,7 @@ func parseExtInfo(r io.Reader, bo binary.ByteOrder, strings stringTable) (map[st
 		for i := uint32(0); i < infoHeader.NumInfo; i++ {
 			var byteOff uint32
 			if err := binary.Read(r, bo, &byteOff); err != nil {
-				return nil, xerrors.Errorf("section %v: can't read extended info offset: %w", secName, err)
+				return nil, xerrors.Errorf("section %v: can't read extended info offset: %v", secName, err)
 			}
 
 			buf := make([]byte, int(recordSize-4))

--- a/internal/btf/strings.go
+++ b/internal/btf/strings.go
@@ -13,7 +13,7 @@ type stringTable []byte
 func readStringTable(r io.Reader) (stringTable, error) {
 	contents, err := ioutil.ReadAll(r)
 	if err != nil {
-		return nil, xerrors.Errorf("can't read string table: %w", err)
+		return nil, xerrors.Errorf("can't read string table: %v", err)
 	}
 
 	if len(contents) < 1 {

--- a/internal/btf/strings.go
+++ b/internal/btf/strings.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"io/ioutil"
 
-	"github.com/pkg/errors"
+	"golang.org/x/xerrors"
 )
 
 type stringTable []byte
@@ -13,19 +13,19 @@ type stringTable []byte
 func readStringTable(r io.Reader) (stringTable, error) {
 	contents, err := ioutil.ReadAll(r)
 	if err != nil {
-		return nil, errors.Wrap(err, "can't read string table")
+		return nil, xerrors.Errorf("can't read string table: %w", err)
 	}
 
 	if len(contents) < 1 {
-		return nil, errors.New("string table is empty")
+		return nil, xerrors.New("string table is empty")
 	}
 
 	if contents[0] != '\x00' {
-		return nil, errors.New("first item in string table is non-empty")
+		return nil, xerrors.New("first item in string table is non-empty")
 	}
 
 	if contents[len(contents)-1] != '\x00' {
-		return nil, errors.New("string table isn't null terminated")
+		return nil, xerrors.New("string table isn't null terminated")
 	}
 
 	return stringTable(contents), nil
@@ -33,22 +33,22 @@ func readStringTable(r io.Reader) (stringTable, error) {
 
 func (st stringTable) Lookup(offset uint32) (string, error) {
 	if int64(offset) > int64(^uint(0)>>1) {
-		return "", errors.Errorf("offset %d overflows int", offset)
+		return "", xerrors.Errorf("offset %d overflows int", offset)
 	}
 
 	pos := int(offset)
 	if pos >= len(st) {
-		return "", errors.Errorf("offset %d is out of bounds", offset)
+		return "", xerrors.Errorf("offset %d is out of bounds", offset)
 	}
 
 	if pos > 0 && st[pos-1] != '\x00' {
-		return "", errors.Errorf("offset %d isn't start of a string", offset)
+		return "", xerrors.Errorf("offset %d isn't start of a string", offset)
 	}
 
 	str := st[pos:]
 	end := bytes.IndexByte(str, '\x00')
 	if end == -1 {
-		return "", errors.Errorf("offset %d isn't null terminated", offset)
+		return "", xerrors.Errorf("offset %d isn't null terminated", offset)
 	}
 
 	return string(str[:end]), nil

--- a/internal/cpu.go
+++ b/internal/cpu.go
@@ -53,7 +53,7 @@ func parseCPUs(path string) (int, error) {
 	var low, high int
 	n, _ := fmt.Fscanf(file, "%d-%d", &low, &high)
 	if n < 1 || low != 0 {
-		return 0, xerrors.Errorf("%s has unknown format: %w", path, err)
+		return 0, xerrors.Errorf("%s has unknown format: %v", path, err)
 	}
 	if n == 1 {
 		high = low

--- a/internal/cpu.go
+++ b/internal/cpu.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"sync"
 
-	"github.com/pkg/errors"
+	"golang.org/x/xerrors"
 )
 
 var sysCPU struct {
@@ -53,7 +53,7 @@ func parseCPUs(path string) (int, error) {
 	var low, high int
 	n, _ := fmt.Fscanf(file, "%d-%d", &low, &high)
 	if n < 1 || low != 0 {
-		return 0, errors.Wrapf(err, "%s has unknown format", path)
+		return 0, xerrors.Errorf("%s has unknown format: %w", path, err)
 	}
 	if n == 1 {
 		high = low

--- a/internal/errors.go
+++ b/internal/errors.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/cilium/ebpf/internal/unix"
-	"github.com/pkg/errors"
+	"golang.org/x/xerrors"
 )
 
 // ErrorWithLog returns an error that includes logs from the
@@ -16,7 +16,7 @@ import (
 // the log. It is used to check for truncation of the output.
 func ErrorWithLog(err error, log []byte, logErr error) error {
 	logStr := strings.Trim(CString(log), "\t\r\n ")
-	if errors.Cause(logErr) == unix.ENOSPC {
+	if xerrors.Is(logErr, unix.ENOSPC) {
 		logStr += " (truncated...)"
 	}
 

--- a/internal/fd.go
+++ b/internal/fd.go
@@ -6,10 +6,10 @@ import (
 
 	"github.com/cilium/ebpf/internal/unix"
 
-	"github.com/pkg/errors"
+	"golang.org/x/xerrors"
 )
 
-var ErrClosedFd = errors.New("use of closed file descriptor")
+var ErrClosedFd = xerrors.New("use of closed file descriptor")
 
 type FD struct {
 	raw int64
@@ -56,7 +56,7 @@ func (fd *FD) Dup() (*FD, error) {
 
 	dup, err := unix.FcntlInt(uintptr(fd.raw), unix.F_DUPFD_CLOEXEC, 0)
 	if err != nil {
-		return nil, errors.Wrap(err, "can't dup fd")
+		return nil, xerrors.Errorf("can't dup fd: %w", err)
 	}
 
 	return NewFD(uint32(dup)), nil

--- a/internal/fd.go
+++ b/internal/fd.go
@@ -56,7 +56,7 @@ func (fd *FD) Dup() (*FD, error) {
 
 	dup, err := unix.FcntlInt(uintptr(fd.raw), unix.F_DUPFD_CLOEXEC, 0)
 	if err != nil {
-		return nil, xerrors.Errorf("can't dup fd: %w", err)
+		return nil, xerrors.Errorf("can't dup fd: %v", err)
 	}
 
 	return NewFD(uint32(dup)), nil

--- a/internal/feature.go
+++ b/internal/feature.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/pkg/errors"
+	"golang.org/x/xerrors"
 )
 
 // UnsupportedFeatureError is returned by FeatureTest() functions.
@@ -61,7 +61,7 @@ func NewVersion(ver string) (Version, error) {
 	var major, minor, patch uint16
 	n, _ := fmt.Sscanf(ver, "%d.%d.%d", &major, &minor, &patch)
 	if n < 2 {
-		return Version{}, errors.Errorf("invalid version: %s", ver)
+		return Version{}, xerrors.Errorf("invalid version: %s", ver)
 	}
 	return Version{major, minor, patch}, nil
 }

--- a/internal/io.go
+++ b/internal/io.go
@@ -1,6 +1,6 @@
 package internal
 
-import "github.com/pkg/errors"
+import "golang.org/x/xerrors"
 
 // DiscardZeroes makes sure that all written bytes are zero
 // before discarding them.
@@ -9,7 +9,7 @@ type DiscardZeroes struct{}
 func (DiscardZeroes) Write(p []byte) (int, error) {
 	for _, b := range p {
 		if b != 0 {
-			return 0, errors.New("encountered non-zero byte")
+			return 0, xerrors.New("encountered non-zero byte")
 		}
 	}
 	return len(p), nil

--- a/linker.go
+++ b/linker.go
@@ -3,7 +3,8 @@ package ebpf
 import (
 	"github.com/cilium/ebpf/asm"
 	"github.com/cilium/ebpf/internal/btf"
-	"github.com/pkg/errors"
+
+	"golang.org/x/xerrors"
 )
 
 // link resolves bpf-to-bpf calls.
@@ -16,7 +17,7 @@ func link(prog *ProgramSpec, libs []*ProgramSpec) error {
 	for _, lib := range libs {
 		insns, err := linkSection(prog.Instructions, lib.Instructions)
 		if err != nil {
-			return errors.Wrapf(err, "linking %s", lib.Name)
+			return xerrors.Errorf("linking %s: %w", lib.Name, err)
 		}
 
 		if len(insns) == len(prog.Instructions) {
@@ -26,7 +27,7 @@ func link(prog *ProgramSpec, libs []*ProgramSpec) error {
 		prog.Instructions = insns
 		if prog.BTF != nil && lib.BTF != nil {
 			if err := btf.ProgramAppend(prog.BTF, lib.BTF); err != nil {
-				return errors.Wrapf(err, "linking BTF of %s", lib.Name)
+				return xerrors.Errorf("linking BTF of %s: %w", lib.Name, err)
 			}
 		}
 	}

--- a/map.go
+++ b/map.go
@@ -7,7 +7,7 @@ import (
 	"github.com/cilium/ebpf/internal/btf"
 	"github.com/cilium/ebpf/internal/unix"
 
-	"github.com/pkg/errors"
+	"golang.org/x/xerrors"
 )
 
 // MapSpec defines a Map.
@@ -65,7 +65,7 @@ type Map struct {
 // You should not use fd after calling this function.
 func NewMapFromFD(fd int) (*Map, error) {
 	if fd < 0 {
-		return nil, errors.New("invalid fd")
+		return nil, xerrors.New("invalid fd")
 	}
 	bpfFd := internal.NewFD(uint32(fd))
 
@@ -88,7 +88,7 @@ func NewMap(spec *MapSpec) (*Map, error) {
 
 	handle, err := btf.NewHandle(btf.MapSpec(spec.BTF))
 	if err != nil && !btf.IsNotSupported(err) {
-		return nil, errors.Wrap(err, "can't load BTF")
+		return nil, xerrors.Errorf("can't load BTF: %w", err)
 	}
 
 	return newMapWithBTF(spec, handle)
@@ -100,7 +100,7 @@ func newMapWithBTF(spec *MapSpec, handle *btf.Handle) (*Map, error) {
 	}
 
 	if spec.InnerMap == nil {
-		return nil, errors.Errorf("%s requires InnerMap", spec.Type)
+		return nil, xerrors.Errorf("%s requires InnerMap", spec.Type)
 	}
 
 	template, err := createMap(spec.InnerMap, nil, handle)
@@ -124,21 +124,21 @@ func createMap(spec *MapSpec, inner *internal.FD, handle *btf.Handle) (*Map, err
 		}
 
 		if spec.ValueSize != 0 && spec.ValueSize != 4 {
-			return nil, errors.Errorf("ValueSize must be zero or four for map of map")
+			return nil, fmt.Errorf("ValueSize must be zero or four for map of map")
 		}
 		spec.ValueSize = 4
 
 	case PerfEventArray:
 		if spec.KeySize != 0 {
-			return nil, errors.Errorf("KeySize must be zero for perf event array")
+			return nil, fmt.Errorf("KeySize must be zero for perf event array")
 		}
 		if spec.ValueSize != 0 {
-			return nil, errors.Errorf("ValueSize must be zero for perf event array")
+			return nil, fmt.Errorf("ValueSize must be zero for perf event array")
 		}
 		if spec.MaxEntries == 0 {
 			n, err := internal.OnlineCPUs()
 			if err != nil {
-				return nil, errors.Wrap(err, "perf event array")
+				return nil, xerrors.Errorf("perf event array: %w", err)
 			}
 			spec.MaxEntries = uint32(n)
 		}
@@ -159,7 +159,7 @@ func createMap(spec *MapSpec, inner *internal.FD, handle *btf.Handle) (*Map, err
 		var err error
 		attr.innerMapFd, err = inner.Value()
 		if err != nil {
-			return nil, errors.Wrap(err, "map create")
+			return nil, xerrors.Errorf("map create: %w", err)
 		}
 	}
 
@@ -171,7 +171,7 @@ func createMap(spec *MapSpec, inner *internal.FD, handle *btf.Handle) (*Map, err
 
 	name, err := newBPFObjName(spec.Name)
 	if err != nil {
-		return nil, errors.Wrap(err, "map create")
+		return nil, xerrors.Errorf("map create: %w", err)
 	}
 
 	if haveObjName() == nil {
@@ -180,7 +180,7 @@ func createMap(spec *MapSpec, inner *internal.FD, handle *btf.Handle) (*Map, err
 
 	fd, err := bpfMapCreate(&attr)
 	if err != nil {
-		return nil, errors.Wrap(err, "map create")
+		return nil, xerrors.Errorf("map create: %w", err)
 	}
 
 	return newMap(fd, spec.Name, newMapABIFromSpec(spec))
@@ -251,9 +251,9 @@ func (m *Map) Lookup(key, valueOut interface{}) error {
 		*value = m
 		return nil
 	case *Map:
-		return errors.Errorf("can't unmarshal into %T, need %T", value, (**Map)(nil))
+		return xerrors.Errorf("can't unmarshal into %T, need %T", value, (**Map)(nil))
 	case Map:
-		return errors.Errorf("can't unmarshal into %T, need %T", value, (**Map)(nil))
+		return xerrors.Errorf("can't unmarshal into %T, need %T", value, (**Map)(nil))
 
 	case **Program:
 		p, err := unmarshalProgram(valueBytes)
@@ -265,9 +265,9 @@ func (m *Map) Lookup(key, valueOut interface{}) error {
 		*value = p
 		return nil
 	case *Program:
-		return errors.Errorf("can't unmarshal into %T, need %T", value, (**Program)(nil))
+		return xerrors.Errorf("can't unmarshal into %T, need %T", value, (**Program)(nil))
 	case Program:
-		return errors.Errorf("can't unmarshal into %T, need %T", value, (**Program)(nil))
+		return xerrors.Errorf("can't unmarshal into %T, need %T", value, (**Program)(nil))
 
 	default:
 		return unmarshalBytes(valueOut, valueBytes)
@@ -280,11 +280,11 @@ func (m *Map) LookupAndDelete(key, valueOut interface{}) error {
 
 	keyPtr, err := marshalPtr(key, int(m.abi.KeySize))
 	if err != nil {
-		return errors.WithMessage(err, "can't marshal key")
+		return xerrors.Errorf("can't marshal key: %w", err)
 	}
 
 	if err := bpfMapLookupAndDelete(m.fd, keyPtr, valuePtr); err != nil {
-		return errors.WithMessage(err, "lookup and delete and delete failed")
+		return xerrors.Errorf("lookup and delete and delete failed: %w", err)
 	}
 
 	return unmarshalBytes(valueOut, valueBytes)
@@ -308,11 +308,13 @@ func (m *Map) LookupBytes(key interface{}) ([]byte, error) {
 func (m *Map) lookup(key interface{}, valueOut internal.Pointer) error {
 	keyPtr, err := marshalPtr(key, int(m.abi.KeySize))
 	if err != nil {
-		return errors.WithMessage(err, "can't marshal key")
+		return xerrors.Errorf("can't marshal key: %w", err)
 	}
 
-	err = bpfMapLookupElem(m.fd, keyPtr, valueOut)
-	return errors.WithMessage(err, "lookup failed")
+	if err = bpfMapLookupElem(m.fd, keyPtr, valueOut); err != nil {
+		return xerrors.Errorf("lookup failed: %w", err)
+	}
+	return nil
 }
 
 // MapUpdateFlags controls the behaviour of the Map.Update call.
@@ -340,7 +342,7 @@ func (m *Map) Put(key, value interface{}) error {
 func (m *Map) Update(key, value interface{}, flags MapUpdateFlags) error {
 	keyPtr, err := marshalPtr(key, int(m.abi.KeySize))
 	if err != nil {
-		return errors.WithMessage(err, "can't marshal key")
+		return xerrors.Errorf("can't marshal key: %w", err)
 	}
 
 	var valuePtr internal.Pointer
@@ -350,7 +352,7 @@ func (m *Map) Update(key, value interface{}, flags MapUpdateFlags) error {
 		valuePtr, err = marshalPtr(value, int(m.abi.ValueSize))
 	}
 	if err != nil {
-		return errors.WithMessage(err, "can't marshal value")
+		return xerrors.Errorf("can't marshal value: %w", err)
 	}
 
 	return bpfMapUpdateElem(m.fd, keyPtr, valuePtr, uint64(flags))
@@ -362,11 +364,13 @@ func (m *Map) Update(key, value interface{}, flags MapUpdateFlags) error {
 func (m *Map) Delete(key interface{}) error {
 	keyPtr, err := marshalPtr(key, int(m.abi.KeySize))
 	if err != nil {
-		return errors.WithMessage(err, "can't marshal key")
+		return xerrors.Errorf("can't marshal key: %w", err)
 	}
 
-	err = bpfMapDeleteElem(m.fd, keyPtr)
-	return errors.WithMessage(err, "can't delete key")
+	if err = bpfMapDeleteElem(m.fd, keyPtr); err != nil {
+		return xerrors.Errorf("can't delete key: %w", err)
+	}
+	return nil
 }
 
 // NextKey finds the key following an initial key.
@@ -383,8 +387,10 @@ func (m *Map) NextKey(key, nextKeyOut interface{}) error {
 		return nil
 	}
 
-	err := unmarshalBytes(nextKeyOut, nextKeyBytes)
-	return errors.WithMessage(err, "can't unmarshal next key")
+	if err := unmarshalBytes(nextKeyOut, nextKeyBytes); err != nil {
+		return xerrors.Errorf("can't unmarshal next key: %w", err)
+	}
+	return nil
 }
 
 // NextKeyBytes returns the key following an initial key as a byte slice.
@@ -413,12 +419,14 @@ func (m *Map) nextKey(key interface{}, nextKeyOut internal.Pointer) error {
 	if key != nil {
 		keyPtr, err = marshalPtr(key, int(m.abi.KeySize))
 		if err != nil {
-			return errors.WithMessage(err, "can't marshal key")
+			return xerrors.Errorf("can't marshal key: %w", err)
 		}
 	}
 
-	err = bpfMapGetNextKey(m.fd, keyPtr, nextKeyOut)
-	return errors.WithMessage(err, "can't get next key")
+	if err = bpfMapGetNextKey(m.fd, keyPtr, nextKeyOut); err != nil {
+		return xerrors.Errorf("can't get next key: %w", err)
+	}
+	return nil
 }
 
 // Iterate traverses a map.
@@ -469,7 +477,7 @@ func (m *Map) Clone() (*Map, error) {
 
 	dup, err := m.fd.Dup()
 	if err != nil {
-		return nil, errors.Wrap(err, "can't clone map")
+		return nil, xerrors.Errorf("can't clone map: %w", err)
 	}
 
 	return newMap(dup, m.name, &m.abi)
@@ -510,7 +518,7 @@ func LoadPinnedMapExplicit(fileName string, abi *MapABI) (*Map, error) {
 
 func unmarshalMap(buf []byte) (*Map, error) {
 	if len(buf) != 4 {
-		return nil, errors.New("map id requires 4 byte value")
+		return nil, xerrors.New("map id requires 4 byte value")
 	}
 
 	// Looking up an entry in a nested map or prog array returns an id,
@@ -562,7 +570,7 @@ func newMapIterator(target *Map) *MapIterator {
 	}
 }
 
-var errIterationAborted = errors.New("iteration aborted")
+var errIterationAborted = xerrors.New("iteration aborted")
 
 // Next decodes the next key and value.
 //
@@ -632,12 +640,12 @@ func (mi *MapIterator) Err() error {
 // IsNotExist returns true if the error indicates that a
 // key doesn't exist.
 func IsNotExist(err error) bool {
-	return errors.Cause(err) == unix.ENOENT
+	return xerrors.Is(err, unix.ENOENT)
 }
 
 // IsIterationAborted returns true if the iteration was aborted.
 //
 // This occurs when keys are deleted from a hash map during iteration.
 func IsIterationAborted(err error) bool {
-	return errors.Cause(err) == errIterationAborted
+	return xerrors.Is(err, errIterationAborted)
 }

--- a/map.go
+++ b/map.go
@@ -284,7 +284,7 @@ func (m *Map) LookupAndDelete(key, valueOut interface{}) error {
 	}
 
 	if err := bpfMapLookupAndDelete(m.fd, keyPtr, valuePtr); err != nil {
-		return xerrors.Errorf("lookup and delete and delete failed: %w", err)
+		return xerrors.Errorf("lookup and delete failed: %w", err)
 	}
 
 	return unmarshalBytes(valueOut, valueBytes)

--- a/map_test.go
+++ b/map_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/cilium/ebpf/internal/testutils"
 	"github.com/cilium/ebpf/internal/unix"
 
-	"github.com/pkg/errors"
+	"golang.org/x/xerrors"
 )
 
 func TestMain(m *testing.M) {
@@ -74,11 +74,11 @@ func TestMapClose(t *testing.T) {
 		t.Fatal("Can't close map:", err)
 	}
 
-	if err := m.Put(uint32(0), uint32(42)); errors.Cause(err) != internal.ErrClosedFd {
+	if err := m.Put(uint32(0), uint32(42)); !xerrors.Is(err, internal.ErrClosedFd) {
 		t.Fatal("Put doesn't check for closed fd", err)
 	}
 
-	if _, err := m.LookupBytes(uint32(0)); errors.Cause(err) != internal.ErrClosedFd {
+	if _, err := m.LookupBytes(uint32(0)); !xerrors.Is(err, internal.ErrClosedFd) {
 		t.Fatal("Get doesn't check for closed fd", err)
 	}
 }

--- a/marshalers.go
+++ b/marshalers.go
@@ -9,8 +9,7 @@ import (
 	"unsafe"
 
 	"github.com/cilium/ebpf/internal"
-
-	"github.com/pkg/errors"
+	"golang.org/x/xerrors"
 )
 
 func marshalPtr(data interface{}, length int) (internal.Pointer, error) {
@@ -18,7 +17,7 @@ func marshalPtr(data interface{}, length int) (internal.Pointer, error) {
 		if length == 0 {
 			return internal.NewPointer(nil), nil
 		}
-		return internal.Pointer{}, errors.New("can't use nil as key of map")
+		return internal.Pointer{}, xerrors.New("can't use nil as key of map")
 	}
 
 	if ptr, ok := data.(unsafe.Pointer); ok {
@@ -42,11 +41,13 @@ func marshalBytes(data interface{}, length int) (buf []byte, err error) {
 	case []byte:
 		buf = value
 	case unsafe.Pointer:
-		err = errors.New("can't marshal from unsafe.Pointer")
+		err = xerrors.New("can't marshal from unsafe.Pointer")
 	default:
 		var wr bytes.Buffer
 		err = binary.Write(&wr, internal.NativeEndian, value)
-		err = errors.Wrapf(err, "encoding %T", value)
+		if err != nil {
+			err = xerrors.Errorf("encoding %T: %w", value, err)
+		}
 		buf = wr.Bytes()
 	}
 	if err != nil {
@@ -54,7 +55,7 @@ func marshalBytes(data interface{}, length int) (buf []byte, err error) {
 	}
 
 	if len(buf) != length {
-		return nil, errors.Errorf("%T doesn't marshal to %d bytes", data, length)
+		return nil, xerrors.Errorf("%T doesn't marshal to %d bytes", data, length)
 	}
 	return buf, nil
 }
@@ -90,13 +91,15 @@ func unmarshalBytes(data interface{}, buf []byte) error {
 		*value = buf
 		return nil
 	case string:
-		return errors.New("require pointer to string")
+		return xerrors.New("require pointer to string")
 	case []byte:
-		return errors.New("require pointer to []byte")
+		return xerrors.New("require pointer to []byte")
 	default:
 		rd := bytes.NewReader(buf)
-		err := binary.Read(rd, internal.NativeEndian, value)
-		return errors.Wrapf(err, "decoding %T", value)
+		if err := binary.Read(rd, internal.NativeEndian, value); err != nil {
+			return xerrors.Errorf("decoding %T: %w", value, err)
+		}
+		return nil
 	}
 }
 
@@ -109,7 +112,7 @@ func unmarshalBytes(data interface{}, buf []byte) error {
 func marshalPerCPUValue(slice interface{}, elemLength int) (internal.Pointer, error) {
 	sliceType := reflect.TypeOf(slice)
 	if sliceType.Kind() != reflect.Slice {
-		return internal.Pointer{}, errors.New("per-CPU value requires slice")
+		return internal.Pointer{}, xerrors.New("per-CPU value requires slice")
 	}
 
 	possibleCPUs, err := internal.PossibleCPUs()
@@ -120,7 +123,7 @@ func marshalPerCPUValue(slice interface{}, elemLength int) (internal.Pointer, er
 	sliceValue := reflect.ValueOf(slice)
 	sliceLen := sliceValue.Len()
 	if sliceLen > possibleCPUs {
-		return internal.Pointer{}, errors.Errorf("per-CPU value exceeds number of CPUs")
+		return internal.Pointer{}, xerrors.Errorf("per-CPU value exceeds number of CPUs")
 	}
 
 	alignedElemLength := align(elemLength, 8)
@@ -147,7 +150,7 @@ func marshalPerCPUValue(slice interface{}, elemLength int) (internal.Pointer, er
 func unmarshalPerCPUValue(slicePtr interface{}, elemLength int, buf []byte) error {
 	slicePtrType := reflect.TypeOf(slicePtr)
 	if slicePtrType.Kind() != reflect.Ptr || slicePtrType.Elem().Kind() != reflect.Slice {
-		return errors.Errorf("per-cpu value requires pointer to slice")
+		return xerrors.Errorf("per-cpu value requires pointer to slice")
 	}
 
 	possibleCPUs, err := internal.PossibleCPUs()
@@ -166,7 +169,7 @@ func unmarshalPerCPUValue(slicePtr interface{}, elemLength int, buf []byte) erro
 
 	step := len(buf) / possibleCPUs
 	if step < elemLength {
-		return errors.Errorf("per-cpu element length is larger than available data")
+		return xerrors.Errorf("per-cpu element length is larger than available data")
 	}
 	for i := 0; i < possibleCPUs; i++ {
 		var elem interface{}
@@ -184,7 +187,7 @@ func unmarshalPerCPUValue(slicePtr interface{}, elemLength int, buf []byte) erro
 
 		err := unmarshalBytes(elem, elemBytes)
 		if err != nil {
-			return errors.Wrapf(err, "cpu %d", i)
+			return xerrors.Errorf("cpu %d: %w", i, err)
 		}
 
 		buf = buf[step:]

--- a/marshalers.go
+++ b/marshalers.go
@@ -9,6 +9,7 @@ import (
 	"unsafe"
 
 	"github.com/cilium/ebpf/internal"
+
 	"golang.org/x/xerrors"
 )
 
@@ -46,7 +47,7 @@ func marshalBytes(data interface{}, length int) (buf []byte, err error) {
 		var wr bytes.Buffer
 		err = binary.Write(&wr, internal.NativeEndian, value)
 		if err != nil {
-			err = xerrors.Errorf("encoding %T: %w", value, err)
+			err = xerrors.Errorf("encoding %T: %v", value, err)
 		}
 		buf = wr.Bytes()
 	}
@@ -97,7 +98,7 @@ func unmarshalBytes(data interface{}, buf []byte) error {
 	default:
 		rd := bytes.NewReader(buf)
 		if err := binary.Read(rd, internal.NativeEndian, value); err != nil {
-			return xerrors.Errorf("decoding %T: %w", value, err)
+			return xerrors.Errorf("decoding %T: %v", value, err)
 		}
 		return nil
 	}

--- a/perf/reader.go
+++ b/perf/reader.go
@@ -12,12 +12,12 @@ import (
 	"github.com/cilium/ebpf/internal"
 	"github.com/cilium/ebpf/internal/unix"
 
-	"github.com/pkg/errors"
+	"golang.org/x/xerrors"
 )
 
 var (
-	errClosed = errors.New("perf reader was closed")
-	errEOR    = errors.New("end of ring")
+	errClosed = xerrors.New("perf reader was closed")
+	errEOR    = xerrors.New("end of ring")
 )
 
 // perfEventHeader must match 'struct perf_event_header` in <linux/perf_event.h>.
@@ -29,7 +29,7 @@ type perfEventHeader struct {
 
 func addToEpoll(epollfd, fd int, cpu int) error {
 	if int64(cpu) > math.MaxInt32 {
-		return errors.Errorf("unsupported CPU number: %d", cpu)
+		return xerrors.Errorf("unsupported CPU number: %d", cpu)
 	}
 
 	// The representation of EpollEvent isn't entirely accurate.
@@ -42,8 +42,10 @@ func addToEpoll(epollfd, fd int, cpu int) error {
 		Pad:    int32(cpu),
 	}
 
-	err := unix.EpollCtl(epollfd, unix.EPOLL_CTL_ADD, fd, &event)
-	return errors.Wrap(err, "can't add fd to epoll")
+	if err := unix.EpollCtl(epollfd, unix.EPOLL_CTL_ADD, fd, &event); err != nil {
+		return xerrors.Errorf("can't add fd to epoll: %w", err)
+	}
+	return nil
 }
 
 func cpuForEvent(event *unix.EpollEvent) int {
@@ -86,7 +88,7 @@ func readRecord(rd io.Reader, cpu int) (Record, error) {
 	}
 
 	if err != nil {
-		return Record{}, errors.Wrap(err, "can't read event header")
+		return Record{}, xerrors.Errorf("can't read event header: %w", err)
 	}
 
 	switch header.Type {
@@ -112,7 +114,7 @@ func readLostRecords(rd io.Reader) (uint64, error) {
 
 	err := binary.Read(rd, internal.NativeEndian, &lostHeader)
 	if err != nil {
-		return 0, errors.Wrap(err, "can't read lost records header")
+		return 0, xerrors.Errorf("can't read lost records header: %w", err)
 	}
 
 	return lostHeader.Lost, nil
@@ -122,12 +124,14 @@ func readRawSample(rd io.Reader) ([]byte, error) {
 	// This must match 'struct perf_event_sample in kernel sources.
 	var size uint32
 	if err := binary.Read(rd, internal.NativeEndian, &size); err != nil {
-		return nil, errors.Wrap(err, "can't read sample size")
+		return nil, xerrors.Errorf("can't read sample size: %w", err)
 	}
 
 	data := make([]byte, int(size))
-	_, err := io.ReadFull(rd, data)
-	return data, errors.Wrap(err, "can't read sample")
+	if _, err := io.ReadFull(rd, data); err != nil {
+		return []byte{}, xerrors.Errorf("can't read sample: %w", err)
+	}
+	return data, nil
 }
 
 // Reader allows reading bpf_perf_event_output
@@ -179,12 +183,12 @@ func NewReader(array *ebpf.Map, perCPUBuffer int) (*Reader, error) {
 // NewReaderWithOptions creates a new reader with the given options.
 func NewReaderWithOptions(array *ebpf.Map, perCPUBuffer int, opts ReaderOptions) (pr *Reader, err error) {
 	if perCPUBuffer < 1 {
-		return nil, errors.New("perCPUBuffer must be larger than 0")
+		return nil, xerrors.New("perCPUBuffer must be larger than 0")
 	}
 
 	epollFd, err := unix.EpollCreate1(unix.EPOLL_CLOEXEC)
 	if err != nil {
-		return nil, errors.Wrap(err, "can't create epoll fd")
+		return nil, xerrors.Errorf("can't create epoll fd: %w", err)
 	}
 
 	var (
@@ -211,7 +215,7 @@ func NewReaderWithOptions(array *ebpf.Map, perCPUBuffer int, opts ReaderOptions)
 	for i := 0; i < nCPU; i++ {
 		ring, err := newPerfEventRing(i, perCPUBuffer, opts.Watermark)
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to create perf ring for CPU %d", i)
+			return nil, xerrors.Errorf("failed to create perf ring for CPU %d: %w", i, err)
 		}
 		rings = append(rings, ring)
 		pauseFds = append(pauseFds, ring.fd)
@@ -272,7 +276,7 @@ func (pr *Reader) Close() error {
 		internal.NativeEndian.PutUint64(value[:], 1)
 		_, err = unix.Write(pr.closeFd, value[:])
 		if err != nil {
-			err = errors.Wrap(err, "can't write event fd")
+			err = xerrors.Errorf("can't write event fd: %w", err)
 			return
 		}
 
@@ -296,8 +300,10 @@ func (pr *Reader) Close() error {
 
 		pr.array.Close()
 	})
-
-	return errors.Wrap(err, "close PerfReader")
+	if err != nil {
+		return xerrors.Errorf("close PerfReader: %w", err)
+	}
+	return nil
 }
 
 // Read the next record from the perf ring buffer.
@@ -374,7 +380,7 @@ func (pr *Reader) Pause() error {
 
 	for i := 0; i < len(pr.pauseFds); i++ {
 		if err := pr.array.Delete(uint32(i)); err != nil && !ebpf.IsNotExist(err) {
-			return errors.Wrapf(err, "could't delete event fd for CPU %d", i)
+			return xerrors.Errorf("could't delete event fd for CPU %d: %w", i, err)
 		}
 	}
 
@@ -395,7 +401,7 @@ func (pr *Reader) Resume() error {
 	for i := 0; i < len(pr.pauseFds); i++ {
 		fd := uint32(pr.pauseFds[i])
 		if err := pr.array.Put(uint32(i), fd); err != nil {
-			return errors.Wrapf(err, "could't put event fd %d for CPU %d", fd, i)
+			return xerrors.Errorf("couldn't put event fd %d for CPU %d: %w", fd, i, err)
 		}
 	}
 
@@ -409,7 +415,7 @@ type temporaryError interface {
 // IsClosed returns true if the error occurred because
 // a Reader was closed.
 func IsClosed(err error) bool {
-	return errors.Cause(err) == errClosed
+	return xerrors.Is(err, errClosed)
 }
 
 type unknownEventError struct {
@@ -423,6 +429,5 @@ func (uev *unknownEventError) Error() string {
 // IsUnknownEvent returns true if the error occured
 // because an unknown event was submitted to the perf event ring.
 func IsUnknownEvent(err error) bool {
-	_, ok := errors.Cause(err).(*unknownEventError)
-	return ok
+	return xerrors.Is(err, (err).(*unknownEventError))
 }

--- a/perf/reader.go
+++ b/perf/reader.go
@@ -43,7 +43,7 @@ func addToEpoll(epollfd, fd int, cpu int) error {
 	}
 
 	if err := unix.EpollCtl(epollfd, unix.EPOLL_CTL_ADD, fd, &event); err != nil {
-		return xerrors.Errorf("can't add fd to epoll: %w", err)
+		return xerrors.Errorf("can't add fd to epoll: %v", err)
 	}
 	return nil
 }
@@ -88,7 +88,7 @@ func readRecord(rd io.Reader, cpu int) (Record, error) {
 	}
 
 	if err != nil {
-		return Record{}, xerrors.Errorf("can't read event header: %w", err)
+		return Record{}, xerrors.Errorf("can't read event header: %v", err)
 	}
 
 	switch header.Type {
@@ -114,7 +114,7 @@ func readLostRecords(rd io.Reader) (uint64, error) {
 
 	err := binary.Read(rd, internal.NativeEndian, &lostHeader)
 	if err != nil {
-		return 0, xerrors.Errorf("can't read lost records header: %w", err)
+		return 0, xerrors.Errorf("can't read lost records header: %v", err)
 	}
 
 	return lostHeader.Lost, nil
@@ -124,12 +124,12 @@ func readRawSample(rd io.Reader) ([]byte, error) {
 	// This must match 'struct perf_event_sample in kernel sources.
 	var size uint32
 	if err := binary.Read(rd, internal.NativeEndian, &size); err != nil {
-		return nil, xerrors.Errorf("can't read sample size: %w", err)
+		return nil, xerrors.Errorf("can't read sample size: %v", err)
 	}
 
 	data := make([]byte, int(size))
 	if _, err := io.ReadFull(rd, data); err != nil {
-		return []byte{}, xerrors.Errorf("can't read sample: %w", err)
+		return nil, xerrors.Errorf("can't read sample: %v", err)
 	}
 	return data, nil
 }
@@ -188,7 +188,7 @@ func NewReaderWithOptions(array *ebpf.Map, perCPUBuffer int, opts ReaderOptions)
 
 	epollFd, err := unix.EpollCreate1(unix.EPOLL_CLOEXEC)
 	if err != nil {
-		return nil, xerrors.Errorf("can't create epoll fd: %w", err)
+		return nil, xerrors.Errorf("can't create epoll fd: %v", err)
 	}
 
 	var (
@@ -276,7 +276,7 @@ func (pr *Reader) Close() error {
 		internal.NativeEndian.PutUint64(value[:], 1)
 		_, err = unix.Write(pr.closeFd, value[:])
 		if err != nil {
-			err = xerrors.Errorf("can't write event fd: %w", err)
+			err = xerrors.Errorf("can't write event fd: %v", err)
 			return
 		}
 

--- a/perf/ring.go
+++ b/perf/ring.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/cilium/ebpf/internal/unix"
 
-	"github.com/pkg/errors"
+	"golang.org/x/xerrors"
 )
 
 // perfEventRing is a page of metadata followed by
@@ -23,7 +23,7 @@ type perfEventRing struct {
 
 func newPerfEventRing(cpu, perCPUBuffer, watermark int) (*perfEventRing, error) {
 	if watermark >= perCPUBuffer {
-		return nil, errors.Errorf("watermark must be smaller than perCPUBuffer")
+		return nil, xerrors.New("watermark must be smaller than perCPUBuffer")
 	}
 
 	// Round to nearest page boundary and allocate
@@ -34,7 +34,7 @@ func newPerfEventRing(cpu, perCPUBuffer, watermark int) (*perfEventRing, error) 
 
 	fd, err := createPerfEvent(cpu, watermark)
 	if err != nil {
-		return nil, errors.Wrap(err, "can't create perf event")
+		return nil, xerrors.Errorf("can't create perf event: %w", err)
 	}
 
 	if err := unix.SetNonblock(fd, true); err != nil {
@@ -89,7 +89,10 @@ func createPerfEvent(cpu, watermark int) (int, error) {
 
 	attr.Size = uint32(unsafe.Sizeof(attr))
 	fd, err := unix.PerfEventOpen(&attr, -1, cpu, -1, unix.PERF_FLAG_FD_CLOEXEC)
-	return fd, errors.Wrap(err, "can't create perf event")
+	if err != nil {
+		return -1, xerrors.Errorf("can't create perf event: %w", err)
+	}
+	return fd, nil
 }
 
 type ringReader struct {

--- a/perf/ring.go
+++ b/perf/ring.go
@@ -90,7 +90,7 @@ func createPerfEvent(cpu, watermark int) (int, error) {
 	attr.Size = uint32(unsafe.Sizeof(attr))
 	fd, err := unix.PerfEventOpen(&attr, -1, cpu, -1, unix.PERF_FLAG_FD_CLOEXEC)
 	if err != nil {
-		return -1, xerrors.Errorf("can't create perf event: %w", err)
+		return -1, xerrors.Errorf("can't create perf event: %v", err)
 	}
 	return fd, nil
 }

--- a/prog.go
+++ b/prog.go
@@ -399,7 +399,7 @@ func (p *Program) testRun(in []byte, repeat int) (uint32, []byte, time.Duration,
 
 	_, err = internal.BPF(_ProgTestRun, unsafe.Pointer(&attr), unsafe.Sizeof(attr))
 	if err != nil {
-		return 0, nil, 0, xerrors.Errorf("can't run test")
+		return 0, nil, 0, xerrors.Errorf("can't run test: %w", err)
 	}
 
 	if int(attr.dataSizeOut) > cap(out) {

--- a/prog.go
+++ b/prog.go
@@ -304,7 +304,7 @@ func (p *Program) Close() error {
 func (p *Program) Test(in []byte) (uint32, []byte, error) {
 	ret, out, _, err := p.testRun(in, 1)
 	if err != nil {
-		return ret, []byte{}, xerrors.Errorf("can't test program: %w", err)
+		return ret, nil, xerrors.Errorf("can't test program: %w", err)
 	}
 	return ret, out, nil
 }

--- a/prog.go
+++ b/prog.go
@@ -221,7 +221,7 @@ func convertProgramSpec(spec *ProgramSpec, handle *btf.Handle) (*bpfProgLoadAttr
 
 		recSize, bytes, err = btf.ProgramFuncInfos(spec.BTF)
 		if err != nil {
-			return nil, xerrors.Errorf("can't get BTF function infos")
+			return nil, xerrors.Errorf("can't get BTF function infos: %w", err)
 		}
 		attr.funcInfoRecSize = recSize
 		attr.funcInfoCnt = uint32(uint64(len(bytes)) / uint64(recSize))

--- a/prog.go
+++ b/prog.go
@@ -13,7 +13,7 @@ import (
 	"github.com/cilium/ebpf/internal/btf"
 	"github.com/cilium/ebpf/internal/unix"
 
-	"github.com/pkg/errors"
+	"golang.org/x/xerrors"
 )
 
 const (
@@ -98,7 +98,7 @@ func NewProgramWithOptions(spec *ProgramSpec, opts ProgramOptions) (*Program, er
 
 	handle, err := btf.NewHandle(btf.ProgramSpec(spec.BTF))
 	if err != nil && !btf.IsNotSupported(err) {
-		return nil, errors.Wrap(err, "can't load BTF")
+		return nil, xerrors.Errorf("can't load BTF: %w", err)
 	}
 
 	return newProgramWithBTF(spec, handle, opts)
@@ -140,8 +140,10 @@ func newProgramWithBTF(spec *ProgramSpec, btf *btf.Handle, opts ProgramOptions) 
 		_, logErr := bpfProgLoad(attr)
 		err = internal.ErrorWithLog(err, logBuf, logErr)
 	}
-
-	return nil, errors.Wrap(err, "can't load program")
+	if err != nil {
+		return nil, xerrors.Errorf("can't load program: %w", err)
+	}
+	return nil, nil
 }
 
 // NewProgramFromFD creates a program from a raw fd.
@@ -151,7 +153,7 @@ func newProgramWithBTF(spec *ProgramSpec, btf *btf.Handle, opts ProgramOptions) 
 // Requires at least Linux 4.11.
 func NewProgramFromFD(fd int) (*Program, error) {
 	if fd < 0 {
-		return nil, errors.New("invalid fd")
+		return nil, xerrors.New("invalid fd")
 	}
 	bpfFd := internal.NewFD(uint32(fd))
 
@@ -174,11 +176,11 @@ func newProgram(fd *internal.FD, name string, abi *ProgramABI) *Program {
 
 func convertProgramSpec(spec *ProgramSpec, handle *btf.Handle) (*bpfProgLoadAttr, error) {
 	if len(spec.Instructions) == 0 {
-		return nil, errors.New("Instructions cannot be empty")
+		return nil, xerrors.New("Instructions cannot be empty")
 	}
 
 	if len(spec.License) == 0 {
-		return nil, errors.New("License cannot be empty")
+		return nil, xerrors.New("License cannot be empty")
 	}
 
 	buf := bytes.NewBuffer(make([]byte, 0, len(spec.Instructions)*asm.InstructionSize))
@@ -211,7 +213,7 @@ func convertProgramSpec(spec *ProgramSpec, handle *btf.Handle) (*bpfProgLoadAttr
 
 		recSize, bytes, err := btf.ProgramLineInfos(spec.BTF)
 		if err != nil {
-			return nil, errors.Wrap(err, "can't get BTF line infos")
+			return nil, xerrors.Errorf("can't get BTF line infos")
 		}
 		attr.lineInfoRecSize = recSize
 		attr.lineInfoCnt = uint32(uint64(len(bytes)) / uint64(recSize))
@@ -219,7 +221,7 @@ func convertProgramSpec(spec *ProgramSpec, handle *btf.Handle) (*bpfProgLoadAttr
 
 		recSize, bytes, err = btf.ProgramFuncInfos(spec.BTF)
 		if err != nil {
-			return nil, errors.Wrap(err, "can't get BTF function infos")
+			return nil, xerrors.Errorf("can't get BTF function infos")
 		}
 		attr.funcInfoRecSize = recSize
 		attr.funcInfoCnt = uint32(uint64(len(bytes)) / uint64(recSize))
@@ -267,7 +269,7 @@ func (p *Program) Clone() (*Program, error) {
 
 	dup, err := p.fd.Dup()
 	if err != nil {
-		return nil, errors.Wrap(err, "can't clone program")
+		return nil, xerrors.Errorf("can't clone program")
 	}
 
 	return newProgram(dup, p.name, &p.abi), nil
@@ -277,7 +279,10 @@ func (p *Program) Clone() (*Program, error) {
 //
 // This requires bpffs to be mounted above fileName. See http://cilium.readthedocs.io/en/doc-1.0/kubernetes/install/#mounting-the-bpf-fs-optional
 func (p *Program) Pin(fileName string) error {
-	return errors.Wrap(bpfPinObject(fileName, p.fd), "can't pin program")
+	if err := bpfPinObject(fileName, p.fd); err != nil {
+		return xerrors.Errorf("can't pin program: %w", err)
+	}
+	return nil
 }
 
 // Close unloads the program from the kernel.
@@ -298,7 +303,10 @@ func (p *Program) Close() error {
 // This function requires at least Linux 4.12.
 func (p *Program) Test(in []byte) (uint32, []byte, error) {
 	ret, out, _, err := p.testRun(in, 1)
-	return ret, out, errors.Wrap(err, "can't test program")
+	if err != nil {
+		return ret, []byte{}, xerrors.Errorf("can't test program: %w", err)
+	}
+	return ret, out, nil
 }
 
 // Benchmark runs the Program with the given input for a number of times
@@ -310,7 +318,10 @@ func (p *Program) Test(in []byte) (uint32, []byte, error) {
 // This function requires at least Linux 4.12.
 func (p *Program) Benchmark(in []byte, repeat int) (uint32, time.Duration, error) {
 	ret, _, total, err := p.testRun(in, repeat)
-	return ret, total, errors.Wrap(err, "can't benchmark program")
+	if err != nil {
+		return ret, total, xerrors.Errorf("can't benchmark program: %w", err)
+	}
+	return ret, total, nil
 }
 
 var haveProgTestRun = internal.FeatureTest("BPF_PROG_TEST_RUN", "4.12", func() bool {
@@ -345,7 +356,7 @@ var haveProgTestRun = internal.FeatureTest("BPF_PROG_TEST_RUN", "4.12", func() b
 
 	// Check for EINVAL specifically, rather than err != nil since we
 	// otherwise misdetect due to insufficient permissions.
-	return errors.Cause(err) != unix.EINVAL
+	return !xerrors.Is(err, unix.EINVAL)
 })
 
 func (p *Program) testRun(in []byte, repeat int) (uint32, []byte, time.Duration, error) {
@@ -388,7 +399,7 @@ func (p *Program) testRun(in []byte, repeat int) (uint32, []byte, time.Duration,
 
 	_, err = internal.BPF(_ProgTestRun, unsafe.Pointer(&attr), unsafe.Sizeof(attr))
 	if err != nil {
-		return 0, nil, 0, errors.Wrap(err, "can't run test")
+		return 0, nil, 0, xerrors.Errorf("can't run test")
 	}
 
 	if int(attr.dataSizeOut) > cap(out) {
@@ -404,7 +415,7 @@ func (p *Program) testRun(in []byte, repeat int) (uint32, []byte, time.Duration,
 
 func unmarshalProgram(buf []byte) (*Program, error) {
 	if len(buf) != 4 {
-		return nil, errors.New("program id requires 4 byte value")
+		return nil, xerrors.New("program id requires 4 byte value")
 	}
 
 	// Looking up an entry in a nested map or prog array returns an id,
@@ -439,7 +450,7 @@ func (p *Program) MarshalBinary() ([]byte, error) {
 // Attach a Program to a container object fd
 func (p *Program) Attach(fd int, typ AttachType, flags AttachFlags) error {
 	if fd < 0 {
-		return errors.New("invalid fd")
+		return xerrors.New("invalid fd")
 	}
 
 	pfd, err := p.fd.Value()
@@ -460,7 +471,7 @@ func (p *Program) Attach(fd int, typ AttachType, flags AttachFlags) error {
 // Detach a Program from a container object fd
 func (p *Program) Detach(fd int, typ AttachType, flags AttachFlags) error {
 	if fd < 0 {
-		return errors.New("invalid fd")
+		return xerrors.New("invalid fd")
 	}
 
 	pfd, err := p.fd.Value()
@@ -490,7 +501,7 @@ func LoadPinnedProgram(fileName string) (*Program, error) {
 	name, abi, err := newProgramABIFromFd(fd)
 	if err != nil {
 		_ = fd.Close()
-		return nil, errors.Wrapf(err, "can't get ABI for %s", fileName)
+		return nil, xerrors.Errorf("can't get ABI for %s: %w", fileName, err)
 	}
 
 	return newProgram(fd, name, abi), nil
@@ -515,6 +526,5 @@ func SanitizeName(name string, replacement rune) string {
 // IsNotSupported returns true if an error occurred because
 // the kernel does not have support for a specific feature.
 func IsNotSupported(err error) bool {
-	_, notSupported := errors.Cause(err).(*internal.UnsupportedFeatureError)
-	return notSupported
+	return xerrors.Is(err, (err).(*internal.UnsupportedFeatureError))
 }

--- a/prog.go
+++ b/prog.go
@@ -213,7 +213,7 @@ func convertProgramSpec(spec *ProgramSpec, handle *btf.Handle) (*bpfProgLoadAttr
 
 		recSize, bytes, err := btf.ProgramLineInfos(spec.BTF)
 		if err != nil {
-			return nil, xerrors.Errorf("can't get BTF line infos")
+			return nil, xerrors.Errorf("can't get BTF line infos: %w", err)
 		}
 		attr.lineInfoRecSize = recSize
 		attr.lineInfoCnt = uint32(uint64(len(bytes)) / uint64(recSize))

--- a/prog.go
+++ b/prog.go
@@ -269,7 +269,7 @@ func (p *Program) Clone() (*Program, error) {
 
 	dup, err := p.fd.Dup()
 	if err != nil {
-		return nil, xerrors.Errorf("can't clone program")
+		return nil, xerrors.Errorf("can't clone program: %w", err)
 	}
 
 	return newProgram(dup, p.name, &p.abi), nil

--- a/syscalls.go
+++ b/syscalls.go
@@ -9,7 +9,7 @@ import (
 	"github.com/cilium/ebpf/internal/btf"
 	"github.com/cilium/ebpf/internal/unix"
 
-	"github.com/pkg/errors"
+	"golang.org/x/xerrors"
 )
 
 // bpfObjName is a null-terminated string made up of
@@ -20,7 +20,7 @@ type bpfObjName [unix.BPF_OBJ_NAME_LEN]byte
 func newBPFObjName(name string) (bpfObjName, error) {
 	idx := strings.IndexFunc(name, invalidBPFObjNameChar)
 	if idx != -1 {
-		return bpfObjName{}, errors.Errorf("invalid character '%c' in name '%s'", name[idx], name)
+		return bpfObjName{}, xerrors.Errorf("invalid character '%c' in name '%s'", name[idx], name)
 	}
 
 	var result bpfObjName
@@ -291,7 +291,7 @@ func bpfPinObject(fileName string, fd *internal.FD) error {
 		return err
 	}
 	if uint64(statfs.Type) != bpfFSType {
-		return errors.Errorf("%s is not on a bpf filesystem", fileName)
+		return xerrors.Errorf("%s is not on a bpf filesystem", fileName)
 	}
 
 	value, err := fd.Value()
@@ -303,7 +303,10 @@ func bpfPinObject(fileName string, fd *internal.FD) error {
 		fileName: internal.NewStringPointer(fileName),
 		fd:       value,
 	}), 16)
-	return errors.Wrapf(err, "pin object %s", fileName)
+	if err != nil {
+		return xerrors.Errorf("pin object %s: %w", fileName, err)
+	}
+	return nil
 }
 
 func bpfGetObject(fileName string) (*internal.FD, error) {
@@ -311,7 +314,7 @@ func bpfGetObject(fileName string) (*internal.FD, error) {
 		fileName: internal.NewStringPointer(fileName),
 	}), 16)
 	if err != nil {
-		return nil, errors.Wrapf(err, "get object %s", fileName)
+		return nil, xerrors.Errorf("get object %s: %w", fileName, err)
 	}
 	return internal.NewFD(uint32(ptr)), nil
 }
@@ -329,19 +332,27 @@ func bpfGetObjectInfoByFD(fd *internal.FD, info unsafe.Pointer, size uintptr) er
 		info:    internal.NewPointer(info),
 	}
 	_, err = internal.BPF(_ObjGetInfoByFD, unsafe.Pointer(&attr), unsafe.Sizeof(attr))
-	return errors.Wrapf(err, "fd %d", fd)
+	if err != nil {
+		return xerrors.Errorf("fd %d: %w", fd, err)
+	}
+	return nil
 }
 
 func bpfGetProgInfoByFD(fd *internal.FD) (*bpfProgInfo, error) {
 	var info bpfProgInfo
-	err := bpfGetObjectInfoByFD(fd, unsafe.Pointer(&info), unsafe.Sizeof(info))
-	return &info, errors.Wrap(err, "can't get program info")
+	if err := bpfGetObjectInfoByFD(fd, unsafe.Pointer(&info), unsafe.Sizeof(info)); err != nil {
+		return &info, xerrors.Errorf("can't get program info: %w", err)
+	}
+	return &info, nil
 }
 
 func bpfGetMapInfoByFD(fd *internal.FD) (*bpfMapInfo, error) {
 	var info bpfMapInfo
 	err := bpfGetObjectInfoByFD(fd, unsafe.Pointer(&info), unsafe.Sizeof(info))
-	return &info, errors.Wrap(err, "can't get map info")
+	if err != nil {
+		return &bpfMapInfo{}, xerrors.Errorf("can't get map info: %w", err)
+	}
+	return &info, nil
 }
 
 var haveObjName = internal.FeatureTest("object names", "4.15", func() bool {
@@ -376,7 +387,7 @@ func bpfGetMapFDByID(id uint32) (*internal.FD, error) {
 	}
 	ptr, err := internal.BPF(_MapGetFDByID, unsafe.Pointer(&attr), unsafe.Sizeof(attr))
 	if err != nil {
-		return nil, errors.Wrapf(err, "can't get fd for map id %d", id)
+		return nil, xerrors.Errorf("can't get fd for map id %d: %w", id, err)
 	}
 	return internal.NewFD(uint32(ptr)), nil
 }
@@ -388,7 +399,7 @@ func bpfGetProgramFDByID(id uint32) (*internal.FD, error) {
 	}
 	ptr, err := internal.BPF(_ProgGetFDByID, unsafe.Pointer(&attr), unsafe.Sizeof(attr))
 	if err != nil {
-		return nil, errors.Wrapf(err, "can't get fd for program id %d", id)
+		return nil, xerrors.Errorf("can't get fd for program id %d: %w", id, err)
 	}
 	return internal.NewFD(uint32(ptr)), nil
 }


### PR DESCRIPTION
Signed-off-by: Lehner Florian <dev@der-flo.net>

As mentioned in #38, this PR migrates error handling from github.com/pkg/errors to golang.org/x/xerrors