### PR TITLE
map: allow creating PerfEventArray with key or value size four

### DIFF
--- a/map.go
+++ b/map.go
@@ -129,11 +129,11 @@ func createMap(spec *MapSpec, inner *internal.FD, handle *btf.Handle) (*Map, err
 		spec.ValueSize = 4
 
 	case PerfEventArray:
-		if spec.KeySize != 0 {
-			return nil, errors.Errorf("KeySize must be zero for perf event array")
+		if spec.KeySize != 0 && spec.KeySize != 4 {
+			return nil, errors.Errorf("KeySize must be zero or four for perf event array")
 		}
-		if spec.ValueSize != 0 {
-			return nil, errors.Errorf("ValueSize must be zero for perf event array")
+		if spec.ValueSize != 0 && spec.ValueSize != 4 {
+			return nil, errors.Errorf("ValueSize must be zero or four for perf event array")
 		}
 		if spec.MaxEntries == 0 {
 			n, err := internal.OnlineCPUs()

--- a/map_test.go
+++ b/map_test.go
@@ -292,13 +292,20 @@ func TestNewMapInMapFromFD(t *testing.T) {
 }
 
 func TestPerfEventArray(t *testing.T) {
-	m, err := NewMap(&MapSpec{
-		Type: PerfEventArray,
-	})
-	if err != nil {
-		t.Fatal("Can't create perf event array:", err)
+	specs := []*MapSpec{
+		{Type: PerfEventArray},
+		{Type: PerfEventArray, KeySize: 4},
+		{Type: PerfEventArray, ValueSize: 4},
 	}
-	m.Close()
+
+	for _, spec := range specs {
+		m, err := NewMap(spec)
+		if err != nil {
+			t.Errorf("Can't create perf event array from %v: %s", spec, err)
+		} else {
+			m.Close()
+		}
+	}
 }
 
 func createMapInMap(t *testing.T, typ MapType) *Map {


### PR DESCRIPTION
libbpf based tooling expects map definitions for PerfEventArrays to
have a key and value size of four, while this package has traditionally
required a size of zero. Accept key or value size of four to be
compatible with libbpf.