### PR TITLE
internal: zero terminate pointers to a string

### DIFF
--- a/internal/ptr.go
+++ b/internal/ptr.go
@@ -22,5 +22,9 @@ func NewStringPointer(str string) Pointer {
 		return Pointer{}
 	}
 
-	return Pointer{ptr: unsafe.Pointer(&[]byte(str)[0])}
+	// The kernel expects strings to be zero terminated
+	buf := make([]byte, len(str)+1)
+	copy(buf, str)
+
+	return Pointer{ptr: unsafe.Pointer(&buf[0])}
 }

--- a/map_test.go
+++ b/map_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"testing"
 	"unsafe"
 
@@ -108,7 +109,11 @@ func TestMapPin(t *testing.T) {
 	}
 	defer os.RemoveAll(tmp)
 
-	path := filepath.Join(tmp, "map")
+	// Issue 51: pad path out to a power of two, to avoid having a
+	// trailing zero at the end of the allocation which holds the string.
+	path := tmp + string(filepath.Separator)
+	path += strings.Repeat("a", 32-len(path))
+
 	if err := m.Pin(path); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
The kernel expects any strings to be zero terminated. The pointer conversion
code so far hasn't ensured that this is the case. Unfortunately it's not
possible to test for this reliably, since the behaviour seems to depend on
how the Go runtime copies strings into byte buffers.

Fixes #51