### PR TITLE
map: populate name from ELF symbol name

### DIFF
--- a/elf_reader.go
+++ b/elf_reader.go
@@ -259,7 +259,9 @@ func (ec *elfCode) loadMaps(maps map[string]*MapSpec, mapSections map[elf.Sectio
 
 			lr := io.LimitReader(r, int64(size))
 
-			var spec MapSpec
+			spec := MapSpec{
+				Name: SanitizeName(mapSym, -1),
+			}
 			switch {
 			case binary.Read(lr, ec.ByteOrder, &spec.Type) != nil:
 				return errors.Errorf("map %v: missing type", mapSym)

--- a/map.go
+++ b/map.go
@@ -169,13 +169,8 @@ func createMap(spec *MapSpec, inner *internal.FD, handle *btf.Handle) (*Map, err
 		attr.btfValueTypeID = btf.MapValue(spec.BTF).ID()
 	}
 
-	name, err := newBPFObjName(spec.Name)
-	if err != nil {
-		return nil, errors.Wrap(err, "map create")
-	}
-
 	if haveObjName() == nil {
-		attr.mapName = name
+		attr.mapName = newBPFObjName(spec.Name)
 	}
 
 	fd, err := bpfMapCreate(&attr)

--- a/prog.go
+++ b/prog.go
@@ -197,13 +197,8 @@ func convertProgramSpec(spec *ProgramSpec, handle *btf.Handle) (*bpfProgLoadAttr
 		license:            internal.NewStringPointer(spec.License),
 	}
 
-	name, err := newBPFObjName(spec.Name)
-	if err != nil {
-		return nil, err
-	}
-
 	if haveObjName() == nil {
-		attr.progName = name
+		attr.progName = newBPFObjName(spec.Name)
 	}
 
 	if handle != nil && spec.BTF != nil {


### PR DESCRIPTION
Use the symbol used to refer to a map as the default name. Since Linux 5.2
it's also valid to include '.' in a name, so make SanitizeName account for
this.