### PR TITLE
use sentinel errors instead of functions

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -136,7 +136,7 @@ func NewCollectionWithOptions(spec *CollectionSpec, opts CollectionOptions) (col
 		var handle *btf.Handle
 		if mapSpec.BTF != nil {
 			handle, err = loadBTF(btf.MapSpec(mapSpec.BTF))
-			if err != nil && !btf.IsNotSupported(err) {
+			if err != nil && !xerrors.Is(err, btf.ErrNotSupported) {
 				return nil, err
 			}
 		}
@@ -176,7 +176,7 @@ func NewCollectionWithOptions(spec *CollectionSpec, opts CollectionOptions) (col
 		var handle *btf.Handle
 		if progSpec.BTF != nil {
 			handle, err = loadBTF(btf.ProgramSpec(progSpec.BTF))
-			if err != nil && !btf.IsNotSupported(err) {
+			if err != nil && !xerrors.Is(err, btf.ErrNotSupported) {
 				return nil, err
 			}
 		}

--- a/internal/btf/btf.go
+++ b/internal/btf/btf.go
@@ -18,6 +18,11 @@ import (
 
 const btfMagic = 0xeB9F
 
+// Errors returned by BTF functions.
+var (
+	ErrNotSupported = internal.ErrNotSupported
+)
+
 // Spec represents decoded BTF.
 type Spec struct {
 	rawTypes  []rawType
@@ -307,8 +312,7 @@ type Handle struct {
 
 // NewHandle loads BTF into the kernel.
 //
-// Returns an error if BTF is not supported, which can
-// be checked by IsNotSupported.
+// Returns ErrNotSupported if BTF is not supported.
 func NewHandle(spec *Spec) (*Handle, error) {
 	if err := haveBTF(); err != nil {
 		return nil, err
@@ -449,13 +453,6 @@ func ProgramLineInfos(s *Program) (recordSize uint32, bytes []byte, err error) {
 	}
 
 	return s.lineInfos.recordSize, bytes, nil
-}
-
-// IsNotSupported returns true if the error indicates that the kernel
-// doesn't support BTF.
-func IsNotSupported(err error) bool {
-	var ufe *internal.UnsupportedFeatureError
-	return xerrors.As(err, &ufe) && ufe.Name == "BTF"
 }
 
 type bpfLoadBTFAttr struct {

--- a/internal/feature.go
+++ b/internal/feature.go
@@ -7,6 +7,9 @@ import (
 	"golang.org/x/xerrors"
 )
 
+// ErrNotSupported indicates that a feature is not supported by the current kernel.
+var ErrNotSupported = xerrors.New("not supported")
+
 // UnsupportedFeatureError is returned by FeatureTest() functions.
 type UnsupportedFeatureError struct {
 	// The minimum Linux mainline version required for this feature.
@@ -19,6 +22,11 @@ type UnsupportedFeatureError struct {
 
 func (ufe *UnsupportedFeatureError) Error() string {
 	return fmt.Sprintf("%s not supported (requires >= %s)", ufe.Name, ufe.MinimumVersion)
+}
+
+// Is indicates that UnsupportedFeatureError is ErrNotSupported.
+func (ufe *UnsupportedFeatureError) Is(target error) bool {
+	return target == ErrNotSupported
 }
 
 // FeatureTest wraps a function so that it is run at most once.

--- a/internal/feature_test.go
+++ b/internal/feature_test.go
@@ -1,8 +1,11 @@
 package internal
 
-import "testing"
+import (
+	"strings"
+	"testing"
 
-import "strings"
+	"golang.org/x/xerrors"
+)
 
 func TestFeatureTest(t *testing.T) {
 	var called bool
@@ -41,6 +44,10 @@ func TestFeatureTest(t *testing.T) {
 
 	if !strings.Contains(fte.Error(), "2.1.1") {
 		t.Error("UnsupportedFeatureError.Error doesn't contain version")
+	}
+
+	if !xerrors.Is(err, ErrNotSupported) {
+		t.Error("UnsupportedFeatureError is not ErrNotSupported")
 	}
 }
 

--- a/perf/reader.go
+++ b/perf/reader.go
@@ -379,7 +379,7 @@ func (pr *Reader) Pause() error {
 	}
 
 	for i := 0; i < len(pr.pauseFds); i++ {
-		if err := pr.array.Delete(uint32(i)); err != nil && !ebpf.IsNotExist(err) {
+		if err := pr.array.Delete(uint32(i)); err != nil && !xerrors.Is(err, ebpf.ErrKeyNotExist) {
 			return xerrors.Errorf("could't delete event fd for CPU %d: %w", i, err)
 		}
 	}

--- a/prog.go
+++ b/prog.go
@@ -16,6 +16,9 @@ import (
 	"golang.org/x/xerrors"
 )
 
+// ErrNotSupported is returned whenever the kernel doesn't support a feature.
+var ErrNotSupported = internal.ErrNotSupported
+
 const (
 	// Number of bytes to pad the output buffer for BPF_PROG_TEST_RUN.
 	// This is currently the maximum of spare space allocated for SKB
@@ -97,7 +100,7 @@ func NewProgramWithOptions(spec *ProgramSpec, opts ProgramOptions) (*Program, er
 	}
 
 	handle, err := btf.NewHandle(btf.ProgramSpec(spec.BTF))
-	if err != nil && !btf.IsNotSupported(err) {
+	if err != nil && !xerrors.Is(err, btf.ErrNotSupported) {
 		return nil, xerrors.Errorf("can't load BTF: %w", err)
 	}
 
@@ -513,11 +516,4 @@ func SanitizeName(name string, replacement rune) string {
 		}
 		return char
 	}, name)
-}
-
-// IsNotSupported returns true if an error occurred because
-// the kernel does not have support for a specific feature.
-func IsNotSupported(err error) bool {
-	var ufe *internal.UnsupportedFeatureError
-	return xerrors.As(err, &ufe)
 }


### PR DESCRIPTION
With the new errors.Is and errors.As functions from Go 1.13 we can remove
the various Is* functions without a loss in flexibility. Instead, we export
sentinel errors and take care to always return them in a wrapped form.

Users that are not yet on Go 1.13 can use the golang.org/x/xerrors package.