### PR TITLE
internal: consider hotplugged CPUs in PossibleCPUs and OnlineCPUs

### DIFF
--- a/internal/cpu.go
+++ b/internal/cpu.go
@@ -1,8 +1,9 @@
 package internal
 
 import (
-	"fmt"
-	"os"
+	"io/ioutil"
+	"strconv"
+	"strings"
 	"sync"
 
 	"golang.org/x/xerrors"
@@ -14,8 +15,7 @@ var sysCPU struct {
 	num  int
 }
 
-// PossibleCPUs returns the max number of CPUs a system may possibly have
-// Logical CPU numbers must be of the form 0-n
+// PossibleCPUs returns the max number of CPUs a system may possibly have.
 func PossibleCPUs() (int, error) {
 	sysCPU.once.Do(func() {
 		sysCPU.num, sysCPU.err = parseCPUs("/sys/devices/system/cpu/possible")
@@ -24,41 +24,39 @@ func PossibleCPUs() (int, error) {
 	return sysCPU.num, sysCPU.err
 }
 
-var onlineCPU struct {
-	once sync.Once
-	err  error
-	num  int
-}
-
-// OnlineCPUs returns the number of currently online CPUs
-// Logical CPU numbers must be of the form 0-n
+// OnlineCPUs returns the number of currently online CPUs.
 func OnlineCPUs() (int, error) {
-	onlineCPU.once.Do(func() {
-		onlineCPU.num, onlineCPU.err = parseCPUs("/sys/devices/system/cpu/online")
-	})
-
-	return onlineCPU.num, onlineCPU.err
+	return parseCPUs("/sys/devices/system/cpu/online")
 }
 
 // parseCPUs parses the number of cpus from sysfs,
 // in the format of "/sys/devices/system/cpu/{possible,online,..}.
-// Logical CPU numbers must be of the form 0-n
 func parseCPUs(path string) (int, error) {
-	file, err := os.Open(path)
+	buf, err := ioutil.ReadFile(path)
 	if err != nil {
 		return 0, err
 	}
-	defer file.Close()
 
-	var low, high int
-	n, _ := fmt.Fscanf(file, "%d-%d", &low, &high)
-	if n < 1 || low != 0 {
-		return 0, xerrors.Errorf("%s has unknown format: %v", path, err)
+	cpus := strings.Trim(string(buf), "\n ")
+	n := int(0)
+	for _, cpuRange := range strings.Split(cpus, ",") {
+		if len(cpuRange) == 0 {
+			continue
+		}
+		rangeOp := strings.SplitN(cpuRange, "-", 2)
+		first, err := strconv.ParseUint(rangeOp[0], 10, 32)
+		if err != nil {
+			return 0, xerrors.Errorf("%s has unknown format: %v", path, err)
+		}
+		if len(rangeOp) == 1 {
+			n++
+			continue
+		}
+		last, err := strconv.ParseUint(rangeOp[1], 10, 32)
+		if err != nil {
+			return 0, xerrors.Errorf("%s has unknown format: %v", path, err)
+		}
+		n += int(last - first + 1)
 	}
-	if n == 1 {
-		high = low
-	}
-
-	// cpus is 0 indexed
-	return high + 1, nil
+	return n, nil
 }

--- a/internal/cpu_test.go
+++ b/internal/cpu_test.go
@@ -8,8 +8,12 @@ import (
 
 func TestParseCPUs(t *testing.T) {
 	for str, result := range map[string]int{
-		"0-1": 2,
-		"0":   1,
+		"0-1":        2,
+		"0":          1,
+		"0,2":        2,
+		"0-2,3":      4,
+		"0,2-4,7":    5,
+		"0,2-4,7-15": 13,
 	} {
 		fh, err := ioutil.TempFile("", "ebpf")
 		if err != nil {


### PR DESCRIPTION
With CPU hotplugging present, /sys/devices/system/cpu/online
may contain not only ranges such as "0-3" but a mixture of CPU ranges
and individual CPUs, e.g. "0,3-7" (meaning CPU 0 and 3-7). Consider this
fact in the implementation of parseCPUs and also don't cache the results
in OnlineCPUs, as CPUs might appear and disappear during runtime.

See Documentation/admin-guide/cputopology.rst in the Linux kernel source
tree for more information.

Implementation based on github.com/tklauser/numcpus

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>