### PR TITLE
Make CI runs a bit faster

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -24,10 +24,10 @@ blocks:
           - GOARCH=arm64 go build ./...
       - name: Test on 5.4.5
         commands:
-          - timeout -s KILL 60s ./run-tests.sh 5.4.5
+          - timeout -s KILL 90s ./run-tests.sh 5.4.5
       - name: Test on 4.19.81
         commands:
-          - timeout -s KILL 60s ./run-tests.sh 4.19.81
+          - timeout -s KILL 90s ./run-tests.sh 4.19.81
       - name: Test on 4.9.198
         commands:
-          - timeout -s KILL 60s ./run-tests.sh 4.9.198
+          - timeout -s KILL 90s ./run-tests.sh 4.9.198

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -13,7 +13,6 @@ blocks:
         commands:
           - checkout
           - sem-version go 1.13
-          - go get -d ./...
           - go build ./...
           - sudo pip3 install https://github.com/amluto/virtme/archive/538f1e756139a6b57a4780e7ceb3ac6bcaa4fe6f.zip
           - sudo apt-get install -y qemu-system-x86

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -8,23 +8,18 @@ set -o pipefail
 if [[ "${1:-}" = "--in-vm" ]]; then
   shift
 
-  readonly home="$(mktemp --directory)"
-
   mount -t bpf bpf /sys/fs/bpf
   export CGO_ENABLED=0
   export GOFLAGS=-mod=readonly
-  export GOPROXY=file:///run/go-proxy
+  export GOPATH=/run/go-path
+  export GOPROXY=file:///run/go-root/pkg/mod/cache/download
   export GOCACHE=/run/go-cache
-  export HOME="$home"
 
   echo Running tests...
   /usr/local/bin/go test -coverprofile="$1/coverage.txt" -covermode=atomic -v ./...
   touch "$1/success"
   exit 0
 fi
-
-# Force Go modules, so that vendoring and building are easier.
-export GO111MODULE=on
 
 # Pull all dependencies, so that we can run tests without the
 # vm having network access.
@@ -53,11 +48,11 @@ test -e "${tmp_dir}/${kernel}" || {
 }
 
 echo Testing on ${kernel_version}
-$sudo virtme-run --kimg "${tmp_dir}/${kernel}" --memory 256M --pwd \
+$sudo virtme-run --kimg "${tmp_dir}/${kernel}" --memory 512M --pwd \
   --rwdir=/run/output="${output}" \
-  --rodir=/run/go-proxy="$(go env GOPATH)/pkg/mod/cache/download" \
+  --rodir=/run/go-path="$(go env GOPATH)" \
   --rwdir=/run/go-cache="$(go env GOCACHE)" \
-  --script-sh "$(realpath "$0") --in-vm /run/output" --qemu-opts -smp 2
+  --script-sh "$(realpath "$0") --in-vm /run/output"
 
 if [[ ! -e "${output}/success" ]]; then
   echo "Test failed on ${kernel_version}"


### PR DESCRIPTION
I'm trying to trim some time from our CI builds, without much luck it seems. I've managed to avoid fetching packages over and over, but I suspect that something is messing with the Go build cache. Since we still have plenty of credit on CI this isn't super pressing, so I'm not investigating further.