### PR TITLE
btf: wrap errors correctly

### DIFF
--- a/internal/btf/btf.go
+++ b/internal/btf/btf.go
@@ -413,7 +413,7 @@ func NewHandle(spec *Spec) (*Handle, error) {
 
 	btf, err := spec.marshal(internal.NativeEndian)
 	if err != nil {
-		return nil, xerrors.Errorf("can't marshal BTF: %w")
+		return nil, xerrors.Errorf("can't marshal BTF: %w", err)
 	}
 
 	if uint64(len(btf)) > math.MaxUint32 {

--- a/internal/btf/ext_info.go
+++ b/internal/btf/ext_info.go
@@ -71,7 +71,7 @@ func parseExtInfos(r io.ReadSeeker, bo binary.ByteOrder, strings stringTable) (f
 
 	lineInfo, err = parseExtInfo(io.LimitReader(r, int64(header.LineInfoLen)), bo, strings)
 	if err != nil {
-		return nil, nil, xerrors.Errorf("line info: %w")
+		return nil, nil, xerrors.Errorf("line info: %w", err)
 	}
 
 	return funcInfo, lineInfo, nil


### PR DESCRIPTION
Two `xerrors.Errorf` calls with the `%w` verb are missing the error to wrap.
Add it.

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>