### PR TITLE
program: include verifier output on error when LogLevel > 0

### DIFF
--- a/internal/errors.go
+++ b/internal/errors.go
@@ -20,24 +20,21 @@ func ErrorWithLog(err error, log []byte, logErr error) error {
 		logStr += " (truncated...)"
 	}
 
-	return &loadError{err, logStr}
+	return &VerifierError{err, logStr}
 }
 
-type loadError struct {
+// VerifierError includes information from the eBPF verifier.
+type VerifierError struct {
 	cause error
 	log   string
 }
 
-func (le *loadError) Error() string {
+func (le *VerifierError) Error() string {
 	if le.log == "" {
 		return le.cause.Error()
 	}
 
 	return fmt.Sprintf("%s: %s", le.cause, le.log)
-}
-
-func (le *loadError) Cause() error {
-	return le.cause
 }
 
 // CString turns a NUL / zero terminated byte buffer into a string.

--- a/prog.go
+++ b/prog.go
@@ -136,6 +136,7 @@ func newProgramWithBTF(spec *ProgramSpec, btf *btf.Handle, opts ProgramOptions) 
 		return prog, nil
 	}
 
+	logErr := err
 	if opts.LogLevel == 0 {
 		// Re-run with the verifier enabled to get better error messages.
 		logBuf = make([]byte, logSize)
@@ -143,9 +144,10 @@ func newProgramWithBTF(spec *ProgramSpec, btf *btf.Handle, opts ProgramOptions) 
 		attr.logSize = uint32(len(logBuf))
 		attr.logBuf = internal.NewSlicePointer(logBuf)
 
-		_, logErr := bpfProgLoad(attr)
-		err = internal.ErrorWithLog(err, logBuf, logErr)
+		_, logErr = bpfProgLoad(attr)
 	}
+
+	err = internal.ErrorWithLog(err, logBuf, logErr)
 	return nil, xerrors.Errorf("can't load program: %w", err)
 }
 

--- a/prog_test.go
+++ b/prog_test.go
@@ -161,9 +161,28 @@ func TestProgramVerifierOutput(t *testing.T) {
 	}
 	defer prog.Close()
 
-	t.Log(prog.VerifierLog)
 	if prog.VerifierLog == "" {
-		t.Error("Expected VerifierLog to not be empty")
+		t.Error("Expected VerifierLog to be present")
+	}
+
+	// Issue 64
+	_, err = NewProgramWithOptions(&ProgramSpec{
+		Type: SocketFilter,
+		Instructions: asm.Instructions{
+			asm.Mov.Reg(asm.R0, asm.R1),
+		},
+		License: "MIT",
+	}, ProgramOptions{
+		LogLevel: 2,
+	})
+
+	if err == nil {
+		t.Fatal("Expected an error from invalid program")
+	}
+
+	var ve *internal.VerifierError
+	if !xerrors.As(err, &ve) {
+		t.Error("Error is not a VerifierError")
 	}
 }
 


### PR DESCRIPTION
An earlier change made it so that we'd discard the verifier output
if the user had specified a LogLevel > 0. Fix this and add a test.

Fixes #64