### PR TITLE
btf: add String() for btfKind

### DIFF
--- a/internal/btf/btf_types.go
+++ b/internal/btf/btf_types.go
@@ -2,6 +2,7 @@ package btf
 
 import (
 	"encoding/binary"
+	"fmt"
 	"io"
 
 	"golang.org/x/xerrors"
@@ -59,6 +60,45 @@ type btfType struct {
 	 * "type" is a type_id referring to another type.
 	 */
 	SizeType uint32
+}
+
+func (k btfKind) String() string {
+	switch k {
+	case kindUnknown:
+		return "Unknown"
+	case kindInt:
+		return "Integer"
+	case kindPointer:
+		return "Pointer"
+	case kindArray:
+		return "Array"
+	case kindStruct:
+		return "Struct"
+	case kindUnion:
+		return "Union"
+	case kindEnum:
+		return "Enumeration"
+	case kindForward:
+		return "Forward"
+	case kindTypedef:
+		return "Typedef"
+	case kindVolatile:
+		return "Volatile"
+	case kindConst:
+		return "Const"
+	case kindRestrict:
+		return "Restrict"
+	case kindFunc:
+		return "Function"
+	case kindFuncProto:
+		return "Function Proto"
+	case kindVar:
+		return "Variable"
+	case kindDatasec:
+		return "Section"
+	default:
+		return fmt.Sprintf("Unknown (%d)", k)
+	}
 }
 
 func mask(len uint32) uint32 {

--- a/internal/btf/types.go
+++ b/internal/btf/types.go
@@ -576,7 +576,7 @@ func inflateRawTypes(rawTypes []rawType, rawStrings stringTable) (namedTypes map
 		}
 
 		if expected := fixup.expectedKind; expected != kindUnknown && rawKind != expected {
-			return nil, xerrors.Errorf("expected type id %d to have kind %s, found %s", expected, rawKind)
+			return nil, xerrors.Errorf("expected type id %d to have kind %s, found %s", fixup.id, expected, rawKind)
 		}
 
 		*fixup.typ = types[i]


### PR DESCRIPTION
Signed-off-by: Lehner Florian <dev@der-flo.net>

This PR started by fixing a simple error message and resulted then in adding the missing `String()` for `btfKind`. 