### PR TITLE
program: retry BPF_PROG_TEST_RUN on EINTR

### DIFF
--- a/internal/unix/types_linux.go
+++ b/internal/unix/types_linux.go
@@ -14,6 +14,8 @@ const (
 	ENOSPC                   = linux.ENOSPC
 	EINVAL                   = linux.EINVAL
 	EPOLLIN                  = linux.EPOLLIN
+	EINTR                    = linux.EINTR
+	ESRCH                    = linux.ESRCH
 	BPF_F_RDONLY_PROG        = linux.BPF_F_RDONLY_PROG
 	BPF_F_WRONLY_PROG        = linux.BPF_F_WRONLY_PROG
 	BPF_OBJ_NAME_LEN         = linux.BPF_OBJ_NAME_LEN
@@ -126,4 +128,19 @@ type Utsname = linux.Utsname
 // Uname is a wrapper
 func Uname(buf *Utsname) (err error) {
 	return linux.Uname(buf)
+}
+
+// Getpid is a wrapper
+func Getpid() int {
+	return linux.Getpid()
+}
+
+// Gettid is a wrapper
+func Gettid() int {
+	return linux.Gettid()
+}
+
+// Tgkill is a wrapper
+func Tgkill(tgid int, tid int, sig syscall.Signal) (err error) {
+	return linux.Tgkill(tgid, tid, sig)
 }

--- a/internal/unix/types_other.go
+++ b/internal/unix/types_other.go
@@ -15,6 +15,8 @@ const (
 	EAGAIN                   = syscall.EAGAIN
 	ENOSPC                   = syscall.ENOSPC
 	EINVAL                   = syscall.EINVAL
+	EINTR                    = syscall.EINTR
+	ESRCH                    = syscall.ESRCH
 	BPF_F_RDONLY_PROG        = 0
 	BPF_F_WRONLY_PROG        = 0
 	BPF_OBJ_NAME_LEN         = 0x10
@@ -191,5 +193,20 @@ type Utsname struct {
 
 // Uname is a wrapper
 func Uname(buf *Utsname) (err error) {
+	return errNonLinux
+}
+
+// Getpid is a wrapper
+func Getpid() int {
+	return -1
+}
+
+// Gettid is a wrapper
+func Gettid() int {
+	return -1
+}
+
+// Tgkill is a wrapper
+func Tgkill(tgid int, tid int, sig syscall.Signal) (err error) {
 	return errNonLinux
 }

--- a/prog.go
+++ b/prog.go
@@ -302,7 +302,7 @@ func (p *Program) Close() error {
 //
 // This function requires at least Linux 4.12.
 func (p *Program) Test(in []byte) (uint32, []byte, error) {
-	ret, out, _, err := p.testRun(in, 1)
+	ret, out, _, err := p.testRun(in, 1, nil)
 	if err != nil {
 		return ret, nil, xerrors.Errorf("can't test program: %w", err)
 	}
@@ -312,12 +312,16 @@ func (p *Program) Test(in []byte) (uint32, []byte, error) {
 // Benchmark runs the Program with the given input for a number of times
 // and returns the time taken per iteration.
 //
-// The returned value is the return value of the last execution of
-// the program.
+// Returns the result of the last execution of the program and the time per
+// run or an error. reset is called whenever the benchmark syscall is
+// interrupted, and should be set to testing.B.ResetTimer or similar.
+//
+// Note: profiling a call to this function will skew it's results, see
+// https://github.com/cilium/ebpf/issues/24
 //
 // This function requires at least Linux 4.12.
-func (p *Program) Benchmark(in []byte, repeat int) (uint32, time.Duration, error) {
-	ret, _, total, err := p.testRun(in, repeat)
+func (p *Program) Benchmark(in []byte, repeat int, reset func()) (uint32, time.Duration, error) {
+	ret, _, total, err := p.testRun(in, repeat, reset)
 	if err != nil {
 		return ret, total, xerrors.Errorf("can't benchmark program: %w", err)
 	}
@@ -359,7 +363,7 @@ var haveProgTestRun = internal.FeatureTest("BPF_PROG_TEST_RUN", "4.12", func() b
 	return !xerrors.Is(err, unix.EINVAL)
 })
 
-func (p *Program) testRun(in []byte, repeat int) (uint32, []byte, time.Duration, error) {
+func (p *Program) testRun(in []byte, repeat int, reset func()) (uint32, []byte, time.Duration, error) {
 	if uint(repeat) > math.MaxUint32 {
 		return 0, nil, 0, fmt.Errorf("repeat is too high")
 	}
@@ -397,8 +401,19 @@ func (p *Program) testRun(in []byte, repeat int) (uint32, []byte, time.Duration,
 		repeat:      uint32(repeat),
 	}
 
-	_, err = internal.BPF(_ProgTestRun, unsafe.Pointer(&attr), unsafe.Sizeof(attr))
-	if err != nil {
+	for {
+		_, err = internal.BPF(_ProgTestRun, unsafe.Pointer(&attr), unsafe.Sizeof(attr))
+		if err == nil {
+			break
+		}
+
+		if xerrors.Is(err, unix.EINTR) {
+			if reset != nil {
+				reset()
+			}
+			continue
+		}
+
 		return 0, nil, 0, xerrors.Errorf("can't run test: %w", err)
 	}
 


### PR DESCRIPTION
Testing a BPF program can be interrupted if a signal arrives for a
userspace thread while being stuck in the BPF syscall.
BPF_PROG_TEST_RUN returns EINTR in that case, and we are required
to retry.

This has an unfortunate side-effect: benchmark results will be
skewed, because we might have to do more work than was originally
asked of us. The per-run calculation performed by the Go test
harness are therefore unreliable. Document this until we get a
better idea how to fix this.

Updates #24