### PR TITLE
remove unused and duplicate code

### DIFF
--- a/internal/btf/ext_info.go
+++ b/internal/btf/ext_info.go
@@ -25,14 +25,12 @@ type btfExtHeader struct {
 }
 
 func parseExtInfos(r io.ReadSeeker, bo binary.ByteOrder, strings stringTable) (funcInfo, lineInfo map[string]extInfo, err error) {
-	const expectedMagic = 0xeB9F
-
 	var header btfExtHeader
 	if err := binary.Read(r, bo, &header); err != nil {
 		return nil, nil, xerrors.Errorf("can't read header: %v", err)
 	}
 
-	if header.Magic != expectedMagic {
+	if header.Magic != btfMagic {
 		return nil, nil, xerrors.Errorf("incorrect magic value %v", header.Magic)
 	}
 

--- a/types.go
+++ b/types.go
@@ -118,12 +118,6 @@ const (
 	_BTFGetNextID
 )
 
-const (
-	_Any = iota
-	_NoExist
-	_Exist
-)
-
 // ProgramType of the eBPF program
 type ProgramType uint32
 


### PR DESCRIPTION
Signed-off-by: Lehner Florian <dev@der-flo.net>

The last use of the constants was removed with commit aaa563ef6a5d4578ae252c89d230713a17b61dfe. And as there is `0xeB9F` already defined, it doesn't need to be defined twice.