### PR TITLE
run tests on current supported go versions

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -12,22 +12,39 @@ blocks:
       prologue:
         commands:
           - checkout
-          - sem-version go 1.13
-          - go build ./...
           - sudo pip3 install https://github.com/amluto/virtme/archive/538f1e756139a6b57a4780e7ceb3ac6bcaa4fe6f.zip
           - sudo apt-get install -y qemu-system-x86
       jobs:
       - name: Test building on other OS and arch
+        matrix:
+          - env_var: GO_VERSION
+            values: ["1.13.8", "1.14"]
         commands:
+          - sem-version $GO_VERSION
           - GOOS=darwin go build ./...
           - GOARCH=arm GOARM=6 go build ./...
           - GOARCH=arm64 go build ./...
       - name: Test on 5.4.5
+        matrix:
+          - env_var: GO_VERSION
+            values: ["1.13.8", "1.14"]
         commands:
+          - sem-version $GO_VERSION
+          - go build ./...
           - timeout -s KILL 90s ./run-tests.sh 5.4.5
       - name: Test on 4.19.81
+        matrix:
+          - env_var: GO_VERSION
+            values: ["1.13.8", "1.14"]
         commands:
+          - sem-version $GO_VERSION
+          - go build ./...
           - timeout -s KILL 90s ./run-tests.sh 4.19.81
       - name: Test on 4.9.198
+        matrix:
+          - env_var: GO_VERSION
+            values: ["1.13.8", "1.14"]
         commands:
+          - sem-version $GO_VERSION
+          - go build ./...
           - timeout -s KILL 90s ./run-tests.sh 4.9.198


### PR DESCRIPTION
Signed-off-by: Lehner Florian <dev@der-flo.net>

This PR runs the go tests on all upstream stable go versions. So far, there is no documentation, which describes the necessary go version for this repository - see https://github.com/cilium/ebpf/issues/37. Maybe, this PR can be an idea for a future discussion.