### PR TITLE
run tests on current supported go versions

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -24,10 +24,10 @@ blocks:
           - GOARCH=arm64 go build ./...
       - name: Test on 5.4.5
         commands:
-          - timeout -s KILL 90s ./run-tests.sh 5.4.5
+          - timeout -s KILL 180s ./run-tests.sh 5.4.5
       - name: Test on 4.19.81
         commands:
-          - timeout -s KILL 90s ./run-tests.sh 4.19.81
+          - timeout -s KILL 180s ./run-tests.sh 4.19.81
       - name: Test on 4.9.198
         commands:
-          - timeout -s KILL 90s ./run-tests.sh 4.9.198
+          - timeout -s KILL 180s ./run-tests.sh 4.9.198


### PR DESCRIPTION
Signed-off-by: Lehner Florian <dev@der-flo.net>

This PR runs the go tests on all upstream stable go versions. So far, there is no documentation, which describes the necessary go version for this repository - see issue https://github.com/cilium/ebpf/issues/37. Maybe, this PR can be an idea for a future discussion.