### PR TITLE
CI: run tests on Go 1.14 and 1.13 and document requirements

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -12,22 +12,25 @@ blocks:
       prologue:
         commands:
           - checkout
-          - sem-version go 1.13
+          - sem-version go 1.14
           - go build ./...
           - sudo pip3 install https://github.com/amluto/virtme/archive/538f1e756139a6b57a4780e7ceb3ac6bcaa4fe6f.zip
           - sudo apt-get install -y qemu-system-x86
+      env_vars:
+        - name: TMPDIR
+          value: /tmp
       jobs:
       - name: Test building on other OS and arch
         commands:
           - GOOS=darwin go build ./...
           - GOARCH=arm GOARM=6 go build ./...
           - GOARCH=arm64 go build ./...
-      - name: Test on 5.4.5
+      - name: Run unit tests
+        matrix:
+          - env_var: GO_VERSION
+            values: [ "1.13", "1.14" ]
+          - env_var: KERNEL_VERSION
+            values: ["5.4.5", "4.19.81", "4.9.198"]
         commands:
-          - timeout -s KILL 90s ./run-tests.sh 5.4.5
-      - name: Test on 4.19.81
-        commands:
-          - timeout -s KILL 90s ./run-tests.sh 4.19.81
-      - name: Test on 4.9.198
-        commands:
-          - timeout -s KILL 90s ./run-tests.sh 4.9.198
+          - sem-version go $GO_VERSION
+          - timeout -s KILL 90s ./run-tests.sh $KERNEL_VERSION

--- a/readme.md
+++ b/readme.md
@@ -13,6 +13,11 @@ The library is maintained by [Cloudflare](https://www.cloudflare.com) and [Ciliu
 The package is production ready, but **the API is explicitly unstable
 right now**. Expect to update your code if you want to follow along.
 
+## Requirements
+
+* A version of Go that is [supported by upstream](https://golang.org/doc/devel/release.html#policy)
+* Linux 4.9, 4.19 or 5.4 (versions in-between should work, but are not tested)
+
 ## Useful resources
 
 * [Cilium eBPF documentation](https://cilium.readthedocs.io/en/latest/bpf/#bpf-guide) (recommended)

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -40,14 +40,14 @@ fi
 
 readonly kernel="linux-${kernel_version}.bz"
 readonly output="$(mktemp -d)"
-readonly tmp_dir="$(mktemp -d)"
+readonly tmp_dir="${TMPDIR:-$(mktemp -d)}"
 
 test -e "${tmp_dir}/${kernel}" || {
-  echo Fetching ${kernel}
+  echo Fetching "${kernel}"
   curl --fail -L "https://github.com/newtools/ci-kernels/blob/master/${kernel}?raw=true" -o "${tmp_dir}/${kernel}"
 }
 
-echo Testing on ${kernel_version}
+echo Testing on "${kernel_version}"
 $sudo virtme-run --kimg "${tmp_dir}/${kernel}" --memory 512M --pwd \
   --rwdir=/run/output="${output}" \
   --rodir=/run/go-path="$(go env GOPATH)" \


### PR DESCRIPTION
Run tests for each combination of supported Go and kernel version,
and document explicitly supported versions in the readme.

Fixes #37