### PR TITLE
perf: fix breaking error for creating over perf ring from a loaded pr…

### DIFF
--- a/perf/reader.go
+++ b/perf/reader.go
@@ -198,6 +198,15 @@ func NewReaderWithOptions(array *ebpf.Map, perCPUBuffer int, opts ReaderOptions)
 		pauseFds = make([]int, 0, nCPU)
 	)
 
+	onlineCPU, err := internal.OnlineCPUs()
+	if err != nil {
+		return nil, xerrors.Errorf("perf event array: %w", err)
+	}
+
+	if nCPU > onlineCPU {
+		nCPU = onlineCPU
+	}
+
 	defer func() {
 		if err != nil {
 			for _, fd := range fds {


### PR DESCRIPTION
Keep same behavior with libbpf.

The ABI `max_entries` of  in **BPF_MAP_TYPE_PERF_EVENT_ARRAY** elf is more like a guidance than an exact value.

I'm glad someone reviewed the code for me.