### PR TITLE
Don't ignore kernelVersion

### DIFF
--- a/prog.go
+++ b/prog.go
@@ -202,6 +202,7 @@ func convertProgramSpec(spec *ProgramSpec, handle *btf.Handle) (*bpfProgLoadAttr
 		insCount:           insCount,
 		instructions:       internal.NewSlicePointer(bytecode),
 		license:            internal.NewStringPointer(spec.License),
+		kernelVersion:      spec.KernelVersion,
 	}
 
 	if haveObjName() == nil {

--- a/prog_test.go
+++ b/prog_test.go
@@ -224,6 +224,23 @@ func TestProgramVerifierOutputOnError(t *testing.T) {
 	}
 }
 
+func TestProgramKernelVersion(t *testing.T) {
+	testutils.SkipOnOldKernel(t, "4.20", "KernelVersion")
+	prog, err := NewProgram(&ProgramSpec{
+		Type: Kprobe,
+		Instructions: asm.Instructions{
+			asm.LoadImm(asm.R0, 0, asm.DWord),
+			asm.Return(),
+		},
+		KernelVersion: 42,
+		License:       "MIT",
+	})
+	if err != nil {
+		t.Fatal("Could not load Kprobe program")
+	}
+	defer prog.Close()
+}
+
 func TestProgramVerifierOutput(t *testing.T) {
 	prog, err := NewProgramWithOptions(socketFilterSpec, ProgramOptions{
 		LogLevel: 2,


### PR DESCRIPTION
Signed-off-by: Lehner Florian <dev@der-flo.net>

If specified in `ProgramSpec` so far `kenelVersion` was just ignored. This attribute is around since 4.1  [2541517c32be](https://github.com/torvalds/linux/commit/2541517c32be). 