### PR TITLE
Use number of possible CPUs for PerfEventArray.MaxEntries

### DIFF
--- a/internal/cpu.go
+++ b/internal/cpu.go
@@ -2,10 +2,9 @@ package internal
 
 import (
 	"fmt"
-	"os"
+	"io/ioutil"
+	"strings"
 	"sync"
-
-	"golang.org/x/xerrors"
 )
 
 var sysCPU struct {
@@ -18,45 +17,44 @@ var sysCPU struct {
 // Logical CPU numbers must be of the form 0-n
 func PossibleCPUs() (int, error) {
 	sysCPU.once.Do(func() {
-		sysCPU.num, sysCPU.err = parseCPUs("/sys/devices/system/cpu/possible")
+		sysCPU.num, sysCPU.err = parseCPUsFromFile("/sys/devices/system/cpu/possible")
 	})
 
 	return sysCPU.num, sysCPU.err
 }
 
-var onlineCPU struct {
-	once sync.Once
-	err  error
-	num  int
-}
-
-// OnlineCPUs returns the number of currently online CPUs
-// Logical CPU numbers must be of the form 0-n
-func OnlineCPUs() (int, error) {
-	onlineCPU.once.Do(func() {
-		onlineCPU.num, onlineCPU.err = parseCPUs("/sys/devices/system/cpu/online")
-	})
-
-	return onlineCPU.num, onlineCPU.err
-}
-
-// parseCPUs parses the number of cpus from sysfs,
-// in the format of "/sys/devices/system/cpu/{possible,online,..}.
-// Logical CPU numbers must be of the form 0-n
-func parseCPUs(path string) (int, error) {
-	file, err := os.Open(path)
+func parseCPUsFromFile(path string) (int, error) {
+	spec, err := ioutil.ReadFile(path)
 	if err != nil {
 		return 0, err
 	}
-	defer file.Close()
+
+	n, err := parseCPUs(string(spec))
+	if err != nil {
+		return 0, fmt.Errorf("can't parse %s: %v", path, err)
+	}
+
+	return n, nil
+}
+
+// parseCPUs parses the number of cpus from a string produced
+// by bitmap_list_string() in the Linux kernel.
+// Multiple ranges are rejected, since they can't be unified
+// into a single number.
+// This is the format of /sys/devices/system/cpu/possible, it
+// is not suitable for /sys/devices/system/cpu/online, etc.
+func parseCPUs(spec string) (int, error) {
+	if strings.Trim(spec, "\n") == "0" {
+		return 1, nil
+	}
 
 	var low, high int
-	n, _ := fmt.Fscanf(file, "%d-%d", &low, &high)
-	if n < 1 || low != 0 {
-		return 0, xerrors.Errorf("%s has unknown format: %v", path, err)
+	n, err := fmt.Sscanf(spec, "%d-%d\n", &low, &high)
+	if n != 2 || err != nil {
+		return 0, fmt.Errorf("invalid format: %s", spec)
 	}
-	if n == 1 {
-		high = low
+	if low != 0 {
+		return 0, fmt.Errorf("CPU spec doesn't start at zero: %s", spec)
 	}
 
 	// cpus is 0 indexed

--- a/internal/cpu_test.go
+++ b/internal/cpu_test.go
@@ -1,31 +1,32 @@
 package internal
 
 import (
-	"io"
-	"io/ioutil"
 	"testing"
 )
 
 func TestParseCPUs(t *testing.T) {
 	for str, result := range map[string]int{
-		"0-1": 2,
-		"0":   1,
+		"0-1":   2,
+		"0-2\n": 3,
+		"0":     1,
 	} {
-		fh, err := ioutil.TempFile("", "ebpf")
+		n, err := parseCPUs(str)
 		if err != nil {
-			t.Fatal(err)
-		}
-
-		if _, err := io.WriteString(fh, str); err != nil {
-			t.Fatal(err)
-		}
-		fh.Close()
-
-		n, err := parseCPUs(fh.Name())
-		if err != nil {
-			t.Error("Can't parse", str, err)
+			t.Errorf("Can't parse `%s`: %v", str, err)
 		} else if n != result {
 			t.Error("Parsing", str, "returns", n, "instead of", result)
+		}
+	}
+
+	for _, str := range []string{
+		"0,3-4",
+		"0-",
+		"1,",
+		"",
+	} {
+		_, err := parseCPUs(str)
+		if err == nil {
+			t.Error("Parsed invalid format:", str)
 		}
 	}
 }

--- a/internal/unix/types_linux.go
+++ b/internal/unix/types_linux.go
@@ -16,6 +16,7 @@ const (
 	EPOLLIN                  = linux.EPOLLIN
 	EINTR                    = linux.EINTR
 	ESRCH                    = linux.ESRCH
+	ENODEV                   = linux.ENODEV
 	BPF_F_RDONLY_PROG        = linux.BPF_F_RDONLY_PROG
 	BPF_F_WRONLY_PROG        = linux.BPF_F_WRONLY_PROG
 	BPF_OBJ_NAME_LEN         = linux.BPF_OBJ_NAME_LEN

--- a/internal/unix/types_other.go
+++ b/internal/unix/types_other.go
@@ -17,6 +17,7 @@ const (
 	EINVAL                   = syscall.EINVAL
 	EINTR                    = syscall.EINTR
 	ESRCH                    = syscall.ESRCH
+	ENODEV                   = syscall.ENODEV
 	BPF_F_RDONLY_PROG        = 0
 	BPF_F_WRONLY_PROG        = 0
 	BPF_OBJ_NAME_LEN         = 0x10

--- a/map.go
+++ b/map.go
@@ -166,7 +166,7 @@ func createMap(spec *MapSpec, inner *internal.FD, handle *btf.Handle) (*Map, err
 		abi.ValueSize = 4
 
 		if abi.MaxEntries == 0 {
-			n, err := internal.OnlineCPUs()
+			n, err := internal.PossibleCPUs()
 			if err != nil {
 				return nil, xerrors.Errorf("perf event array: %w", err)
 			}

--- a/perf/ring.go
+++ b/perf/ring.go
@@ -34,7 +34,7 @@ func newPerfEventRing(cpu, perCPUBuffer, watermark int) (*perfEventRing, error) 
 
 	fd, err := createPerfEvent(cpu, watermark)
 	if err != nil {
-		return nil, xerrors.Errorf("can't create perf event: %w", err)
+		return nil, err
 	}
 
 	if err := unix.SetNonblock(fd, true); err != nil {
@@ -90,7 +90,7 @@ func createPerfEvent(cpu, watermark int) (int, error) {
 	attr.Size = uint32(unsafe.Sizeof(attr))
 	fd, err := unix.PerfEventOpen(&attr, -1, cpu, -1, unix.PERF_FLAG_FD_CLOEXEC)
 	if err != nil {
-		return -1, xerrors.Errorf("can't create perf event: %v", err)
+		return -1, xerrors.Errorf("can't create perf event: %w", err)
 	}
 	return fd, nil
 }


### PR DESCRIPTION
Based on discussion in #58 and prompted by @iAklis and his PRs #78 and #80.

This fixes the behaviour on systems that have one or more CPUs disabled. Previously things would only work if the disabled CPUs were on the end of the range.

It's still not possible to use PerfEventArrays that have more than the total number of CPUs in the system (as suggested by @iAklis), since I'm not sure that's a good idea to do. We also don't deal with CPUs being added or removed after a perf.Reader has been created.

More details in the commit descriptions.