### PR TITLE
Fix test build on non-linux

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -22,9 +22,9 @@ blocks:
       jobs:
       - name: Test building on other OS and arch
         commands:
-          - GOOS=darwin go build ./...
-          - GOARCH=arm GOARM=6 go build ./...
-          - GOARCH=arm64 go build ./...
+          - GOOS=darwin go build ./... && for p in $(go list ./...) ; do GOOS=darwin go test -c $p ; done
+          - GOARCH=arm GOARM=6 go build ./... && for p in $(go list ./...) ; do GOARCH=arm GOARM=6 go test -c $p ; done
+          - GOARCH=arm64 go build ./... && for p in $(go list ./...) ; do GOARCH=arm64 go test -c $p ; done
       - name: Run unit tests
         matrix:
           - env_var: GO_VERSION

--- a/internal/unix/types_other.go
+++ b/internal/unix/types_other.go
@@ -37,6 +37,7 @@ const (
 	PerfBitWatermark         = 0x4000
 	PERF_SAMPLE_RAW          = 0x400
 	PERF_FLAG_FD_CLOEXEC     = 0x8
+	RLIM_INFINITY            = 0x7fffffffffffffff
 )
 
 // Statfs_t is a wrapper

--- a/prog_test.go
+++ b/prog_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/cilium/ebpf/asm"
 	"github.com/cilium/ebpf/internal"
 	"github.com/cilium/ebpf/internal/testutils"
-	"golang.org/x/sys/unix"
+	"github.com/cilium/ebpf/internal/unix"
 	"golang.org/x/xerrors"
 )
 


### PR DESCRIPTION
Use wrappers from github.com/cilium/ebpf/internal/unix to avoid the
following build error when building the tests on non-linux:

```
./prog_test.go:131:14: undefined: "golang.org/x/sys/unix".Gettid
./prog_test.go:148:10: undefined: "golang.org/x/sys/unix".Tgkill
```

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>