### PR TITLE
perf: Fix mmap buffer size calculation

### DIFF
--- a/perf/ring.go
+++ b/perf/ring.go
@@ -2,6 +2,7 @@ package perf
 
 import (
 	"io"
+	"math"
 	"os"
 	"runtime"
 	"sync/atomic"
@@ -26,12 +27,6 @@ func newPerfEventRing(cpu, perCPUBuffer, watermark int) (*perfEventRing, error) 
 		return nil, xerrors.New("watermark must be smaller than perCPUBuffer")
 	}
 
-	// Round to nearest page boundary and allocate
-	// an extra page for meta data
-	pageSize := os.Getpagesize()
-	nPages := (perCPUBuffer + pageSize - 1) / pageSize
-	size := (1 + nPages) * pageSize
-
 	fd, err := createPerfEvent(cpu, watermark)
 	if err != nil {
 		return nil, err
@@ -42,10 +37,10 @@ func newPerfEventRing(cpu, perCPUBuffer, watermark int) (*perfEventRing, error) 
 		return nil, err
 	}
 
-	mmap, err := unix.Mmap(fd, 0, size, unix.PROT_READ|unix.PROT_WRITE, unix.MAP_SHARED)
+	mmap, err := unix.Mmap(fd, 0, perfBufferSize(perCPUBuffer), unix.PROT_READ|unix.PROT_WRITE, unix.MAP_SHARED)
 	if err != nil {
 		unix.Close(fd)
-		return nil, err
+		return nil, xerrors.Errorf("can't mmap: %v", err)
 	}
 
 	// This relies on the fact that we allocate an extra metadata page,
@@ -63,6 +58,22 @@ func newPerfEventRing(cpu, perCPUBuffer, watermark int) (*perfEventRing, error) 
 	runtime.SetFinalizer(ring, (*perfEventRing).Close)
 
 	return ring, nil
+}
+
+// mmapBufferSize returns a valid mmap buffer size for use with perf_event_open (1+2^n pages)
+func perfBufferSize(perCPUBuffer int) int {
+	pageSize := os.Getpagesize()
+
+	// Smallest whole number of pages
+	nPages := (perCPUBuffer + pageSize - 1) / pageSize
+
+	// Round up to nearest power of two number of pages
+	nPages = int(math.Pow(2, math.Ceil(math.Log2(float64(nPages)))))
+
+	// Add one for metadata
+	nPages += 1
+
+	return nPages * pageSize
 }
 
 func (ring *perfEventRing) Close() {

--- a/perf/ring_test.go
+++ b/perf/ring_test.go
@@ -3,6 +3,7 @@ package perf
 import (
 	"bytes"
 	"io"
+	"os"
 	"testing"
 
 	"github.com/cilium/ebpf/internal/unix"
@@ -61,4 +62,47 @@ func makeRing(size, offset int) *ringReader {
 	}
 
 	return newRingReader(&meta, ring)
+}
+
+func TestPerfEventRing(t *testing.T) {
+	check := func(buffer, watermark int) {
+		ring, err := newPerfEventRing(0, buffer, watermark)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		size := len(ring.ringReader.ring)
+
+		// Ring size should be at least as big as buffer
+		if size < buffer {
+			t.Fatalf("ring size %d smaller than buffer %d", size, buffer)
+		}
+
+		// Ring size should be of the form 2^n pages (meta page has already been removed)
+		if size%os.Getpagesize() != 0 {
+			t.Fatalf("ring size %d not whole number of pages (pageSize %d)", size, os.Getpagesize())
+		}
+		nPages := size / os.Getpagesize()
+		if nPages&(nPages-1) != 0 {
+			t.Fatalf("ring size %d (%d pages) not a power of two pages (pageSize %d)", size, nPages, os.Getpagesize())
+		}
+	}
+
+	// watermark > buffer
+	_, err := newPerfEventRing(0, 8192, 8193)
+	if err == nil {
+		t.Fatal("watermark > buffer allowed")
+	}
+
+	// watermark == buffer
+	_, err = newPerfEventRing(0, 8192, 8192)
+	if err == nil {
+		t.Fatal("watermark == buffer allowed")
+	}
+
+	// buffer not a power of two, watermark < buffer
+	check(8193, 8192)
+
+	// large buffer not a multiple of page size at all (prime)
+	check(65537, 8192)
 }


### PR DESCRIPTION
The mmap buffer is sized in bytes, but needs to be page aligned.
This was correctly derived.

Additionally, with perf_event_open, according to man 2 perf_event_open:

> The mmap size should be 1+2^n pages

This wasn't correctly enforced, and caused the mmap call to fail with
EINVAL for some buffer sizes. For example 8193 bytes would be
incorrectly rounded to 3 pages instead of 4.
Always round up to the nearest power of two number of pages, and add
some tests.

Also allow `watermark == buffer` as this as a source of confusion, 
see https://github.com/cloudflare/xdpcap/issues/39#issuecomment-616382309
