### PR TITLE
Use RLIMIT_MEMLOCK and RLIM_INFINITY consts from x/sys/unix

### DIFF
--- a/internal/unix/types_linux.go
+++ b/internal/unix/types_linux.go
@@ -36,6 +36,7 @@ const (
 	PERF_SAMPLE_RAW          = linux.PERF_SAMPLE_RAW
 	PERF_FLAG_FD_CLOEXEC     = linux.PERF_FLAG_FD_CLOEXEC
 	RLIM_INFINITY            = linux.RLIM_INFINITY
+	RLIMIT_MEMLOCK           = linux.RLIMIT_MEMLOCK
 )
 
 // Statfs_t is a wrapper

--- a/internal/unix/types_other.go
+++ b/internal/unix/types_other.go
@@ -38,6 +38,7 @@ const (
 	PERF_SAMPLE_RAW          = 0x400
 	PERF_FLAG_FD_CLOEXEC     = 0x8
 	RLIM_INFINITY            = 0x7fffffffffffffff
+	RLIMIT_MEMLOCK           = 8
 )
 
 // Statfs_t is a wrapper

--- a/map_test.go
+++ b/map_test.go
@@ -19,9 +19,9 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	err := unix.Setrlimit(8, &unix.Rlimit{
-		Cur: math.MaxUint64,
-		Max: math.MaxUint64,
+	err := unix.Setrlimit(unix.RLIMIT_MEMLOCK, &unix.Rlimit{
+		Cur: unix.RLIM_INFINITY,
+		Max: unix.RLIM_INFINITY,
 	})
 	if err != nil {
 		fmt.Println("WARNING: Failed to adjust rlimit, tests may fail")


### PR DESCRIPTION
Signed-off-by: Tobias Klauser <tklauser@distanz.ch>