### PR TITLE
The newtools ci-kernels project is running into LFS bandwidth

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -44,7 +44,7 @@ readonly tmp_dir="${TMPDIR:-$(mktemp -d)}"
 
 test -e "${tmp_dir}/${kernel}" || {
   echo Fetching "${kernel}"
-  curl --fail -L "https://github.com/newtools/ci-kernels/blob/master/${kernel}?raw=true" -o "${tmp_dir}/${kernel}"
+  curl --fail -L "https://github.com/cilium/ci-kernels/blob/master/${kernel}?raw=true" -o "${tmp_dir}/${kernel}"
 }
 
 echo Testing on "${kernel_version}"


### PR DESCRIPTION
limits, because it is not on a paid account. This retrieves the
kernels from cilium, rather than newtools, so the bandwidth
limit is not hit.

Signed-off-by: Nate Sweet <nathanjsweet@pm.me>