### PR TITLE
elf: fix libbpf integration tests

### DIFF
--- a/elf_reader_test.go
+++ b/elf_reader_test.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/cilium/ebpf/internal/testutils"
@@ -233,9 +234,14 @@ func TestLibBPFCompat(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	for _, file := range files {
+	for _, f := range files {
+		file := f // force copy
 		name := filepath.Base(file)
 		t.Run(name, func(t *testing.T) {
+			if strings.Contains(name, "_core_") {
+				t.Skip("CO-RE is not implemented")
+			}
+
 			t.Parallel()
 
 			spec, err := LoadCollectionSpec(file)


### PR DESCRIPTION
The integration tests are currently broken. When running them in parallel,
the file variable is captured by the closure in t.Run, and so we only
ever try to load a single file.

Fix this by taking an explicit copy of the filename, and by turning off
parallel tests. This is turn makes the tests fail, since there is plenty
of libbpf stuff that we don't understand.

Related to #92