### PR TITLE
Friendly map create errors, document rlimit and perf ring garbage

### DIFF
--- a/elf_reader.go
+++ b/elf_reader.go
@@ -524,7 +524,7 @@ func uintFromBTF(typ btf.Type) (uint32, error) {
 
 func (ec *elfCode) loadDataSections(maps map[string]*MapSpec, dataSections map[elf.SectionIndex]*elf.Section, spec *btf.Spec) error {
 	if spec == nil {
-		return xerrors.New("data sections require BTF")
+		return xerrors.New("data sections require BTF, make sure all consts are marked as static")
 	}
 
 	for _, sec := range dataSections {

--- a/map.go
+++ b/map.go
@@ -107,6 +107,10 @@ func NewMapFromFD(fd int) (*Map, error) {
 //
 // Creating a map for the first time will perform feature detection
 // by creating small, temporary maps.
+//
+// The caller is responsible for ensuring the process' rlimit is set
+// sufficiently high for locking memory during map creation. This can be done
+// by calling unix.Setrlimit with unix.RLIMIT_MEMLOCK prior to calling NewMap.
 func NewMap(spec *MapSpec) (*Map, error) {
 	if spec.BTF == nil {
 		return newMapWithBTF(spec, nil)

--- a/perf/reader_test.go
+++ b/perf/reader_test.go
@@ -21,7 +21,7 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	err := unix.Setrlimit(8, &unix.Rlimit{
+	err := unix.Setrlimit(unix.RLIMIT_MEMLOCK, &unix.Rlimit{
 		Cur: unix.RLIM_INFINITY,
 		Max: unix.RLIM_INFINITY,
 	})

--- a/syscalls.go
+++ b/syscalls.go
@@ -1,6 +1,7 @@
 package ebpf
 
 import (
+	"os"
 	"path/filepath"
 	"unsafe"
 
@@ -13,7 +14,7 @@ import (
 
 // Generic errors returned by BPF syscalls.
 var (
-	ErrNotExist = xerrors.New("requested object does not exit")
+	ErrNotExist = xerrors.New("requested object does not exist")
 )
 
 // bpfObjName is a null-terminated string made up of
@@ -185,6 +186,10 @@ func bpfProgAlter(cmd int, attr *bpfProgAlterAttr) error {
 
 func bpfMapCreate(attr *bpfMapCreateAttr) (*internal.FD, error) {
 	fd, err := internal.BPF(_MapCreate, unsafe.Pointer(attr), unsafe.Sizeof(*attr))
+	if xerrors.Is(err, os.ErrPermission) {
+		return nil, xerrors.New("permission denied or insufficient rlimit to lock memory for map")
+	}
+
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Hi all,

While migrating a project off of gobpf, I encountered some issues loading an ELF binary, most of which have been addressed below. There's another part that deals with overwriting the binary's `version` section with the running kernel's `LINUX_VERSION_CODE`, but that I'd like to address in another PR.

The removal of BTF requirements in data sections and the rlimit changes might need some extra test coverage, but please let me know what you think before I get started on that.

I've added a bit more detailed info about the perf event buffer underrun in [the commit that introduced it](https://github.com/ti-mo/ebpf/commit/2cc7e4625e0baab30bfd8be9d5a5c4e6d8012dd2):
> https://elixir.bootlin.com/linux/v5.5.13/source/kernel/events/core.c#L6611 raw->size is used to size the buffer, but frag->size is used to fill it.

> https://elixir.bootlin.com/linux/v5.5.13/source/kernel/events/core.c#L6827
> While preparing the sample output, raw->size is set to the sum of all
> fragments' sizes minus 4 bytes. However, header->size doesn't include this
> 4-byte deduction.

I think I might've stumbled across a kernel bug, but looking at bcc and gobpf, it seems like many userspace libraries already depend on that behaviour by now and discard those bytes by default. Raw perf events are 64-bit aligned, but the test case wasn't.