### PR TITLE
Simplify attaching to raw tracepoints

### DIFF
--- a/prog.go
+++ b/prog.go
@@ -494,6 +494,23 @@ func (p *Program) Detach(fd int, typ AttachType, flags AttachFlags) error {
 	return bpfProgAlter(_ProgDetach, &attr)
 }
 
+// Attach a Program to raw tracepoint.
+//
+// Requires at least Linux 4.17.
+func (p *Program) AttachRawTracepoint(tpName string) error {
+	fd, err := p.fd.Value()
+	if err != nil {
+		return xerrors.Errorf("failed to get program FD: %w", err)
+	}
+
+	attr := bpfRawTracepointOpenAttr{
+		name: internal.NewStringPointer(tpName),
+		fd:   fd,
+	}
+
+	return bpfRawTracepointOpen(&attr)
+}
+
 // LoadPinnedProgram loads a Program from a BPF file.
 //
 // Requires at least Linux 4.11.

--- a/prog_test.go
+++ b/prog_test.go
@@ -425,6 +425,29 @@ func TestProgramAlter(t *testing.T) {
 	}
 }
 
+func TestProgramAttachRawTracepoint(t *testing.T) {
+	testutils.SkipOnOldKernel(t, "4.17", "BPF_RAW_TRACEPOINT Api")
+
+	var err error
+	var prog *Program
+	prog, err = NewProgram(&ProgramSpec{
+		Type: RawTracepoint,
+		Instructions: asm.Instructions{
+			asm.LoadImm(asm.R0, 0, asm.DWord),
+			asm.Return(),
+		},
+		License: "MIT",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer prog.Close()
+
+	if err := prog.AttachRawTracepoint("cgroup_mkdir"); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestHaveProgTestRun(t *testing.T) {
 	testutils.CheckFeatureTest(t, haveProgTestRun)
 }

--- a/syscalls.go
+++ b/syscalls.go
@@ -140,6 +140,11 @@ type bpfProgAlterAttr struct {
 	attachFlags uint32
 }
 
+type bpfRawTracepointOpenAttr struct {
+	name internal.Pointer
+	fd   uint32
+}
+
 type bpfObjGetInfoByFDAttr struct {
 	fd      uint32
 	infoLen uint32
@@ -180,6 +185,11 @@ func bpfProgLoad(attr *bpfProgLoadAttr) (*internal.FD, error) {
 
 func bpfProgAlter(cmd int, attr *bpfProgAlterAttr) error {
 	_, err := internal.BPF(cmd, unsafe.Pointer(attr), unsafe.Sizeof(*attr))
+	return err
+}
+
+func bpfRawTracepointOpen(attr *bpfRawTracepointOpenAttr) error {
+	_, err := internal.BPF(_RawTracepointOpen, unsafe.Pointer(attr), unsafe.Sizeof(*attr))
 	return err
 }
 


### PR DESCRIPTION
First of al,l thanks for the great project! :+1: 

I use `github.com/cilium/ebpf` to monitor various system events through raw tracepoints. This PR helps to use it (not needed to copy-paste BPF syscall wrapper and other).