### PR TITLE
Expose EEXIST

### DIFF
--- a/internal/unix/types_linux.go
+++ b/internal/unix/types_linux.go
@@ -10,6 +10,7 @@ import (
 
 const (
 	ENOENT                   = linux.ENOENT
+	EEXIST                   = linux.EEXIST
 	EAGAIN                   = linux.EAGAIN
 	ENOSPC                   = linux.ENOSPC
 	EINVAL                   = linux.EINVAL

--- a/internal/unix/types_other.go
+++ b/internal/unix/types_other.go
@@ -12,6 +12,7 @@ var errNonLinux = fmt.Errorf("unsupported platform %s/%s", runtime.GOOS, runtime
 
 const (
 	ENOENT                   = syscall.ENOENT
+	EEXIST                   = syscall.EEXIST
 	EAGAIN                   = syscall.EAGAIN
 	ENOSPC                   = syscall.ENOSPC
 	EINVAL                   = syscall.EINVAL

--- a/map.go
+++ b/map.go
@@ -14,6 +14,7 @@ import (
 // Errors returned by Map and MapIterator methods.
 var (
 	ErrKeyNotExist      = xerrors.New("key does not exist")
+	ErrKeyExist         = xerrors.New("key does exist")
 	ErrIterationAborted = xerrors.New("iteration aborted")
 )
 

--- a/map.go
+++ b/map.go
@@ -14,7 +14,7 @@ import (
 // Errors returned by Map and MapIterator methods.
 var (
 	ErrKeyNotExist      = xerrors.New("key does not exist")
-	ErrKeyExist         = xerrors.New("key does exist")
+	ErrKeyExist         = xerrors.New("key already exists")
 	ErrIterationAborted = xerrors.New("iteration aborted")
 )
 

--- a/map_test.go
+++ b/map_test.go
@@ -456,6 +456,19 @@ func TestNotExist(t *testing.T) {
 	}
 }
 
+func TestExist(t *testing.T) {
+	hash := createHash()
+	defer hash.Close()
+
+	if err := hash.Put("hello", uint32(21)); err != nil {
+		t.Errorf("Failed to put key/value pair into hash: %v", err)
+	}
+
+	if err := hash.Update("hello", uint32(42), UpdateNoExist); !xerrors.Is(err, ErrKeyExist) {
+		t.Error("Updating existing key doesn't return ErrKeyExist")
+	}
+}
+
 func TestIterateMapInMap(t *testing.T) {
 	const idx = uint32(1)
 

--- a/syscalls.go
+++ b/syscalls.go
@@ -340,6 +340,10 @@ func wrapMapError(err error) error {
 		return ErrKeyNotExist
 	}
 
+	if xerrors.Is(err, unix.EEXIST) {
+		return ErrKeyExist
+	}
+
 	return xerrors.New(err.Error())
 }
 


### PR DESCRIPTION
Signed-off-by: Lehner Florian <dev@der-flo.net>

If you update a hash map with the flag `UpdateNoExist` you expect an error if the key already exists. This PR exposes this error and let the user of the package handle it properly.