### PR TITLE
asm: support printing unsupported opcode

### DIFF
--- a/asm/opcode.go
+++ b/asm/opcode.go
@@ -225,7 +225,7 @@ func (op OpCode) String() string {
 		}
 
 	default:
-		fmt.Fprintf(&f, "%#x", op)
+		fmt.Fprintf(&f, "OpCode(%#x)", uint8(op))
 	}
 
 	return f.String()


### PR DESCRIPTION
For example:
```
var ins asm.Instruction
ins.OpCode = 6
fmt.Printf("%v\n", ins)
// Result: OpCode(0x6)
```

Previously this causes a stack overflow error.