### PR TITLE
hasPerCPUValue function add MapType LRUCPUHash

### DIFF
--- a/types.go
+++ b/types.go
@@ -85,7 +85,7 @@ const (
 
 // hasPerCPUValue returns true if the Map stores a value per CPU.
 func (mt MapType) hasPerCPUValue() bool {
-	if mt == PerCPUHash || mt == PerCPUArray {
+	if mt == PerCPUHash || mt == PerCPUArray || mt == LRUCPUHash {
 		return true
 	}
 	return false


### PR DESCRIPTION
Hi lmb,
I have added a test for LRUCPUHash, LRUCPUHash is PerCPU map that store a distinct value for each CPU, so from userspace we need to see it in the form of an array