### PR TITLE
Fixed marshalBytes length check.

### DIFF
--- a/marshalers.go
+++ b/marshalers.go
@@ -55,7 +55,7 @@ func marshalBytes(data interface{}, length int) (buf []byte, err error) {
 		return nil, err
 	}
 
-	if len(buf) != length {
+	if int(reflect.TypeOf(data).Size()) != length && len(buf) != length {
 		return nil, xerrors.Errorf("%T doesn't marshal to %d bytes", data, length)
 	}
 	return buf, nil


### PR DESCRIPTION
## Why
When I passed the structure to RewriteConstants, it said the following
```
marshal hoge.consts: hoge.Constants doesn't marshal to 28 bytes
```

You don't appear to have taken alignment into account.

case example.
* buffsize(cons) == sizeof(cons): https://play.golang.org/p/5-na-qFSF9R
* buffsize(cons) != sizeof(cons): https://play.golang.org/p/7pvZxwJZrOP

## What
Alignment considerations and check for errors fix.

Thank you :)