### PR TITLE
doc: mention the link package in documentation

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -12,6 +12,5 @@
 // eBPF code should be compiled ahead of time using clang, and shipped with
 // your application as any other resource.
 //
-// This package doesn't include code required to attach eBPF to Linux
-// subsystems, since this varies per subsystem.
+// Use the link subpackage to attach a loaded program to a hook in the kernel.
 package ebpf

--- a/link/doc.go
+++ b/link/doc.go
@@ -1,0 +1,2 @@
+// Package link allows attaching eBPF programs to various kernel hooks.
+package link

--- a/readme.md
+++ b/readme.md
@@ -1,10 +1,11 @@
 eBPF
 -------
-[![](https://godoc.org/github.com/cilium/ebpf?status.svg)](https://godoc.org/github.com/cilium/ebpf)
+[![PkgGoDev](https://pkg.go.dev/badge/github.com/cilium/ebpf)](https://pkg.go.dev/github.com/cilium/ebpf)
 
 eBPF is a pure Go library that provides utilities for loading, compiling, and debugging eBPF programs. It has minimal external dependencies and is intended to be used in long running processes.
 
-[ebpf/asm](https://godoc.org/github.com/cilium/ebpf/asm) contains a basic assembler.
+* [ebpf/link](https://pkg.go.dev/github.com/cilium/ebpf/link) allows attaching eBPF to various hooks.
+* [ebpf/asm](https://pkg.go.dev/github.com/cilium/ebpf/asm) contains a basic assembler.
 
 The library is maintained by [Cloudflare](https://www.cloudflare.com) and [Cilium](https://www.cilium.io). Feel free to [join](https://cilium.herokuapp.com/) the [libbpf-go](https://cilium.slack.com/messages/libbpf-go) channel on Slack.
 


### PR DESCRIPTION
We now have support for attaching to some subsystems, so update
the documentation accordingly.