### PR TITLE
Support raw_tracepoint link update

### DIFF
--- a/link/raw_tracepoint_test.go
+++ b/link/raw_tracepoint_test.go
@@ -11,18 +11,7 @@ import (
 func TestRawTracepoint(t *testing.T) {
 	testutils.SkipOnOldKernel(t, "4.17", "BPF_RAW_TRACEPOINT API")
 
-	prog, err := ebpf.NewProgram(&ebpf.ProgramSpec{
-		Type:       ebpf.RawTracepoint,
-		AttachType: ebpf.AttachNone,
-		Instructions: asm.Instructions{
-			asm.LoadImm(asm.R0, 0, asm.DWord),
-			asm.Return(),
-		},
-		License: "GPL",
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	prog := mustRawTracepointProgram(t, ebpf.RawTracepoint)
 	defer prog.Close()
 
 	link, err := AttachRawTracepoint(RawTracepointOptions{
@@ -30,23 +19,44 @@ func TestRawTracepoint(t *testing.T) {
 		Program: prog,
 	})
 	if err != nil {
-		t.Fatal(err)
+		t.Fatal("Can't create link:", err)
 	}
 
-	if link == nil {
-		t.Fatal("no link")
-	}
+	prog2 := mustRawTracepointProgram(t, ebpf.RawTracepoint)
+	defer prog2.Close()
 
-	if err := link.Close(); err != nil {
-		t.Fatalf("failed to close link: %v", err)
-	}
+	testLink(t, link, testLinkOptions{
+		prog: prog2,
+	})
 }
 
 func TestRawTracepoint_writable(t *testing.T) {
 	testutils.SkipOnOldKernel(t, "5.2", "BPF_RAW_TRACEPOINT_WRITABLE API")
 
+	prog := mustRawTracepointProgram(t, ebpf.RawTracepointWritable)
+	defer prog.Close()
+
+	link, err := AttachRawTracepoint(RawTracepointOptions{
+		Name:    "cgroup_rmdir",
+		Program: prog,
+	})
+	if err != nil {
+		t.Fatal("Can't create link:", err)
+	}
+
+	prog2 := mustRawTracepointProgram(t, ebpf.RawTracepointWritable)
+	defer prog2.Close()
+
+	testLink(t, link, testLinkOptions{
+		prog: prog2,
+	})
+}
+
+func mustRawTracepointProgram(t *testing.T, typ ebpf.ProgramType) *ebpf.Program {
+	t.Helper()
+
 	prog, err := ebpf.NewProgram(&ebpf.ProgramSpec{
-		Type:       ebpf.RawTracepointWritable,
+		Type:       typ,
 		AttachType: ebpf.AttachNone,
 		Instructions: asm.Instructions{
 			asm.LoadImm(asm.R0, 0, asm.DWord),
@@ -57,21 +67,5 @@ func TestRawTracepoint_writable(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer prog.Close()
-
-	link, err := AttachRawTracepoint(RawTracepointOptions{
-		Name:    "cgroup_rmdir",
-		Program: prog,
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if link == nil {
-		t.Fatal("no link")
-	}
-
-	if err := link.Close(); err != nil {
-		t.Fatalf("failed to close link: %v", err)
-	}
+	return prog
 }


### PR DESCRIPTION
afaik `BPF_LINK_UPDATE` doesn't support raw tracepoint updates (see [bpf_raw_tp_link_lops](https://github.com/torvalds/linux/blob/c0842fbc1b18c7a044e6ff3e8fa78bfa822c7d1a/kernel/bpf/syscall.c#L2656-L2661)). So we have only one way to update a raw tracepoint link - open it for a new program and close the previous fd.