### PR TITLE
Add kind_flag support for Struct, Union, and Fwd

### DIFF
--- a/internal/btf/btf_types.go
+++ b/internal/btf/btf_types.go
@@ -139,7 +139,7 @@ func (bt *btfType) SetVlen(vlen int) {
 }
 
 func (bt *btfType) KindFlag() bool {
-	return int(bt.info(btfTypeKindFlagMask, btfTypeKindFlagShift)) == 1
+	return bt.info(btfTypeKindFlagMask, btfTypeKindFlagShift) == 1
 }
 
 func (bt *btfType) Linkage() btfFuncLinkage {

--- a/internal/btf/btf_types.go
+++ b/internal/btf/btf_types.go
@@ -40,10 +40,12 @@ const (
 )
 
 const (
-	btfTypeKindShift = 24
-	btfTypeKindLen   = 4
-	btfTypeVlenShift = 0
-	btfTypeVlenMask  = 16
+	btfTypeKindShift     = 24
+	btfTypeKindLen       = 4
+	btfTypeVlenShift     = 0
+	btfTypeVlenMask      = 16
+	btfTypeKindFlagShift = 31
+	btfTypeKindFlagMask  = 1
 )
 
 // btfType is equivalent to struct btf_type in Documentation/bpf/btf.rst.
@@ -134,6 +136,10 @@ func (bt *btfType) Vlen() int {
 
 func (bt *btfType) SetVlen(vlen int) {
 	bt.setInfo(uint32(vlen), btfTypeVlenMask, btfTypeVlenShift)
+}
+
+func (bt *btfType) KindFlag() bool {
+	return int(bt.info(btfTypeKindFlagMask, btfTypeKindFlagShift)) == 1
 }
 
 func (bt *btfType) Linkage() btfFuncLinkage {

--- a/internal/btf/types.go
+++ b/internal/btf/types.go
@@ -158,7 +158,6 @@ type Member struct {
 	Type         Type
 	Offset       uint32
 	BitfieldSize uint32
-	BitOffset    uint32
 }
 
 // Enum lists possible values.
@@ -461,7 +460,7 @@ func inflateRawTypes(rawTypes []rawType, rawStrings stringTable) (namedTypes map
 			}
 			if kindFlag {
 				m.BitfieldSize = btfMember.Offset >> 24
-				m.BitOffset = m.Offset & 0xffffff
+				m.Offset = m.Offset & 0xffffff
 			}
 			members = append(members, m)
 		}

--- a/internal/btf/types.go
+++ b/internal/btf/types.go
@@ -155,7 +155,8 @@ var (
 // It is not a valid Type.
 type Member struct {
 	Name
-	Type         Type
+	Type Type
+	// Offset is the bit offset of this member
 	Offset       uint32
 	BitfieldSize uint32
 }
@@ -460,7 +461,7 @@ func inflateRawTypes(rawTypes []rawType, rawStrings stringTable) (namedTypes map
 			}
 			if kindFlag {
 				m.BitfieldSize = btfMember.Offset >> 24
-				m.Offset = m.Offset & 0xffffff
+				m.Offset &= 0xffffff
 			}
 			members = append(members, m)
 		}


### PR DESCRIPTION
This supports bitfield types for Struct & Union. kind_flag indicates whether Fwd is for a struct or union.

In support of #114 