### PR TITLE
CI: specify custom test flags last

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -22,7 +22,7 @@ if [[ "${1:-}" = "--in-vm" ]]; then
 
   echo Running tests...
   # TestLibBPFCompat runs separately to pass the "-elfs" flag only for it: https://github.com/cilium/ebpf/pull/119
-  /usr/local/bin/go test -v -elfs "$elfs" -run TestLibBPFCompat
+  /usr/local/bin/go test -v -run TestLibBPFCompat -elfs "$elfs"
   /usr/local/bin/go test -v ./...
   touch "$1/success"
   exit 0


### PR DESCRIPTION
The go test command requires custom flags to be passed at the end of
the invocation. Go 1.15 has become stricter with this, and the test
therefore fails on that version.