### PR TITLE
program: move jump and call fixup out of asm package

### DIFF
--- a/asm/opcode.go
+++ b/asm/opcode.go
@@ -66,10 +66,10 @@ type OpCode uint8
 // InvalidOpCode is returned by setters on OpCode
 const InvalidOpCode OpCode = 0xff
 
-// marshalledInstructions returns the number of BPF instructions required
+// rawInstructions returns the number of BPF instructions required
 // to encode this opcode.
-func (op OpCode) marshalledInstructions() int {
-	if op == LoadImmOp(DWord) {
+func (op OpCode) rawInstructions() int {
+	if op.isDWordLoad() {
 		return 2
 	}
 	return 1

--- a/prog.go
+++ b/prog.go
@@ -208,8 +208,15 @@ func convertProgramSpec(spec *ProgramSpec, handle *btf.Handle) (*bpfProgLoadAttr
 		return nil, fmt.Errorf("can't load %s program on %s", spec.ByteOrder, internal.NativeEndian)
 	}
 
+	insns := make(asm.Instructions, len(spec.Instructions))
+	copy(insns, spec.Instructions)
+
+	if err := fixupJumpsAndCalls(insns); err != nil {
+		return nil, err
+	}
+
 	buf := bytes.NewBuffer(make([]byte, 0, len(spec.Instructions)*asm.InstructionSize))
-	err := spec.Instructions.Marshal(buf, internal.NativeEndian)
+	err := insns.Marshal(buf, internal.NativeEndian)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Jumps and calls may have to be fixed up, if their target isn't known
at compile time. This happens when a user uses the asm package to write
"inline" BPF programs, and when using function calls in C derived BPF.

The jump and call targets have to be expressed in units of raw BPF
instructions. Since some asm.Instructions have to be encoded in two
BPF instructions there is no 1:1 mapping. Figuring out the raw
instruction offset therefore involves iterating all instructions
and keeping a running count.

Due to this the fixup currently happens during instruction marshalling.
This is a bit of a hack, but so far allowed to keep the details of raw
instruction offsets contained to the asm package.

With BPF CO-RE this doesn't work too well anymore: the fixup we have to do
is also based on raw BPF instruction offsets. Cramming this into
instruction marshalling seems like the wrong thing to do, and is
probably not possible due to import cycles between the asm and btf
package.

Introduce a RawInstructionOffset type and an InstructionIterator to
encapsulate the raw offset handling, and move jump and call fixup to
a function in the main package.