### PR TITLE
map, program: deprecate ABI()

### DIFF
--- a/collection_test.go
+++ b/collection_test.go
@@ -308,8 +308,8 @@ func ExampleCollectionSpec_LoadAndAssign() {
 		panic(err)
 	}
 
-	fmt.Println(objs.Program.ABI().Type)
-	fmt.Println(objs.Map.ABI().Type)
+	fmt.Println(objs.Program.Type())
+	fmt.Println(objs.Map.Type())
 
 	// Output: SocketFilter
 	// Array
@@ -349,8 +349,8 @@ func ExampleCollection_Assign() {
 		panic(err)
 	}
 
-	fmt.Println(objs.Program.ABI().Type)
-	fmt.Println(objs.Map.ABI().Type)
+	fmt.Println(objs.Program.Type())
+	fmt.Println(objs.Map.Type())
 
 	// Output: SocketFilter
 	// Array

--- a/map.go
+++ b/map.go
@@ -269,7 +269,29 @@ func (m *Map) String() string {
 	return fmt.Sprintf("%s#%v", m.abi.Type, m.fd)
 }
 
-// ABI gets the ABI of the Map
+// Type returns the underlying type of the map.
+func (m *Map) Type() MapType {
+	return m.abi.Type
+}
+
+// KeySize returns the size of the map key in bytes.
+func (m *Map) KeySize() uint32 {
+	return m.abi.KeySize
+}
+
+// ValueSize returns the size of the map value in bytes.
+func (m *Map) ValueSize() uint32 {
+	return m.abi.ValueSize
+}
+
+// MaxEntries returns the maximum number of elements the map can hold.
+func (m *Map) MaxEntries() uint32 {
+	return m.abi.MaxEntries
+}
+
+// ABI gets the ABI of the Map.
+//
+// Deprecated: use Type, KeySize, ValueSize, MaxEntries instead.
 func (m *Map) ABI() MapABI {
 	return m.abi
 }

--- a/perf/reader.go
+++ b/perf/reader.go
@@ -191,7 +191,7 @@ func NewReaderWithOptions(array *ebpf.Map, perCPUBuffer int, opts ReaderOptions)
 
 	var (
 		fds      = []int{epollFd}
-		nCPU     = int(array.ABI().MaxEntries)
+		nCPU     = int(array.MaxEntries())
 		rings    = make([]*perfEventRing, 0, nCPU)
 		pauseFds = make([]int, 0, nCPU)
 	)

--- a/prog.go
+++ b/prog.go
@@ -276,7 +276,14 @@ func (p *Program) String() string {
 	return fmt.Sprintf("%s#%v", p.abi.Type, p.fd)
 }
 
-// ABI gets the ABI of the Program
+// Type returns the underlying type of the program.
+func (p *Program) Type() ProgramType {
+	return p.abi.Type
+}
+
+// ABI gets the ABI of the Program.
+//
+// Deprecated: use Type instead.
 func (p *Program) ABI() ProgramABI {
 	return p.abi
 }


### PR DESCRIPTION
Add explicit getters for fields that are currently exported via
ABI() and mark the functions as deprecated. They will be removed
in a follow up PR.