### PR TITLE
btf: fix LoadKernelSpec

### DIFF
--- a/internal/btf/btf_test.go
+++ b/internal/btf/btf_test.go
@@ -134,6 +134,17 @@ func TestLoadSpecFromElf(t *testing.T) {
 	})
 }
 
+func TestLoadKernelSpec(t *testing.T) {
+	if _, err := os.Stat("/sys/kernel/btf/vmlinux"); os.IsNotExist(err) {
+		t.Skip("/sys/kernel/btf/vmlinux not present")
+	}
+
+	_, err := LoadKernelSpec()
+	if err != nil {
+		t.Fatal("Can't load kernel spec:", err)
+	}
+}
+
 func TestHaveBTF(t *testing.T) {
 	testutils.CheckFeatureTest(t, haveBTF)
 }


### PR DESCRIPTION
The current code fails to find any kernel spec because the call to
Sprintf may contain too many or too few arguments. The result then
contains %!s(MISSING), etc. which of course triggers an error when
trying to open the path.

Another problem is that the function tries other filenames if reading
the BTF itself fails for some reason. In that case it will most likely
return ErrNotFound, and the user is none the wiser: we found a BTF
but couldn't load it.

Change the code so that we return any error from the BTF loading itself.