### PR TITLE
make lsm attachment work

### DIFF
--- a/elf_reader.go
+++ b/elf_reader.go
@@ -637,6 +637,7 @@ func getProgType(sectionName string) (ProgramType, AttachType, string) {
 		"flow_dissector":        {FlowDissector, AttachFlowDissector},
 		"iter/":                 {Tracing, AttachTraceIter},
 		"sk_lookup/":            {SkLookup, AttachSkLookup},
+		"lsm/":                  {LSM, AttachLSMMac},
 
 		"cgroup_skb/ingress": {CGroupSKB, AttachCGroupInetIngress},
 		"cgroup_skb/egress":  {CGroupSKB, AttachCGroupInetEgress},

--- a/prog_test.go
+++ b/prog_test.go
@@ -479,6 +479,24 @@ func TestProgramRejectIncorrectByteOrder(t *testing.T) {
 	}
 }
 
+func TestProgramTypeLSM(t *testing.T) {
+	prog, err := NewProgram(&ProgramSpec{
+		AttachTo:   "task_getpgid",
+		AttachType: AttachLSMMac,
+		Instructions: asm.Instructions{
+			asm.LoadImm(asm.R0, 0, asm.DWord),
+			asm.Return(),
+		},
+		License: "GPL",
+		Type:    LSM,
+	})
+	testutils.SkipIfNotSupported(t, err)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer prog.Close()
+}
+
 func createProgramArray(t *testing.T) *Map {
 	t.Helper()
 


### PR DESCRIPTION
BPF LSM requires that the kernel has CONFIG_BPF_LSM enabled, which is required for the BTF for LSM hooks to be present, and that the bpf security module is active, without which the attached programs will never be called.

Tested on an Ubuntu Groovy system with a modified kernel config.