### PR TITLE
cmd/bpf2go: document required clang version

### DIFF
--- a/cmd/bpf2go/doc.go
+++ b/cmd/bpf2go/doc.go
@@ -18,6 +18,8 @@
 // By exporting $BPF_CFLAGS from your build system you can then control
 // all builds from a single location.
 //
+// Requires at least clang 9.
+//
 // For a full list of accepted options check the `-help` output. There is a
 // fully worked example at https://github.com/cilium/ebpf/tree/master/cmd/bpf2go/example.
 package main


### PR DESCRIPTION
We need at least clang 9, since earlier versions don't support
-fdebug-compilation-dir. Without that flag reproducible builds don't work.