### PR TITLE
map: add a getter for Flags

### DIFF
--- a/map.go
+++ b/map.go
@@ -376,9 +376,14 @@ func (m *Map) MaxEntries() uint32 {
 	return m.abi.MaxEntries
 }
 
+// Flags returns the flags of the map.
+func (m *Map) Flags() uint32 {
+	return m.abi.Flags
+}
+
 // ABI gets the ABI of the Map.
 //
-// Deprecated: use Type, KeySize, ValueSize, MaxEntries instead.
+// Deprecated: use Type, KeySize, ValueSize, MaxEntries and Flags instead.
 func (m *Map) ABI() MapABI {
 	return m.abi
 }


### PR DESCRIPTION
Add a getter for MapABI.Flags, so that we can deprecate MapABI without
losing access to Flags.