### PR TITLE
use buffered I/O to cut down on read syscalls

### DIFF
--- a/elf_reader.go
+++ b/elf_reader.go
@@ -1,6 +1,7 @@
 package ebpf
 
 import (
+	"bufio"
 	"bytes"
 	"debug/elf"
 	"encoding/binary"
@@ -236,7 +237,7 @@ func (ec *elfCode) loadPrograms(progSections map[elf.SectionIndex]*elf.Section, 
 
 func (ec *elfCode) loadInstructions(section *elf.Section, symbols, relocations map[uint64]elf.Symbol) (asm.Instructions, uint64, error) {
 	var (
-		r      = section.Open()
+		r      = bufio.NewReader(section.Open())
 		insns  asm.Instructions
 		offset uint64
 	)
@@ -389,7 +390,7 @@ func (ec *elfCode) loadMaps(maps map[string]*MapSpec, mapSections map[elf.Sectio
 		}
 
 		var (
-			r    = sec.Open()
+			r    = bufio.NewReader(sec.Open())
 			size = sec.Size / uint64(len(syms))
 		)
 		for i, offset := 0, uint64(0); i < len(syms); i, offset = i+1, offset+size {
@@ -687,7 +688,7 @@ func (ec *elfCode) loadRelocations(sections map[elf.SectionIndex]*elf.Section) (
 			return nil, nil, fmt.Errorf("section %s: relocations are less than 16 bytes", sec.Name)
 		}
 
-		r := sec.Open()
+		r := bufio.NewReader(sec.Open())
 		for off := uint64(0); off < sec.Size; off += sec.Entsize {
 			ent := io.LimitReader(r, int64(sec.Entsize))
 

--- a/internal/btf/ext_info.go
+++ b/internal/btf/ext_info.go
@@ -1,6 +1,7 @@
 package btf
 
 import (
+	"bufio"
 	"bytes"
 	"encoding/binary"
 	"errors"
@@ -58,7 +59,8 @@ func parseExtInfos(r io.ReadSeeker, bo binary.ByteOrder, strings stringTable) (f
 		return nil, nil, fmt.Errorf("can't seek to function info section: %v", err)
 	}
 
-	funcInfo, err = parseExtInfo(io.LimitReader(r, int64(header.FuncInfoLen)), bo, strings)
+	buf := bufio.NewReader(io.LimitReader(r, int64(header.FuncInfoLen)))
+	funcInfo, err = parseExtInfo(buf, bo, strings)
 	if err != nil {
 		return nil, nil, fmt.Errorf("function info: %w", err)
 	}
@@ -67,7 +69,8 @@ func parseExtInfos(r io.ReadSeeker, bo binary.ByteOrder, strings stringTable) (f
 		return nil, nil, fmt.Errorf("can't seek to line info section: %v", err)
 	}
 
-	lineInfo, err = parseExtInfo(io.LimitReader(r, int64(header.LineInfoLen)), bo, strings)
+	buf = bufio.NewReader(io.LimitReader(r, int64(header.LineInfoLen)))
+	lineInfo, err = parseExtInfo(buf, bo, strings)
 	if err != nil {
 		return nil, nil, fmt.Errorf("line info: %w", err)
 	}


### PR DESCRIPTION
I noticed that the libbpf integration tests are extremely slow in the VM
compared to running them natively. Looking at a CPU profile shows that
we spend a lot of time in read syscalls. This is because reading from
an ELF section is not buffered.

Instrument the important places to use a buffered reader. The test time
in the VM drops from ~20s to less than one second.