### PR TITLE
cmd/bpf2go: output ELF .o next to the .go file

### DIFF
--- a/cmd/bpf2go/main.go
+++ b/cmd/bpf2go/main.go
@@ -143,8 +143,8 @@ func run(stdout io.Writer, pkg, outputDir string, args []string) (err error) {
 
 	cFlags = cFlags[:len(cFlags):len(cFlags)]
 	for _, target := range targets {
-		objFileName := fmt.Sprintf("%s_%s.o", stripExtension(inputFile), target)
-		objFileName = filepath.Join(inputDir, objFileName)
+		objFileName := fmt.Sprintf("%s_%s.o", strings.ToLower(ident), target)
+		objFileName = filepath.Join(outputDir, objFileName)
 
 		var dep bytes.Buffer
 		err = compile(compileArgs{


### PR DESCRIPTION
Go 1.16 will add file embedding via magic comments, which we can use to
store the .o file instead of stuffing it into a global. Move the
compiled object file next to the .go to simplify this in the future.