### PR TITLE
Remove two unused functions

### DIFF
--- a/abi.go
+++ b/abi.go
@@ -88,12 +88,6 @@ type ProgramABI struct {
 	Type ProgramType
 }
 
-func newProgramABIFromSpec(spec *ProgramSpec) *ProgramABI {
-	return &ProgramABI{
-		spec.Type,
-	}
-}
-
 func newProgramABIFromFd(fd *internal.FD) (string, *ProgramABI, error) {
 	info, err := bpfGetProgInfoByFD(fd)
 	if err != nil {

--- a/cmd/bpf2go/tools.go
+++ b/cmd/bpf2go/tools.go
@@ -9,10 +9,6 @@ import (
 	"unicode/utf8"
 )
 
-func stripExtension(file string) string {
-	return file[:len(file)-len(filepath.Ext(file))]
-}
-
 func splitCFlagsFromArgs(in []string) (args, cflags []string) {
 	for i, arg := range in {
 		if arg == "--" {


### PR DESCRIPTION
Remove two functions which are unused after refactoring in b17e4fd67aaf and the removal of `CollectionABI` in b04f777e8ed0.