### PR TITLE
btf: add go-fuzz targets

### DIFF
--- a/internal/btf/ext_info.go
+++ b/internal/btf/ext_info.go
@@ -130,6 +130,8 @@ func (ei extInfo) MarshalBinary() ([]byte, error) {
 }
 
 func parseExtInfo(r io.Reader, bo binary.ByteOrder, strings stringTable) (map[string]extInfo, error) {
+	const maxRecordSize = 256
+
 	var recordSize uint32
 	if err := binary.Read(r, bo, &recordSize); err != nil {
 		return nil, fmt.Errorf("can't read record size: %v", err)
@@ -138,6 +140,9 @@ func parseExtInfo(r io.Reader, bo binary.ByteOrder, strings stringTable) (map[st
 	if recordSize < 4 {
 		// Need at least insnOff
 		return nil, errors.New("record size too short")
+	}
+	if recordSize > maxRecordSize {
+		return nil, fmt.Errorf("record size %v exceeds %v", recordSize, maxRecordSize)
 	}
 
 	result := make(map[string]extInfo)

--- a/internal/btf/ext_info_test.go
+++ b/internal/btf/ext_info_test.go
@@ -1,0 +1,17 @@
+package btf
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cilium/ebpf/internal"
+)
+
+func TestParseExtInfoBigRecordSize(t *testing.T) {
+	rd := strings.NewReader("\xff\xff\xff\xff\x00\x00\x00\x000709171295166016")
+	table := stringTable("\x00")
+	_, err := parseExtInfo(rd, internal.NativeEndian, table)
+	if err == nil {
+		t.Error("Parsing ext info with large record size doesn't return an error")
+	}
+}

--- a/internal/btf/fuzz.go
+++ b/internal/btf/fuzz.go
@@ -1,0 +1,49 @@
+// +build gofuzz
+
+// Use with https://github.com/dvyukov/go-fuzz
+
+package btf
+
+import (
+	"bytes"
+	"encoding/binary"
+
+	"github.com/cilium/ebpf/internal"
+)
+
+func FuzzSpec(data []byte) int {
+	if len(data) < binary.Size(btfHeader{}) {
+		return -1
+	}
+
+	spec, err := loadNakedSpec(bytes.NewReader(data), internal.NativeEndian, nil, nil)
+	if err != nil {
+		if spec != nil {
+			panic("spec is not nil")
+		}
+		return 0
+	}
+	if spec == nil {
+		panic("spec is nil")
+	}
+	return 1
+}
+
+func FuzzExtInfo(data []byte) int {
+	if len(data) < binary.Size(btfExtHeader{}) {
+		return -1
+	}
+
+	table := stringTable("\x00foo\x00barfoo\x00")
+	info, err := parseExtInfo(bytes.NewReader(data), internal.NativeEndian, table)
+	if err != nil {
+		if info != nil {
+			panic("info is not nil")
+		}
+		return 0
+	}
+	if info == nil {
+		panic("info is nil")
+	}
+	return 1
+}


### PR DESCRIPTION
Add two targets for go-fuzz, for further experimentation. A short run already found an OOM condition, so I'm sure there is lots more to discover.