### PR TITLE
btf: avoid Type copy in FuncProto.walk

### DIFF
--- a/internal/btf/types.go
+++ b/internal/btf/types.go
@@ -297,8 +297,8 @@ type FuncProto struct {
 
 func (fp *FuncProto) walk(cs *copyStack) {
 	cs.push(&fp.Return)
-	for _, m := range fp.Params {
-		cs.push(&m.Type)
+	for i := range fp.Params {
+		cs.push(&fp.Params[i].Type)
 	}
 }
 


### PR DESCRIPTION
FuncProto.walk currently takes a copy of FuncParam.Type since the
for loop implicitly makes a copy of the FuncParam value:

    for _, m := range fp.Params {

m is a copy of the original param, so &m.Type is the address of a
temporary variable. Instead, iterate params using the index and
take the correct address. Also extend the tests to cover this case.