### PR TITLE
better error messages when RLIMIT_MEMLOCK is too low

### DIFF
--- a/map.go
+++ b/map.go
@@ -306,6 +306,9 @@ func createMap(spec *MapSpec, inner *internal.FD, handle *btf.Handle, opts MapOp
 
 	fd, err := bpfMapCreate(&attr)
 	if err != nil {
+		if errors.Is(err, unix.EPERM) {
+			return nil, fmt.Errorf("map create: RLIMIT_MEMLOCK may be too low: %w", err)
+		}
 		return nil, fmt.Errorf("map create: %w", err)
 	}
 	defer closeOnError(fd)

--- a/prog.go
+++ b/prog.go
@@ -163,8 +163,12 @@ func newProgramWithBTF(spec *ProgramSpec, btf *btf.Handle, opts ProgramOptions) 
 		_, logErr = bpfProgLoad(attr)
 	}
 
+	if errors.Is(logErr, unix.EPERM) && logBuf[0] == 0 {
+		return nil, fmt.Errorf("load program: RLIMIT_MEMLOCK may be too low: %w", logErr)
+	}
+
 	err = internal.ErrorWithLog(err, logBuf, logErr)
-	return nil, fmt.Errorf("can't load program: %w", err)
+	return nil, fmt.Errorf("load program: %w", err)
 }
 
 // NewProgramFromFD creates a program from a raw fd.

--- a/prog.go
+++ b/prog.go
@@ -164,6 +164,8 @@ func newProgramWithBTF(spec *ProgramSpec, btf *btf.Handle, opts ProgramOptions) 
 	}
 
 	if errors.Is(logErr, unix.EPERM) && logBuf[0] == 0 {
+		// EPERM due to RLIMIT_MEMLOCK happens before the verifier, so we can
+		// check that the log is empty to reduce false positives.
 		return nil, fmt.Errorf("load program: RLIMIT_MEMLOCK may be too low: %w", logErr)
 	}
 

--- a/syscalls.go
+++ b/syscalls.go
@@ -3,7 +3,6 @@ package ebpf
 import (
 	"errors"
 	"fmt"
-	"os"
 	"unsafe"
 
 	"github.com/cilium/ebpf/internal"
@@ -168,10 +167,6 @@ func bpfProgTestRun(attr *bpfProgTestRunAttr) error {
 
 func bpfMapCreate(attr *bpfMapCreateAttr) (*internal.FD, error) {
 	fd, err := internal.BPF(internal.BPF_MAP_CREATE, unsafe.Pointer(attr), unsafe.Sizeof(*attr))
-	if errors.Is(err, os.ErrPermission) {
-		return nil, errors.New("permission denied or insufficient rlimit to lock memory for map")
-	}
-
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
map: make RLIMIT_MEMLOCK error more specific
    
    The current check for os.ErrPermission will also return true for EACCES,
    which shouldn't trigger the memlock message. It also discards the
    underlying error, which might break feature tests, etc.
    
    Move the check and make it specific to EPERM.

program: try to be helpful when RLIMIT_MEMLOCK is too low
    
    One of the most puzzling errors from BPF is EPERM when trying to load
    a perfectly legitimate program into the kernel. Most of the time this
    means that RLIMIT_MEMLOCK is too low.
    
    Detect this case by checking whether the error from BPF_PROG_LOAD is
    EPERM. Since EPERM may indicate other problems as well, only emit the
    error mentioning rlimit if the verifier buffer is empty.