### PR TITLE
fix spurious test failures due to closed fds

### DIFF
--- a/prog_test.go
+++ b/prog_test.go
@@ -379,7 +379,12 @@ func TestProgramFromFD(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	prog2.Close()
+	// Both programs refer to the same fd now. Closing either of them will
+	// release the fd to the OS, which then might re-use that fd for another
+	// test. Once we close the second map we might close the re-used fd
+	// inadvertently, leading to spurious test failures.
+	// To avoid this we have to "leak" one of the programs.
+	prog2.fd.Forget()
 }
 
 func TestHaveProgTestRun(t *testing.T) {


### PR DESCRIPTION
The tests for NewProgramFromFD and NewMapFromFD create new objects
from an existing map / program. This means that there are now two
internal.FDs for one actual file descriptor, e.g. 9. Since the FD
objects use runtime.SetFinalizer, we will invoke close(9) twice.
For the first call this is acceptable, but the second call to close
may affect a re-used fd 9. The net effect is that other tests start
failing with weird "bad filedescriptor" errors, since the finalizer
callback closed it.

Avoid this by removing the finalizer from  the "cloned" program and
map objects and then explicitly not closing them.

Fixes #168