### PR TITLE
internal/unix: add BPF_F_NO_PREALLOC const

### DIFF
--- a/elf_reader_test.go
+++ b/elf_reader_test.go
@@ -11,14 +11,13 @@ import (
 	"github.com/cilium/ebpf/internal"
 	"github.com/cilium/ebpf/internal/btf"
 	"github.com/cilium/ebpf/internal/testutils"
+	"github.com/cilium/ebpf/internal/unix"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
 func TestLoadCollectionSpec(t *testing.T) {
-	const BPF_F_NO_PREALLOC = 1
-
 	coll := &CollectionSpec{
 		Maps: map[string]*MapSpec{
 			"hash_map": {
@@ -27,7 +26,7 @@ func TestLoadCollectionSpec(t *testing.T) {
 				KeySize:    4,
 				ValueSize:  8,
 				MaxEntries: 1,
-				Flags:      BPF_F_NO_PREALLOC,
+				Flags:      unix.BPF_F_NO_PREALLOC,
 			},
 			"hash_map2": {
 				Name:       "hash_map2",

--- a/info_test.go
+++ b/info_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/cilium/ebpf/internal"
 	"github.com/cilium/ebpf/internal/testutils"
+	"github.com/cilium/ebpf/internal/unix"
 )
 
 func TestMapInfoFromProc(t *testing.T) {
@@ -15,7 +16,7 @@ func TestMapInfoFromProc(t *testing.T) {
 		KeySize:    4,
 		ValueSize:  5,
 		MaxEntries: 2,
-		Flags:      0x1, // BPF_F_NO_PREALLOC
+		Flags:      unix.BPF_F_NO_PREALLOC,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -43,8 +44,8 @@ func TestMapInfoFromProc(t *testing.T) {
 		t.Error("Expected MaxEntries of 2, got", info.MaxEntries)
 	}
 
-	if info.Flags != 1 {
-		t.Error("Expected Flags to be 1, got", info.Flags)
+	if info.Flags != unix.BPF_F_NO_PREALLOC {
+		t.Errorf("Expected Flags to be %d, got %d", unix.BPF_F_NO_PREALLOC, info.Flags)
 	}
 
 	if info.Name != "" && info.Name != "testing" {

--- a/internal/unix/types_linux.go
+++ b/internal/unix/types_linux.go
@@ -20,6 +20,7 @@ const (
 	EPERM                    = linux.EPERM
 	ESRCH                    = linux.ESRCH
 	ENODEV                   = linux.ENODEV
+	BPF_F_NO_PREALLOC        = linux.BPF_F_NO_PREALLOC
 	BPF_F_NUMA_NODE          = linux.BPF_F_NUMA_NODE
 	BPF_F_RDONLY_PROG        = linux.BPF_F_RDONLY_PROG
 	BPF_F_WRONLY_PROG        = linux.BPF_F_WRONLY_PROG

--- a/internal/unix/types_other.go
+++ b/internal/unix/types_other.go
@@ -20,6 +20,7 @@ const (
 	EPERM                    = syscall.EPERM
 	ESRCH                    = syscall.ESRCH
 	ENODEV                   = syscall.ENODEV
+	BPF_F_NO_PREALLOC        = 0
 	BPF_F_NUMA_NODE          = 0
 	BPF_F_RDONLY_PROG        = 0
 	BPF_F_WRONLY_PROG        = 0


### PR DESCRIPTION
...and use it in MapSpec.Flags where appropriate.