### PR TITLE
Simplify feature tests

### DIFF
--- a/internal/feature_test.go
+++ b/internal/feature_test.go
@@ -2,7 +2,6 @@ package internal
 
 import (
 	"errors"
-	"fmt"
 	"strings"
 	"testing"
 )
@@ -10,9 +9,9 @@ import (
 func TestFeatureTest(t *testing.T) {
 	var called bool
 
-	fn := FeatureTest("foo", "1.0", func() (bool, error) {
+	fn := FeatureTest("foo", "1.0", func() error {
 		called = true
-		return true, nil
+		return nil
 	})
 
 	if called {
@@ -28,8 +27,8 @@ func TestFeatureTest(t *testing.T) {
 		t.Error("Unexpected negative result:", err)
 	}
 
-	fn = FeatureTest("bar", "2.1.1", func() (bool, error) {
-		return false, nil
+	fn = FeatureTest("bar", "2.1.1", func() error {
+		return ErrNotSupported
 	})
 
 	err = fn()
@@ -50,22 +49,18 @@ func TestFeatureTest(t *testing.T) {
 		t.Error("UnsupportedFeatureError is not ErrNotSupported")
 	}
 
-	fn = FeatureTest("bar", "2.1.1", func() (bool, error) {
-		return false, errors.New("foo")
+	err2 := fn()
+	if err != err2 {
+		t.Error("Didn't cache an error wrapping ErrNotSupported")
+	}
+
+	fn = FeatureTest("bar", "2.1.1", func() error {
+		return errors.New("foo")
 	})
 
 	err1, err2 := fn(), fn()
 	if err1 == err2 {
 		t.Error("Cached result of unsuccessful execution")
-	}
-
-	fn = FeatureTest("bar", "2.1.1", func() (bool, error) {
-		return false, fmt.Errorf("bar: %w", ErrNotSupported)
-	})
-
-	err1, err2 = fn(), fn()
-	if err1 != err2 {
-		t.Error("Didn't cache an error wrapping ErrNotSupported")
 	}
 }
 

--- a/internal/unix/types_linux.go
+++ b/internal/unix/types_linux.go
@@ -20,6 +20,7 @@ const (
 	EPERM                    = linux.EPERM
 	ESRCH                    = linux.ESRCH
 	ENODEV                   = linux.ENODEV
+	EBADF                    = linux.EBADF
 	BPF_F_NO_PREALLOC        = linux.BPF_F_NO_PREALLOC
 	BPF_F_NUMA_NODE          = linux.BPF_F_NUMA_NODE
 	BPF_F_RDONLY_PROG        = linux.BPF_F_RDONLY_PROG

--- a/internal/unix/types_other.go
+++ b/internal/unix/types_other.go
@@ -20,6 +20,7 @@ const (
 	EPERM                    = syscall.EPERM
 	ESRCH                    = syscall.ESRCH
 	ENODEV                   = syscall.ENODEV
+	EBADF                    = syscall.Errno(0)
 	BPF_F_NO_PREALLOC        = 0
 	BPF_F_NUMA_NODE          = 0
 	BPF_F_RDONLY_PROG        = 0

--- a/prog.go
+++ b/prog.go
@@ -384,7 +384,7 @@ func (p *Program) Benchmark(in []byte, repeat int, reset func()) (uint32, time.D
 	return ret, total, nil
 }
 
-var haveProgTestRun = internal.FeatureTest("BPF_PROG_TEST_RUN", "4.12", func() (bool, error) {
+var haveProgTestRun = internal.FeatureTest("BPF_PROG_TEST_RUN", "4.12", func() error {
 	prog, err := NewProgram(&ProgramSpec{
 		Type: SocketFilter,
 		Instructions: asm.Instructions{
@@ -395,7 +395,7 @@ var haveProgTestRun = internal.FeatureTest("BPF_PROG_TEST_RUN", "4.12", func() (
 	})
 	if err != nil {
 		// This may be because we lack sufficient permissions, etc.
-		return false, err
+		return err
 	}
 	defer prog.Close()
 
@@ -408,10 +408,12 @@ var haveProgTestRun = internal.FeatureTest("BPF_PROG_TEST_RUN", "4.12", func() (
 	}
 
 	err = bpfProgTestRun(&attr)
-
-	// Check for EINVAL specifically, rather than err != nil since we
-	// otherwise misdetect due to insufficient permissions.
-	return !errors.Is(err, unix.EINVAL), nil
+	if errors.Is(err, unix.EINVAL) {
+		// Check for EINVAL specifically, rather than err != nil since we
+		// otherwise misdetect due to insufficient permissions.
+		return internal.ErrNotSupported
+	}
+	return err
 })
 
 func (p *Program) testRun(in []byte, repeat int, reset func()) (uint32, []byte, time.Duration, error) {

--- a/syscalls.go
+++ b/syscalls.go
@@ -203,7 +203,7 @@ func bpfMapCreate(attr *bpfMapCreateAttr) (*internal.FD, error) {
 	return internal.NewFD(uint32(fd)), nil
 }
 
-var haveNestedMaps = internal.FeatureTest("nested maps", "4.12", func() (bool, error) {
+var haveNestedMaps = internal.FeatureTest("nested maps", "4.12", func() error {
 	inner, err := bpfMapCreate(&bpfMapCreateAttr{
 		mapType:    Array,
 		keySize:    4,
@@ -211,7 +211,7 @@ var haveNestedMaps = internal.FeatureTest("nested maps", "4.12", func() (bool, e
 		maxEntries: 1,
 	})
 	if err != nil {
-		return false, err
+		return err
 	}
 	defer inner.Close()
 
@@ -224,14 +224,14 @@ var haveNestedMaps = internal.FeatureTest("nested maps", "4.12", func() (bool, e
 		innerMapFd: innerFd,
 	})
 	if err != nil {
-		return false, nil
+		return internal.ErrNotSupported
 	}
 
 	_ = nested.Close()
-	return true, nil
+	return nil
 })
 
-var haveMapMutabilityModifiers = internal.FeatureTest("read- and write-only maps", "5.2", func() (bool, error) {
+var haveMapMutabilityModifiers = internal.FeatureTest("read- and write-only maps", "5.2", func() error {
 	// This checks BPF_F_RDONLY_PROG and BPF_F_WRONLY_PROG. Since
 	// BPF_MAP_FREEZE appeared in 5.2 as well we don't do a separate check.
 	m, err := bpfMapCreate(&bpfMapCreateAttr{
@@ -242,10 +242,10 @@ var haveMapMutabilityModifiers = internal.FeatureTest("read- and write-only maps
 		flags:      unix.BPF_F_RDONLY_PROG,
 	})
 	if err != nil {
-		return false, nil
+		return internal.ErrNotSupported
 	}
 	_ = m.Close()
-	return true, nil
+	return nil
 })
 
 func bpfMapLookupElem(m *internal.FD, key, valueOut internal.Pointer) error {
@@ -388,7 +388,7 @@ func bpfGetMapInfoByFD(fd *internal.FD) (*bpfMapInfo, error) {
 	return &info, nil
 }
 
-var haveObjName = internal.FeatureTest("object names", "4.15", func() (bool, error) {
+var haveObjName = internal.FeatureTest("object names", "4.15", func() error {
 	attr := bpfMapCreateAttr{
 		mapType:    Array,
 		keySize:    4,
@@ -399,16 +399,16 @@ var haveObjName = internal.FeatureTest("object names", "4.15", func() (bool, err
 
 	fd, err := bpfMapCreate(&attr)
 	if err != nil {
-		return false, nil
+		return internal.ErrNotSupported
 	}
 
 	_ = fd.Close()
-	return true, nil
+	return nil
 })
 
-var objNameAllowsDot = internal.FeatureTest("dot in object names", "5.2", func() (bool, error) {
+var objNameAllowsDot = internal.FeatureTest("dot in object names", "5.2", func() error {
 	if err := haveObjName(); err != nil {
-		return false, err
+		return err
 	}
 
 	attr := bpfMapCreateAttr{
@@ -421,11 +421,11 @@ var objNameAllowsDot = internal.FeatureTest("dot in object names", "5.2", func()
 
 	fd, err := bpfMapCreate(&attr)
 	if err != nil {
-		return false, nil
+		return internal.ErrNotSupported
 	}
 
 	_ = fd.Close()
-	return true, nil
+	return nil
 })
 
 func bpfObjGetFDByID(cmd internal.BPFCmd, id uint32) (*internal.FD, error) {


### PR DESCRIPTION
syscalls: simplify nested map feature test
    
    We can detect support for nested maps using a single instead of three
    syscalls.

internal: simplify FeatureTest
    
    FeatureTest requires a function that returns `(bool, error)`. The
    semantics of when to return what is a bit complicated, and difficult
    for contributors to grasp. In essence, we need to represent three
    states:
    
    * we know that the feature is available
    * we know that the feature is not available
    * we don't know either
    
    Switch FeatureTest to a `func() error`. I think this makes it easier
    to write accurate tests.
