### PR TITLE
btf: add String method to Type

### DIFF
--- a/internal/btf/types_test.go
+++ b/internal/btf/types_test.go
@@ -77,7 +77,7 @@ func ExampleType_validTypes() {
 func TestType(t *testing.T) {
 	types := []func() Type{
 		func() Type { return &Void{} },
-		func() Type { return &Int{} },
+		func() Type { return &Int{Size: 2, Bits: 3} },
 		func() Type { return &Pointer{Target: &Void{}} },
 		func() Type { return &Array{Type: &Int{}} },
 		func() Type {
@@ -118,6 +118,8 @@ func TestType(t *testing.T) {
 	for _, fn := range types {
 		typ := fn()
 		t.Run(fmt.Sprintf("%T", typ), func(t *testing.T) {
+			t.Logf("%v", typ)
+
 			if typ == typ.copy() {
 				t.Error("Copy doesn't copy")
 			}


### PR DESCRIPTION
Give types a useful printable representation:

    === RUN   TestType/*btf.Void
        types_test.go:121: void#0
    === RUN   TestType/*btf.Int
        types_test.go:121: uint16#0[bits=3]
    === RUN   TestType/*btf.Pointer
        types_test.go:121: pointer#0[target=#0]
    === RUN   TestType/*btf.Array
        types_test.go:121: array#0[type=#0 n=0]
    === RUN   TestType/*btf.Struct
        types_test.go:121: struct#0[""]
    === RUN   TestType/*btf.Union
        types_test.go:121: union#0[""]
    === RUN   TestType/*btf.Enum
        types_test.go:121: enum#0[""]
    === RUN   TestType/*btf.Fwd
        types_test.go:121: fwd#0[struct "thunk"]
    === RUN   TestType/*btf.Typedef
        types_test.go:121: typedef#0["" #0]
    === RUN   TestType/*btf.Volatile
        types_test.go:121: volatile#0[#0]
    === RUN   TestType/*btf.Const
        types_test.go:121: const#0[#0]
    === RUN   TestType/*btf.Restrict
        types_test.go:121: restrict#0[#0]
    === RUN   TestType/*btf.Func
        types_test.go:121: func#0["foo" proto=#0]
    === RUN   TestType/*btf.FuncProto
        types_test.go:121: proto#0["bar"=#0, return=#0]
    === RUN   TestType/*btf.Var
        types_test.go:121: var#0[""]
    === RUN   TestType/*btf.Datasec
        types_test.go:121: section#0[""]

The rough format is

    <type>#<type id>[<other information>].

It is intentionally different from the in-kernel BTF log output:

    [type id] <type> <name> <other>

This is intentional, since we don't know where and how a user
might embed a stringified type. A more compact format seems
better here.

We can always add a dedicated function that prints a []Type in
kernel style if we find that necessary.