### PR TITLE
CO-RE: add type / field compatibility logic

### DIFF
--- a/internal/btf/core.go
+++ b/internal/btf/core.go
@@ -1,0 +1,178 @@
+package btf
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+)
+
+// Code in this file is derived from libbpf, which is available under a BSD
+// 2-Clause license.
+
+/* The comment below is from bpf_core_types_are_compat in libbpf.c:
+ *
+ * Check local and target types for compatibility. This check is used for
+ * type-based CO-RE relocations and follow slightly different rules than
+ * field-based relocations. This function assumes that root types were already
+ * checked for name match. Beyond that initial root-level name check, names
+ * are completely ignored. Compatibility rules are as follows:
+ *   - any two STRUCTs/UNIONs/FWDs/ENUMs/INTs are considered compatible, but
+ *     kind should match for local and target types (i.e., STRUCT is not
+ *     compatible with UNION);
+ *   - for ENUMs, the size is ignored;
+ *   - for INT, size and signedness are ignored;
+ *   - for ARRAY, dimensionality is ignored, element types are checked for
+ *     compatibility recursively;
+ *   - CONST/VOLATILE/RESTRICT modifiers are ignored;
+ *   - TYPEDEFs/PTRs are compatible if types they pointing to are compatible;
+ *   - FUNC_PROTOs are compatible if they have compatible signature: same
+ *     number of input args and compatible return and argument types.
+ * These rules are not set in stone and probably will be adjusted as we get
+ * more experience with using BPF CO-RE relocations.
+ */
+func coreAreTypesCompatible(localType Type, targetType Type) (bool, error) {
+	var (
+		localTs, targetTs typeDeque
+		l, t              = &localType, &targetType
+		depth             = 0
+	)
+
+	for ; l != nil && t != nil; l, t = localTs.shift(), targetTs.shift() {
+		if depth >= maxTypeDepth {
+			return false, errors.New("types are nested too deep")
+		}
+
+		localType = skipQualifierAndTypedef(*l)
+		targetType = skipQualifierAndTypedef(*t)
+
+		if reflect.TypeOf(localType) != reflect.TypeOf(targetType) {
+			return false, nil
+		}
+
+		switch lv := (localType).(type) {
+		case *Void, *Struct, *Union, *Enum, *Fwd:
+			// Nothing to do here
+
+		case *Int:
+			tv := targetType.(*Int)
+			if lv.isBitfield() || tv.isBitfield() {
+				return false, nil
+			}
+
+		case *Pointer, *Array:
+			depth++
+			localType.walk(&localTs)
+			targetType.walk(&targetTs)
+
+		case *FuncProto:
+			tv := targetType.(*FuncProto)
+			if len(lv.Params) != len(tv.Params) {
+				return false, nil
+			}
+
+			depth++
+			localType.walk(&localTs)
+			targetType.walk(&targetTs)
+
+		default:
+			return false, fmt.Errorf("unsupported type %T", localType)
+		}
+	}
+
+	if l != nil {
+		return false, fmt.Errorf("dangling local type %T", *l)
+	}
+
+	if t != nil {
+		return false, fmt.Errorf("dangling target type %T", *t)
+	}
+
+	return true, nil
+}
+
+/* The comment below is from bpf_core_fields_are_compat in libbpf.c:
+ *
+ * Check two types for compatibility for the purpose of field access
+ * relocation. const/volatile/restrict and typedefs are skipped to ensure we
+ * are relocating semantically compatible entities:
+ *   - any two STRUCTs/UNIONs are compatible and can be mixed;
+ *   - any two FWDs are compatible, if their names match (modulo flavor suffix);
+ *   - any two PTRs are always compatible;
+ *   - for ENUMs, names should be the same (ignoring flavor suffix) or at
+ *     least one of enums should be anonymous;
+ *   - for ENUMs, check sizes, names are ignored;
+ *   - for INT, size and signedness are ignored;
+ *   - for ARRAY, dimensionality is ignored, element types are checked for
+ *     compatibility recursively;
+ *   - everything else shouldn't be ever a target of relocation.
+ * These rules are not set in stone and probably will be adjusted as we get
+ * more experience with using BPF CO-RE relocations.
+ */
+func coreAreMembersCompatible(localType Type, targetType Type) (bool, error) {
+	doNamesMatch := func(a, b string) bool {
+		if a == "" || b == "" {
+			// allow anonymous and named type to match
+			return true
+		}
+
+		return essentialName(a) == essentialName(b)
+	}
+
+	for depth := 0; depth <= maxTypeDepth; depth++ {
+		localType = skipQualifierAndTypedef(localType)
+		targetType = skipQualifierAndTypedef(targetType)
+
+		_, lok := localType.(composite)
+		_, tok := targetType.(composite)
+		if lok && tok {
+			return true, nil
+		}
+
+		if reflect.TypeOf(localType) != reflect.TypeOf(targetType) {
+			return false, nil
+		}
+
+		switch lv := localType.(type) {
+		case *Pointer:
+			return true, nil
+
+		case *Enum:
+			tv := targetType.(*Enum)
+			return doNamesMatch(lv.name(), tv.name()), nil
+
+		case *Fwd:
+			tv := targetType.(*Fwd)
+			return doNamesMatch(lv.name(), tv.name()), nil
+
+		case *Int:
+			tv := targetType.(*Int)
+			return !lv.isBitfield() && !tv.isBitfield(), nil
+
+		case *Array:
+			tv := targetType.(*Array)
+
+			localType = lv.Type
+			targetType = tv.Type
+
+		default:
+			return false, fmt.Errorf("unsupported type %T", localType)
+		}
+	}
+
+	return false, errors.New("types are nested too deep")
+}
+
+func skipQualifierAndTypedef(typ Type) Type {
+	result := typ
+	for depth := 0; depth <= maxTypeDepth; depth++ {
+		switch v := (result).(type) {
+		case qualifier:
+			result = v.qualify()
+		case *Typedef:
+			result = v.Type
+		default:
+			return result
+		}
+	}
+	return typ
+}

--- a/internal/btf/core_test.go
+++ b/internal/btf/core_test.go
@@ -1,0 +1,144 @@
+package btf
+
+import "testing"
+
+func TestCoreAreTypesCompatible(t *testing.T) {
+	tests := []struct {
+		a, b       Type
+		compatible bool
+	}{
+		{&Void{}, &Void{}, true},
+		{&Struct{Name: "a"}, &Struct{Name: "b"}, true},
+		{&Union{Name: "a"}, &Union{Name: "b"}, true},
+		{&Union{Name: "a"}, &Struct{Name: "b"}, false},
+		{&Enum{Name: "a"}, &Enum{Name: "b"}, true},
+		{&Fwd{Name: "a"}, &Fwd{Name: "b"}, true},
+		{&Int{Name: "a", Size: 2}, &Int{Name: "b", Size: 4}, true},
+		{&Int{Offset: 1}, &Int{}, false},
+		{&Pointer{Target: &Void{}}, &Pointer{Target: &Void{}}, true},
+		{&Pointer{Target: &Void{}}, &Void{}, false},
+		{&Array{Type: &Void{}}, &Array{Type: &Void{}}, true},
+		{&Array{Type: &Int{}}, &Array{Type: &Void{}}, false},
+		{&FuncProto{Return: &Int{}}, &FuncProto{Return: &Void{}}, false},
+		{
+			&FuncProto{Return: &Void{}, Params: []FuncParam{{Name: "a", Type: &Void{}}}},
+			&FuncProto{Return: &Void{}, Params: []FuncParam{{Name: "b", Type: &Void{}}}},
+			true,
+		},
+		{
+			&FuncProto{Return: &Void{}, Params: []FuncParam{{Type: &Void{}}}},
+			&FuncProto{Return: &Void{}, Params: []FuncParam{{Type: &Int{}}}},
+			false,
+		},
+		{
+			&FuncProto{Return: &Void{}, Params: []FuncParam{{Type: &Void{}}, {Type: &Void{}}}},
+			&FuncProto{Return: &Void{}, Params: []FuncParam{{Type: &Void{}}}},
+			false,
+		},
+		{&Typedef{Name: "a", Type: &Void{}}, &Void{}, true},
+		{&Typedef{Name: "a", Type: &Void{}}, &Int{}, false},
+		{&Const{Type: &Void{}}, &Void{}, true},
+		{&Const{Type: &Void{}}, &Int{}, false},
+		{&Volatile{Type: &Void{}}, &Void{}, true},
+		{&Volatile{Type: &Void{}}, &Int{}, false},
+		{&Restrict{Type: &Void{}}, &Void{}, true},
+		{&Restrict{Type: &Void{}}, &Int{}, false},
+	}
+
+	for _, test := range tests {
+		compatible, err := coreAreTypesCompatible(test.a, test.b)
+		if err != nil {
+			t.Errorf("Can't compare types: %s\na = %#v\nb = %#v", err, test.a, test.b)
+			continue
+		}
+
+		if compatible != test.compatible {
+			if test.compatible {
+				t.Errorf("Expected types to be compatible:\na = %#v\nb = %#v", test.a, test.b)
+			} else {
+				t.Errorf("Expected types to be incompatible:\na = %#v\nb = %#v", test.a, test.b)
+			}
+			continue
+		}
+
+		compatibleReverse, err := coreAreTypesCompatible(test.b, test.a)
+		if err != nil {
+			t.Errorf("Can't compare reversed types: %s\na = %#v\nb = %#v", err, test.a, test.b)
+			continue
+		}
+		if compatibleReverse != compatible {
+			t.Errorf("Expected the reverse comparison to be %v as well:\na = %#v\nb = %#v", compatible, test.a, test.b)
+		}
+	}
+
+	for _, invalid := range []Type{&Var{}, &Datasec{}} {
+		_, err := coreAreTypesCompatible(invalid, invalid)
+		if err == nil {
+			t.Errorf("Expected an error for %T", invalid)
+		}
+	}
+}
+
+func TestCoreAreMembersCompatible(t *testing.T) {
+	tests := []struct {
+		a, b       Type
+		compatible bool
+	}{
+		{&Struct{Name: "a"}, &Struct{Name: "b"}, true},
+		{&Union{Name: "a"}, &Union{Name: "b"}, true},
+		{&Union{Name: "a"}, &Struct{Name: "b"}, true},
+		{&Enum{Name: "a"}, &Enum{Name: "b"}, false},
+		{&Enum{Name: "a"}, &Enum{Name: "a___foo"}, true},
+		{&Enum{Name: "a"}, &Enum{Name: ""}, true},
+		{&Fwd{Name: "a"}, &Fwd{Name: "b"}, false},
+		{&Fwd{Name: "a"}, &Fwd{Name: "a___foo"}, true},
+		{&Fwd{Name: "a"}, &Fwd{Name: ""}, true},
+		{&Int{Name: "a", Size: 2}, &Int{Name: "b", Size: 4}, true},
+		{&Int{Offset: 1}, &Int{}, false},
+		{&Pointer{Target: &Void{}}, &Pointer{Target: &Void{}}, true},
+		{&Pointer{Target: &Void{}}, &Void{}, false},
+		{&Array{Type: &Int{}}, &Array{Type: &Int{}}, true},
+		{&Array{Type: &Int{}}, &Array{Type: &Void{}}, false},
+		{&Typedef{Name: "a", Type: &Int{}}, &Int{}, true},
+		{&Typedef{Name: "a", Type: &Int{}}, &Void{}, false},
+		{&Const{Type: &Int{}}, &Int{}, true},
+		{&Const{Type: &Int{}}, &Void{}, false},
+		{&Volatile{Type: &Int{}}, &Int{}, true},
+		{&Volatile{Type: &Int{}}, &Void{}, false},
+		{&Restrict{Type: &Int{}}, &Int{}, true},
+		{&Restrict{Type: &Int{}}, &Void{}, false},
+	}
+
+	for _, test := range tests {
+		compatible, err := coreAreMembersCompatible(test.a, test.b)
+		if err != nil {
+			t.Errorf("Can't compare types: %s\na = %#v\nb = %#v", err, test.a, test.b)
+			continue
+		}
+
+		if compatible != test.compatible {
+			if test.compatible {
+				t.Errorf("Expected types to be compatible:\na = %#v\nb = %#v", test.a, test.b)
+			} else {
+				t.Errorf("Expected types to be incompatible:\na = %#v\nb = %#v", test.a, test.b)
+			}
+			continue
+		}
+
+		compatibleReverse, err := coreAreMembersCompatible(test.b, test.a)
+		if err != nil {
+			t.Errorf("Can't compare reversed types: %s\na = %#v\nb = %#v", err, test.a, test.b)
+			continue
+		}
+		if compatibleReverse != compatible {
+			t.Errorf("Expected the reverse comparison to be %v as well:\na = %#v\nb = %#v", compatible, test.a, test.b)
+		}
+	}
+
+	for _, invalid := range []Type{&Void{}, &FuncProto{}, &Var{}, &Datasec{}} {
+		_, err := coreAreMembersCompatible(invalid, invalid)
+		if err == nil {
+			t.Errorf("Expected an error for %T", invalid)
+		}
+	}
+}

--- a/internal/btf/types.go
+++ b/internal/btf/types.go
@@ -113,6 +113,10 @@ func (i *Int) copy() Type {
 	return &cpy
 }
 
+func (i *Int) isBitfield() bool {
+	return i.Offset > 0
+}
+
 // Pointer is a pointer to another type.
 type Pointer struct {
 	TypeID

--- a/internal/btf/types_test.go
+++ b/internal/btf/types_test.go
@@ -124,15 +124,91 @@ func TestType(t *testing.T) {
 				t.Error("Copy doesn't copy")
 			}
 
-			var first, second copyStack
+			var first, second typeDeque
 			typ.walk(&first)
 			typ.walk(&second)
 
-			if diff := cmp.Diff(first, second, compareTypes); diff != "" {
+			if diff := cmp.Diff(first.all(), second.all(), compareTypes); diff != "" {
 				t.Errorf("Walk mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
+}
+
+func TestTypeDeque(t *testing.T) {
+	a, b := new(Type), new(Type)
+
+	t.Run("pop", func(t *testing.T) {
+		var td typeDeque
+		td.push(a)
+		td.push(b)
+
+		if td.pop() != b {
+			t.Error("Didn't pop b first")
+		}
+
+		if td.pop() != a {
+			t.Error("Didn't pop a second")
+		}
+
+		if td.pop() != nil {
+			t.Error("Didn't pop nil")
+		}
+	})
+
+	t.Run("shift", func(t *testing.T) {
+		var td typeDeque
+		td.push(a)
+		td.push(b)
+
+		if td.shift() != a {
+			t.Error("Didn't shift a second")
+		}
+
+		if td.shift() != b {
+			t.Error("Didn't shift b first")
+		}
+
+		if td.shift() != nil {
+			t.Error("Didn't shift nil")
+		}
+	})
+
+	t.Run("push", func(t *testing.T) {
+		var td typeDeque
+		td.push(a)
+		td.push(b)
+		td.shift()
+
+		ts := make([]Type, 12)
+		for i := range ts {
+			td.push(&ts[i])
+		}
+
+		if td.shift() != b {
+			t.Error("Didn't shift b first")
+		}
+		for i := range ts {
+			if td.shift() != &ts[i] {
+				t.Fatal("Shifted wrong Type at pos", i)
+			}
+		}
+	})
+
+	t.Run("all", func(t *testing.T) {
+		var td typeDeque
+		td.push(a)
+		td.push(b)
+
+		all := td.all()
+		if len(all) != 2 {
+			t.Fatal("Expected 2 elements, got", len(all))
+		}
+
+		if all[0] != a || all[1] != b {
+			t.Fatal("Elements don't match")
+		}
+	})
 }
 
 func newCyclicalType(n int) Type {


### PR DESCRIPTION
btf: port CO-RE relocation compatibility logic
    
    coreAreTypesCompatible will be used to figure out if a particular target
    (aka kernel) type can be substituted for a local type. coreAreMembersCompatible
    will be used to figure out if we can relocate a load from a local type with
    a load from a target type.
    
    This code is based on Bryce Kahle's CO-RE work and derived from libbpf
    under a BSD 2-Clause license.
    
Updates #114

btf: use a deque instead of a stack
    
    For some of the CO-RE algorithms it's useful to get the first *Type
    from the stack, rather than the last one. Implement a deque based on
    a resizing ring buffer and use it instead of copyStack.