### PR TITLE
link: tracepoint support

### DIFF
--- a/link/link.go
+++ b/link/link.go
@@ -14,7 +14,7 @@ var ErrNotSupported = internal.ErrNotSupported
 type Link interface {
 	// Replace the current program with a new program.
 	//
-	// Passing a nil program is an error.
+	// Passing a nil program is an error. May return an error wrapping ErrNotSupported.
 	Update(*ebpf.Program) error
 
 	// Persist a link by pinning it into a bpffs.

--- a/link/link_test.go
+++ b/link/link_test.go
@@ -131,20 +131,29 @@ func testLink(t *testing.T, link Link, opts testLinkOptions) {
 		}
 	}
 
-	if err := link.Update(opts.prog); err != nil {
-		t.Fatalf("%T.Update returns an error: %s", link, err)
-	}
-
-	func() {
-		// Panicking is OK
-		defer func() {
-			recover()
-		}()
-
-		if err := link.Update(nil); err == nil {
-			t.Fatalf("%T.Update accepts nil program", link)
+	t.Run("update", func(t *testing.T) {
+		err := link.Update(opts.prog)
+		if err == ErrNotSupported {
+			t.Fatal("Update returns unwrapped ErrNotSupported", link)
 		}
-	}()
+		if errors.Is(err, ErrNotSupported) {
+			return
+		}
+		if err != nil {
+			t.Fatal("Update returns an error:", err)
+		}
+
+		func() {
+			// Panicking is OK
+			defer func() {
+				recover()
+			}()
+
+			if err := link.Update(nil); err == nil {
+				t.Fatalf("%T.Update accepts nil program", link)
+			}
+		}()
+	})
 
 	if err := link.Close(); err != nil {
 		t.Fatalf("%T.Close returns an error: %s", link, err)

--- a/link/raw_tracepoint.go
+++ b/link/raw_tracepoint.go
@@ -18,6 +18,9 @@ type RawTracepointOptions struct {
 //
 // Requires at least Linux 4.17.
 func AttachRawTracepoint(opts RawTracepointOptions) (Link, error) {
+	if t := opts.Program.Type(); t != ebpf.RawTracepoint && t != ebpf.RawTracepointWritable {
+		return nil, fmt.Errorf("invalid program type %s, expected RawTracepoint(Writable)", t)
+	}
 	if opts.Program.FD() < 0 {
 		return nil, fmt.Errorf("invalid program: %w", internal.ErrClosedFd)
 	}

--- a/link/raw_tracepoint_test.go
+++ b/link/raw_tracepoint_test.go
@@ -33,13 +33,9 @@ func TestRawTracepoint(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if link == nil {
-		t.Fatal("no link")
-	}
-
-	if err := link.Close(); err != nil {
-		t.Fatalf("failed to close link: %v", err)
-	}
+	testLink(t, link, testLinkOptions{
+		prog: prog,
+	})
 }
 
 func TestRawTracepoint_writable(t *testing.T) {
@@ -67,11 +63,7 @@ func TestRawTracepoint_writable(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if link == nil {
-		t.Fatal("no link")
-	}
-
-	if err := link.Close(); err != nil {
-		t.Fatalf("failed to close link: %v", err)
-	}
+	testLink(t, link, testLinkOptions{
+		prog: prog,
+	})
 }

--- a/link/tracepoint.go
+++ b/link/tracepoint.go
@@ -1,0 +1,105 @@
+package link
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/internal"
+	"golang.org/x/sys/unix"
+)
+
+type TracepointOptions struct {
+	// Tracepoint name.
+	Name string
+	// Program must be of type TracePoint
+	Program *ebpf.Program
+}
+
+// tracepoint is a perf event based tracepoint.
+type tracepoint struct {
+	fd *internal.FD
+}
+
+// AttachTracepoint attaches a program to a perf event based tracepoint.
+func AttachTracepoint(opts TracepointOptions) (Link, error) {
+	tid, err := getTracepointID(opts.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	attr := unix.PerfEventAttr{
+		Type:        unix.PERF_TYPE_TRACEPOINT,
+		Config:      tid,
+		Sample_type: unix.PERF_SAMPLE_RAW,
+		Sample:      1,
+		Wakeup:      1,
+	}
+	pfd, err := unix.PerfEventOpen(&attr, -1, 0, -1, unix.PERF_FLAG_FD_CLOEXEC)
+	if err != nil {
+		return nil, fmt.Errorf("open perf event: %s", err)
+	}
+
+	if err := unix.IoctlSetInt(pfd, unix.PERF_EVENT_IOC_ENABLE, 0); err != nil {
+		unix.Close(pfd)
+		return nil, fmt.Errorf("enable perf event: %s", err)
+	}
+
+	tp := &tracepoint{internal.NewFD(uint32(pfd))}
+	if err := tp.Update(opts.Program); err != nil {
+		tp.Close()
+		return nil, err
+	}
+
+	return tp, nil
+}
+
+func (tp *tracepoint) isLink() {}
+
+func (tp *tracepoint) Pin(string) error {
+	return fmt.Errorf("pin tracepoint: %w", ErrNotSupported)
+}
+
+func (tp *tracepoint) Update(prog *ebpf.Program) error {
+	if t := prog.Type(); t != ebpf.TracePoint {
+		return fmt.Errorf("invalid program type %s", t)
+	}
+	if prog.FD() < 0 {
+		return fmt.Errorf("invalid program: %w", internal.ErrClosedFd)
+	}
+
+	pfd, err := tp.fd.Value()
+	if err != nil {
+		return fmt.Errorf("tracepoint fd: %s", err)
+	}
+
+	err = unix.IoctlSetInt(int(pfd), unix.PERF_EVENT_IOC_SET_BPF, prog.FD())
+	if err != nil {
+		return fmt.Errorf("update tracepoint: %s", err)
+	}
+	return nil
+}
+
+// Close disables the tracepoint.
+func (tp *tracepoint) Close() error {
+	return tp.fd.Close()
+}
+
+func getTracepointID(name string) (uint64, error) {
+	// Prevent directory traversal attacks
+	path := filepath.Join("/", name)
+	path = filepath.Join("/sys/kernel/debug/tracing/events", path, "id")
+	data, err := ioutil.ReadFile(path)
+	if os.IsNotExist(err) {
+		return 0, fmt.Errorf("tracepoint %q: %w", name, ErrNotSupported)
+	}
+	if err != nil {
+		return 0, fmt.Errorf("read tracepoint ID of %q: %s", name, err)
+	}
+	tid := strings.TrimSuffix(string(data), "\n")
+	return strconv.ParseUint(tid, 10, 64)
+}

--- a/link/tracepoint_test.go
+++ b/link/tracepoint_test.go
@@ -1,0 +1,52 @@
+package link
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/asm"
+	"github.com/cilium/ebpf/internal"
+	"github.com/cilium/ebpf/internal/testutils"
+)
+
+func TestGetTracepointID(t *testing.T) {
+	_, err := getTracepointID("syscalls/sys_enter_open")
+	if err != nil {
+		t.Fatal("Can't read tracepoint ID:", err)
+	}
+
+	_, err = getTracepointID("totally_bogus")
+	if !errors.Is(err, internal.ErrNotSupported) {
+		t.Fatal("Doesn't return ErrNotSupported")
+	}
+}
+
+func TestAttachTracepoint(t *testing.T) {
+	prog, err := ebpf.NewProgram(&ebpf.ProgramSpec{
+		Type:    ebpf.TracePoint,
+		License: "MIT",
+		Instructions: asm.Instructions{
+			// set exit code to 0
+			asm.Mov.Imm(asm.R0, 0),
+			asm.Return(),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer prog.Close()
+
+	tp, err := AttachTracepoint(TracepointOptions{
+		Name:    "syscalls/sys_enter_open",
+		Program: prog,
+	})
+	testutils.SkipIfNotSupported(t, err)
+	if err != nil {
+		t.Fatal("Can't attach program:", err)
+	}
+
+	if err := tp.Close(); err != nil {
+		t.Error("Closing the tracepoint returns an error:", err)
+	}
+}

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -9,6 +9,7 @@ if [[ "${1:-}" = "--in-vm" ]]; then
   shift
 
   mount -t bpf bpf /sys/fs/bpf
+  mount -t tracefs tracefs /sys/kernel/debug/tracing
   export CGO_ENABLED=0
   export GOFLAGS=-mod=readonly
   export GOPATH=/run/go-path


### PR DESCRIPTION
link: add perf event tracepoint support
    
    Allow attaching to perf event fd based tracepoints (which are
    different than raw tracepoints).
    
    Fixes #83

link: check program type for raw tracepoints
    
    Return a more useful error message when passing a program with
    the wrong type. This is especially useful here because it's
    easy to mix up tracepoints and raw tracepoints.

link: allow Update to return ErrNotSupported
    
    Raw tracepoints don't allow updating the program, yet they use
    the bpf_link infrastructure. Allow Update to return ErrNotSupported
    for that reason.