### PR TITLE
raw tracepoint cleanups

### DIFF
--- a/link/link.go
+++ b/link/link.go
@@ -14,7 +14,7 @@ var ErrNotSupported = internal.ErrNotSupported
 type Link interface {
 	// Replace the current program with a new program.
 	//
-	// Passing a nil program is an error.
+	// Passing a nil program is an error. May return an error wrapping ErrNotSupported.
 	Update(*ebpf.Program) error
 
 	// Persist a link by pinning it into a bpffs.

--- a/link/link_test.go
+++ b/link/link_test.go
@@ -131,20 +131,29 @@ func testLink(t *testing.T, link Link, opts testLinkOptions) {
 		}
 	}
 
-	if err := link.Update(opts.prog); err != nil {
-		t.Fatalf("%T.Update returns an error: %s", link, err)
-	}
-
-	func() {
-		// Panicking is OK
-		defer func() {
-			recover()
-		}()
-
-		if err := link.Update(nil); err == nil {
-			t.Fatalf("%T.Update accepts nil program", link)
+	t.Run("update", func(t *testing.T) {
+		err := link.Update(opts.prog)
+		if err == ErrNotSupported {
+			t.Fatal("Update returns unwrapped ErrNotSupported", link)
 		}
-	}()
+		if errors.Is(err, ErrNotSupported) {
+			return
+		}
+		if err != nil {
+			t.Fatal("Update returns an error:", err)
+		}
+
+		func() {
+			// Panicking is OK
+			defer func() {
+				recover()
+			}()
+
+			if err := link.Update(nil); err == nil {
+				t.Fatalf("%T.Update accepts nil program", link)
+			}
+		}()
+	})
 
 	if err := link.Close(); err != nil {
 		t.Fatalf("%T.Close returns an error: %s", link, err)

--- a/link/raw_tracepoint.go
+++ b/link/raw_tracepoint.go
@@ -18,6 +18,9 @@ type RawTracepointOptions struct {
 //
 // Requires at least Linux 4.17.
 func AttachRawTracepoint(opts RawTracepointOptions) (Link, error) {
+	if t := opts.Program.Type(); t != ebpf.RawTracepoint && t != ebpf.RawTracepointWritable {
+		return nil, fmt.Errorf("invalid program type %s, expected RawTracepoint(Writable)", t)
+	}
 	if opts.Program.FD() < 0 {
 		return nil, fmt.Errorf("invalid program: %w", internal.ErrClosedFd)
 	}

--- a/link/raw_tracepoint_test.go
+++ b/link/raw_tracepoint_test.go
@@ -33,13 +33,9 @@ func TestRawTracepoint(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if link == nil {
-		t.Fatal("no link")
-	}
-
-	if err := link.Close(); err != nil {
-		t.Fatalf("failed to close link: %v", err)
-	}
+	testLink(t, link, testLinkOptions{
+		prog: prog,
+	})
 }
 
 func TestRawTracepoint_writable(t *testing.T) {
@@ -67,11 +63,7 @@ func TestRawTracepoint_writable(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if link == nil {
-		t.Fatal("no link")
-	}
-
-	if err := link.Close(); err != nil {
-		t.Fatalf("failed to close link: %v", err)
-	}
+	testLink(t, link, testLinkOptions{
+		prog: prog,
+	})
 }


### PR DESCRIPTION
link: check program type for raw tracepoints
    
    Return a more useful error message when passing a program with
    the wrong type. This is especially useful here because it's
    easy to mix up tracepoints and raw tracepoints.

link: allow Update to return ErrNotSupported
    
    Raw tracepoints don't allow updating the program, yet they use
    the bpf_link infrastructure. Allow Update to return ErrNotSupported
    for that reason.