### PR TITLE
Fix little endian conversion of ETH_P_ALL in example

### DIFF
--- a/example_sock_elf_test.go
+++ b/example_sock_elf_test.go
@@ -150,7 +150,7 @@ func openRawSock(index int) (int, error) {
 	}
 	sll := syscall.SockaddrLinklayer{
 		Ifindex:  index,
-		Protocol: htons(ETH_P_ALL),
+		Protocol: htons(syscall.ETH_P_ALL),
 	}
 	if err := syscall.Bind(sock, &sll); err != nil {
 		return 0, err

--- a/example_sock_elf_test.go
+++ b/example_sock_elf_test.go
@@ -4,10 +4,12 @@ package ebpf_test
 
 import (
 	"bytes"
+	"encoding/binary"
 	"flag"
 	"fmt"
 	"syscall"
 	"time"
+	"unsafe"
 
 	"github.com/cilium/ebpf"
 )
@@ -142,17 +144,23 @@ func Example_socketELF() {
 }
 
 func openRawSock(index int) (int, error) {
-	// network byte order representation of ETH_P_ALL
-	const ETH_P_ALL uint16 = 0x03 << 8
-	sock, err := syscall.Socket(syscall.AF_PACKET, syscall.SOCK_RAW|syscall.SOCK_NONBLOCK|syscall.SOCK_CLOEXEC, int(ETH_P_ALL))
+	sock, err := syscall.Socket(syscall.AF_PACKET, syscall.SOCK_RAW|syscall.SOCK_NONBLOCK|syscall.SOCK_CLOEXEC, int(htons(syscall.ETH_P_ALL)))
 	if err != nil {
 		return 0, err
 	}
-	sll := syscall.SockaddrLinklayer{}
-	sll.Protocol = ETH_P_ALL
-	sll.Ifindex = index
+	sll := syscall.SockaddrLinklayer{
+		Ifindex:  index,
+		Protocol: htons(ETH_P_ALL),
+	}
 	if err := syscall.Bind(sock, &sll); err != nil {
 		return 0, err
 	}
 	return sock, nil
+}
+
+// htons converts the unsigned short integer hostshort from host byte order to network byte order.
+func htons(i uint16) uint16 {
+	b := make([]byte, 2)
+	binary.BigEndian.PutUint16(b, i)
+	return *(*uint16)(unsafe.Pointer(&b[0]))
 }

--- a/example_sock_elf_test.go
+++ b/example_sock_elf_test.go
@@ -142,7 +142,8 @@ func Example_socketELF() {
 }
 
 func openRawSock(index int) (int, error) {
-	const ETH_P_ALL uint16 = 0x00<<8 | 0x03
+	// network byte order representation of ETH_P_ALL
+	const ETH_P_ALL uint16 = 0x03 << 8
 	sock, err := syscall.Socket(syscall.AF_PACKET, syscall.SOCK_RAW|syscall.SOCK_NONBLOCK|syscall.SOCK_CLOEXEC, int(ETH_P_ALL))
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
Hi, congratulations on the cool project!

I was taking a look at the examples and (unless I'm missed something :-)), I think I found a bug. The logic for the network byte order conversion of  ETH_P_ALL does not seem to be good in `example_sock_elf_test.go`.