### PR TITLE
Kprobe compile 

### DIFF
--- a/cmd/bpf2go/compile.go
+++ b/cmd/bpf2go/compile.go
@@ -17,17 +17,17 @@ type compileArgs struct {
 	cc     string
 	cFlags []string
 	// Absolute working directory
-	dir    string
+	dir string
 	// Absolute input file name
 	source string
 	// Absolute output file name
-	dest   string
+	dest string
 	// Depfile will be written here if depName is not empty
-	dep    io.Writer
+	dep io.Writer
 	// Pipe through llc?
 	usellc bool
 	// Which system compiler to use
-	llc    string
+	llc string
 	// Binary target
 	target string
 }
@@ -54,7 +54,7 @@ func compile(args compileArgs) error {
 	)
 
 	if args.usellc {
-		cmd.Args = append(cmd.Args, "-o", fmt.Sprintf("%s.llvm", args.dest) )
+		cmd.Args = append(cmd.Args, "-o", fmt.Sprintf("%s.llvm", args.dest))
 	} else {
 		cmd.Args = append(cmd.Args, "-o", args.dest)
 	}
@@ -100,13 +100,13 @@ func compile(args compileArgs) error {
 	// Need to llc system compiler to generate object code
 	if args.usellc {
 		var llc_args []string
-		llc_args = append(llc_args, fmt.Sprintf("-march=%s", args.target), "-filetype=obj", "-o", args.dest, fmt.Sprintf("%s.llvm", args.dest) )
+		llc_args = append(llc_args, fmt.Sprintf("-march=%s", args.target), "-filetype=obj", "-o", args.dest, fmt.Sprintf("%s.llvm", args.dest))
 		cmdllc := exec.Command(args.llc, llc_args...)
 		cmdllc.Stderr = os.Stderr
 		if err := cmdllc.Start(); err != nil {
 			return fmt.Errorf("can't execute %s: %s", args.llc, err)
 		}
-		if err := cmd.Wait(); err != nil {
+		if err := cmdllc.Wait(); err != nil {
 			return fmt.Errorf("%s: %s", args.llc, err)
 		}
 

--- a/cmd/bpf2go/compile_test.go
+++ b/cmd/bpf2go/compile_test.go
@@ -51,14 +51,14 @@ func TestCompileKprobe(t *testing.T) {
 
 	var dep bytes.Buffer
 	err := compile(compileArgs{
-		cc:     "clang-10",
+		cc:     "clang-9",
 		dir:    dir,
 		source: filepath.Join(dir, "test.c"),
 		dest:   filepath.Join(dir, "test.o"),
 		dep:    &dep,
 		usellc: true,
-		cFlags: []string{"-emit-llvm"},
-		llc:    "llc-10",
+		cFlags: []string{"-O2", "-emit-llvm"}, // This is odd, but clang-9 crashes without the optimize
+		llc:    "llc-9",
 		target: "bpfeb",
 	})
 	if err != nil {

--- a/cmd/bpf2go/compile_test.go
+++ b/cmd/bpf2go/compile_test.go
@@ -22,6 +22,7 @@ func TestCompile(t *testing.T) {
 		source: filepath.Join(dir, "test.c"),
 		dest:   filepath.Join(dir, "test.o"),
 		dep:    &dep,
+		usellc: false,
 	})
 	if err != nil {
 		t.Fatal("Can't compile:", err)

--- a/cmd/bpf2go/main.go
+++ b/cmd/bpf2go/main.go
@@ -49,6 +49,8 @@ func run(stdout io.Writer, pkg, outputDir string, args []string) (err error) {
 		flagTags     = fs.String("tags", "", "list of Go build tags to include in generated files")
 		flagTarget   = fs.String("target", "", "clang target to compile for (bpf, bpfel, bpfeb)")
 		flagMakeBase = fs.String("makebase", "", "write make compatible depinfo files relative to `directory`")
+		flagKprobe   = fs.Bool("buildkprobe", true, "compile a kprobe with clang incompatible headers")
+		flagLlc      = fs.String("llc", "llc", "name of llvm system compiler to use for kprobes")
 	)
 
 	fs.SetOutput(stdout)
@@ -147,14 +149,35 @@ func run(stdout io.Writer, pkg, outputDir string, args []string) (err error) {
 		objFileName = filepath.Join(outputDir, objFileName)
 
 		var dep bytes.Buffer
-		err = compile(compileArgs{
-			cc:     *flagCC,
-			cFlags: append(cFlags, "-target", target),
-			dir:    cwd,
-			source: inputDir + inputFile,
-			dest:   objFileName,
-			dep:    &dep,
-		})
+		var compile_args compileArgs
+		if *flagKprobe {
+			compile_args =
+				compileArgs{
+					cc:     *flagCC,
+					cFlags: append(cFlags, "-emit-llvm"),
+					dir:    cwd,
+					source: inputDir + inputFile,
+					dest:   objFileName,
+					dep:    &dep,
+					usellc: *flagKprobe,
+					llc:    *flagLlc,
+					target: target,
+				}
+		} else {
+			compile_args = compileArgs{
+				cc:     *flagCC,
+				cFlags: append(cFlags, "-target", target),
+				dir:    cwd,
+				source: inputDir + inputFile,
+				dest:   objFileName,
+				dep:    &dep,
+				usellc: *flagKprobe,
+				llc:    *flagLlc,
+				target: target,
+			}
+		}
+
+		err = compile(compile_args)
 		if err != nil {
 			return err
 		}

--- a/cmd/bpf2go/main.go
+++ b/cmd/bpf2go/main.go
@@ -49,7 +49,7 @@ func run(stdout io.Writer, pkg, outputDir string, args []string) (err error) {
 		flagTags     = fs.String("tags", "", "list of Go build tags to include in generated files")
 		flagTarget   = fs.String("target", "", "clang target to compile for (bpf, bpfel, bpfeb)")
 		flagMakeBase = fs.String("makebase", "", "write make compatible depinfo files relative to `directory`")
-		flagKprobe   = fs.Bool("buildkprobe", true, "compile a kprobe with clang incompatible headers")
+		flagKprobe   = fs.Bool("buildkprobe", false, "compile a kprobe with clang incompatible headers")
 		flagLlc      = fs.String("llc", "llc", "name of llvm system compiler to use for kprobes")
 	)
 


### PR DESCRIPTION
Work in progress to add the ability to compile kprobe type bpf programs.

Compiling to object code with clang get's hung up on the assembly macros in the kernel headers, but if we emit-llvm and then do a second pass with llc it seems to work.  This seems like a workaround for something in the compiler.   My bpf programs are working though.



