### PR TITLE
Test on 5.10

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -27,12 +27,14 @@ blocks:
           - GOOS=darwin go build ./... && for p in $(go list ./...) ; do GOOS=darwin go test -c $p ; done
           - GOARCH=arm GOARM=6 go build ./... && for p in $(go list ./...) ; do GOARCH=arm GOARM=6 go test -c $p ; done
           - GOARCH=arm64 go build ./... && for p in $(go list ./...) ; do GOARCH=arm64 go test -c $p ; done
+      - name: Run unit tests on previous stable Go
+        commands:
+          - sem-version go 1.14
+          - timeout -s KILL 600s ./run-tests.sh 5.10
       - name: Run unit tests
         matrix:
-          - env_var: GO_VERSION
-            values: [ "1.14", "1.15" ]
           - env_var: KERNEL_VERSION
-            values: ["5.9", "5.4", "4.19", "4.9"]
+            values: ["5.10", "5.9", "5.4", "4.19", "4.9"]
         commands:
-          - sem-version go $GO_VERSION
+          - sem-version go 1.15
           - timeout -s KILL 600s ./run-tests.sh $KERNEL_VERSION

--- a/internal/btf/btf.go
+++ b/internal/btf/btf.go
@@ -315,7 +315,7 @@ func fixupDatasec(rawTypes []rawType, rawStrings stringTable, sectionSizes map[s
 			return err
 		}
 
-		if name == ".kconfig" || name == ".ksym" {
+		if name == ".kconfig" || name == ".ksyms" {
 			return fmt.Errorf("reference to %s: %w", name, ErrNotSupported)
 		}
 


### PR DESCRIPTION
Test on the new stable 5.10 kernel. Cut down on CI times by not
testing the full Go version x Linux version matrix. Instead,
test the latest kernel on the old Go version only.