### PR TITLE
btf: delay loading and handle EPERM

### DIFF
--- a/map.go
+++ b/map.go
@@ -166,19 +166,13 @@ func NewMap(spec *MapSpec) (*Map, error) {
 // sufficiently high for locking memory during map creation. This can be done
 // by calling unix.Setrlimit with unix.RLIMIT_MEMLOCK prior to calling NewMapWithOptions.
 func NewMapWithOptions(spec *MapSpec, opts MapOptions) (*Map, error) {
-	if spec.BTF == nil {
-		return newMapWithBTF(spec, nil, opts)
-	}
+	btfs := make(btfHandleCache)
+	defer btfs.close()
 
-	handle, err := btf.NewHandle(btf.MapSpec(spec.BTF))
-	if err != nil && !errors.Is(err, btf.ErrNotSupported) {
-		return nil, fmt.Errorf("can't load BTF: %w", err)
-	}
-
-	return newMapWithBTF(spec, handle, opts)
+	return newMapWithOptions(spec, opts, btfs)
 }
 
-func newMapWithBTF(spec *MapSpec, handle *btf.Handle, opts MapOptions) (*Map, error) {
+func newMapWithOptions(spec *MapSpec, opts MapOptions, btfs btfHandleCache) (*Map, error) {
 	switch spec.Pinning {
 	case PinByName:
 		if spec.Name == "" || opts.PinPath == "" {
@@ -213,7 +207,7 @@ func newMapWithBTF(spec *MapSpec, handle *btf.Handle, opts MapOptions) (*Map, er
 			return nil, fmt.Errorf("%s requires InnerMap", spec.Type)
 		}
 
-		template, err := createMap(spec.InnerMap, nil, handle, opts)
+		template, err := createMap(spec.InnerMap, nil, opts, btfs)
 		if err != nil {
 			return nil, err
 		}
@@ -222,7 +216,7 @@ func newMapWithBTF(spec *MapSpec, handle *btf.Handle, opts MapOptions) (*Map, er
 		innerFd = template.fd
 	}
 
-	m, err := createMap(spec, innerFd, handle, opts)
+	m, err := createMap(spec, innerFd, opts, btfs)
 	if err != nil {
 		return nil, err
 	}
@@ -237,7 +231,7 @@ func newMapWithBTF(spec *MapSpec, handle *btf.Handle, opts MapOptions) (*Map, er
 	return m, nil
 }
 
-func createMap(spec *MapSpec, inner *internal.FD, handle *btf.Handle, opts MapOptions) (_ *Map, err error) {
+func createMap(spec *MapSpec, inner *internal.FD, opts MapOptions, btfs btfHandleCache) (_ *Map, err error) {
 	closeOnError := func(closer io.Closer) {
 		if err != nil {
 			closer.Close()
@@ -302,20 +296,32 @@ func createMap(spec *MapSpec, inner *internal.FD, handle *btf.Handle, opts MapOp
 		}
 	}
 
-	if handle != nil && spec.BTF != nil {
-		attr.btfFd = uint32(handle.FD())
-		attr.btfKeyTypeID = btf.MapKey(spec.BTF).ID()
-		attr.btfValueTypeID = btf.MapValue(spec.BTF).ID()
-	}
-
 	if haveObjName() == nil {
 		attr.mapName = newBPFObjName(spec.Name)
+	}
+
+	var btfDisabled bool
+	if spec.BTF != nil {
+		handle, err := btfs.load(btf.MapSpec(spec.BTF))
+		btfDisabled = errors.Is(err, btf.ErrNotSupported)
+		if err != nil && !btfDisabled {
+			return nil, fmt.Errorf("load BTF: %w", err)
+		}
+
+		if handle != nil {
+			attr.btfFd = uint32(handle.FD())
+			attr.btfKeyTypeID = btf.MapKey(spec.BTF).ID()
+			attr.btfValueTypeID = btf.MapValue(spec.BTF).ID()
+		}
 	}
 
 	fd, err := bpfMapCreate(&attr)
 	if err != nil {
 		if errors.Is(err, unix.EPERM) {
 			return nil, fmt.Errorf("map create: RLIMIT_MEMLOCK may be too low: %w", err)
+		}
+		if btfDisabled {
+			return nil, fmt.Errorf("map create without BTF: %w", err)
 		}
 		return nil, fmt.Errorf("map create: %w", err)
 	}

--- a/map_test.go
+++ b/map_test.go
@@ -13,6 +13,7 @@ import (
 	"unsafe"
 
 	"github.com/cilium/ebpf/internal"
+	"github.com/cilium/ebpf/internal/btf"
 	"github.com/cilium/ebpf/internal/testutils"
 	"github.com/cilium/ebpf/internal/unix"
 )
@@ -829,6 +830,11 @@ func TestMapPinning(t *testing.T) {
 	if err := m1.Put(uint32(0), uint32(42)); err != nil {
 		t.Fatal("Can't write value:", err)
 	}
+
+	// This is a terrible hack: if loading a pinned map tries to load BTF,
+	// it will get a nil *btf.Spec from this *btf.Map. This is turn will make
+	// btf.NewHandle fail.
+	spec.BTF = new(btf.Map)
 
 	m2, err := NewMapWithOptions(spec, MapOptions{PinPath: tmp})
 	if err != nil {

--- a/prog.go
+++ b/prog.go
@@ -121,19 +121,13 @@ func NewProgram(spec *ProgramSpec) (*Program, error) {
 // Loading a program for the first time will perform
 // feature detection by loading small, temporary programs.
 func NewProgramWithOptions(spec *ProgramSpec, opts ProgramOptions) (*Program, error) {
-	if spec.BTF == nil {
-		return newProgramWithBTF(spec, nil, opts)
-	}
+	btfs := make(btfHandleCache)
+	defer btfs.close()
 
-	handle, err := btf.NewHandle(btf.ProgramSpec(spec.BTF))
-	if err != nil && !errors.Is(err, btf.ErrNotSupported) {
-		return nil, fmt.Errorf("can't load BTF: %w", err)
-	}
-
-	return newProgramWithBTF(spec, handle, opts)
+	return newProgramWithOptions(spec, opts, btfs)
 }
 
-func newProgramWithBTF(spec *ProgramSpec, handle *btf.Handle, opts ProgramOptions) (*Program, error) {
+func newProgramWithOptions(spec *ProgramSpec, opts ProgramOptions, btfs btfHandleCache) (*Program, error) {
 	if len(spec.Instructions) == 0 {
 		return nil, errors.New("Instructions cannot be empty")
 	}
@@ -174,24 +168,33 @@ func newProgramWithBTF(spec *ProgramSpec, handle *btf.Handle, opts ProgramOption
 		attr.progName = newBPFObjName(spec.Name)
 	}
 
-	if handle != nil && spec.BTF != nil {
-		attr.progBTFFd = uint32(handle.FD())
-
-		recSize, bytes, err := btf.ProgramLineInfos(spec.BTF)
-		if err != nil {
-			return nil, fmt.Errorf("can't get BTF line infos: %w", err)
+	var btfDisabled bool
+	if spec.BTF != nil {
+		handle, err := btfs.load(btf.ProgramSpec(spec.BTF))
+		btfDisabled = errors.Is(err, btf.ErrNotSupported)
+		if err != nil && !btfDisabled {
+			return nil, fmt.Errorf("load BTF: %w", err)
 		}
-		attr.lineInfoRecSize = recSize
-		attr.lineInfoCnt = uint32(uint64(len(bytes)) / uint64(recSize))
-		attr.lineInfo = internal.NewSlicePointer(bytes)
 
-		recSize, bytes, err = btf.ProgramFuncInfos(spec.BTF)
-		if err != nil {
-			return nil, fmt.Errorf("can't get BTF function infos: %w", err)
+		if handle != nil {
+			attr.progBTFFd = uint32(handle.FD())
+
+			recSize, bytes, err := btf.ProgramLineInfos(spec.BTF)
+			if err != nil {
+				return nil, fmt.Errorf("get BTF line infos: %w", err)
+			}
+			attr.lineInfoRecSize = recSize
+			attr.lineInfoCnt = uint32(uint64(len(bytes)) / uint64(recSize))
+			attr.lineInfo = internal.NewSlicePointer(bytes)
+
+			recSize, bytes, err = btf.ProgramFuncInfos(spec.BTF)
+			if err != nil {
+				return nil, fmt.Errorf("get BTF function infos: %w", err)
+			}
+			attr.funcInfoRecSize = recSize
+			attr.funcInfoCnt = uint32(uint64(len(bytes)) / uint64(recSize))
+			attr.funcInfo = internal.NewSlicePointer(bytes)
 		}
-		attr.funcInfoRecSize = recSize
-		attr.funcInfoCnt = uint32(uint64(len(bytes)) / uint64(recSize))
-		attr.funcInfo = internal.NewSlicePointer(bytes)
 	}
 
 	if spec.AttachTo != "" {
@@ -240,6 +243,9 @@ func newProgramWithBTF(spec *ProgramSpec, handle *btf.Handle, opts ProgramOption
 	}
 
 	err = internal.ErrorWithLog(err, logBuf, logErr)
+	if btfDisabled {
+		return nil, fmt.Errorf("load program without BTF: %w", err)
+	}
 	return nil, fmt.Errorf("load program: %w", err)
 }
 


### PR DESCRIPTION
map, program: delay loading BTF as long as possible
    
    We currently try to load BTF into the kernel even when re-using a pinned
    map. Instead, load BTF only when it is really required. This also fixes
    "leaking" btf.Handle when directly creating a map with BTF via
    NewMapWithOptions.

btf: treat EPERM as unsupported during feature detection
    
    Loading an unprivileged socket filter that has been compiled with
    debug info enabled fails since the BTF feature test returns EPERM.
    However, the socket filter would work just fine without BTF enabled.
    Treat EPERM in the BTF feature test to mean not supported.
    
    This is a two edged sword: EPERM can be a transient condition, e.g.
    a process may drop capabilities after executing haveBTF. It's not
    clear to me whether this happens in practice. Since the library
    will return EPERM in that case we'll hopefully get a bug report.
