### PR TITLE
map: Add a method to Unpin maps

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/cilium/ebpf
 go 1.15
 
 require (
+	github.com/frankban/quicktest v1.11.3
 	github.com/google/go-cmp v0.5.4
 	golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,12 @@
+github.com/frankban/quicktest v1.11.3 h1:8sXhOn0uLys67V8EsXLc6eszDs8VXWxL3iRvebPhedY=
+github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM0I9ntUbOk+k=
 github.com/google/go-cmp v0.5.4 h1:L8R9j+yAqZuZjsqh/z+F1NCffTKKLShY6zXTItVIZ8M=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
+github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
+github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
+github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 golang.org/x/sys v0.0.0-20200124204421-9fbb57f87de9 h1:1/DFK4b7JH8DmkqhUk48onnSfrPzImPoVxuomtbT2nk=
 golang.org/x/sys v0.0.0-20200124204421-9fbb57f87de9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c h1:VwygUrnw9jn88c4u8GD3rZQbqrP/tgas88tPUbBxQrk=

--- a/map.go
+++ b/map.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -125,6 +126,7 @@ type Map struct {
 	valueSize  uint32
 	maxEntries uint32
 	flags      uint32
+	pinnedPath string
 	// Per CPU maps return values larger than the size in the spec
 	fullValueSize int
 }
@@ -354,6 +356,7 @@ func newMap(fd *internal.FD, name string, typ MapType, keySize, valueSize, maxEn
 		valueSize,
 		maxEntries,
 		flags,
+		"",
 		int(valueSize),
 	}
 
@@ -618,6 +621,7 @@ func (m *Map) FD() int {
 //
 // Closing the duplicate does not affect the original, and vice versa.
 // Changes made to the map are reflected by both instances however.
+// If the original map was pinned, the cloned map will not be pinned by default.
 //
 // Cloning a nil Map returns nil.
 func (m *Map) Clone() (*Map, error) {
@@ -638,15 +642,63 @@ func (m *Map) Clone() (*Map, error) {
 		m.valueSize,
 		m.maxEntries,
 		m.flags,
+		"",
 		m.fullValueSize,
 	}, nil
 }
 
 // Pin persists the map past the lifetime of the process that created it.
 //
+// Calling Pin on a previously pinned map will override the path.
+// You can Clone a map to pin it to a different path.
+//
 // This requires bpffs to be mounted above fileName. See https://docs.cilium.io/en/k8s-doc/admin/#admin-mount-bpffs
 func (m *Map) Pin(fileName string) error {
-	return internal.BPFObjPin(fileName, m.fd)
+	if fileName == "" {
+		return fmt.Errorf("pinned path cannot be empty")
+	}
+	if m.IsPinned() {
+		path := m.pinnedPath
+		if path == fileName {
+			return nil
+		}
+		if err := os.Rename(m.pinnedPath, fileName); err != nil {
+			if !os.IsNotExist(err) {
+				return fmt.Errorf("unable to pin the map at new path %v: %w", fileName, err)
+			}
+		} else {
+			m.pinnedPath = fileName
+			return nil
+		}
+	}
+	err := internal.BPFObjPin(fileName, m.fd)
+	if err == nil {
+		m.pinnedPath = fileName
+	}
+	return err
+}
+
+// Unpin removes the persisted state for the map.
+//
+// Unpinning an un-pinned Map returns nil.
+func (m *Map) Unpin() error {
+	if m.pinnedPath == "" {
+		return nil
+	}
+	err := os.Remove(m.pinnedPath)
+	if err == nil || os.IsNotExist(err) {
+		m.pinnedPath = ""
+		return nil
+	}
+	return err
+}
+
+// IsPinned returns true if the map has non-empty pinned path.
+func (m *Map) IsPinned() bool {
+	if m.pinnedPath == "" {
+		return false
+	}
+	return true
 }
 
 // Freeze prevents a map to be modified from user space.
@@ -789,7 +841,12 @@ func LoadPinnedMap(fileName string) (*Map, error) {
 		return nil, err
 	}
 
-	return newMapFromFD(fd)
+	m, err := newMapFromFD(fd)
+	if err == nil {
+		m.pinnedPath = fileName
+	}
+
+	return m, err
 }
 
 // unmarshalMap creates a map from a map ID encoded in host endianness.

--- a/map_test.go
+++ b/map_test.go
@@ -16,6 +16,19 @@ import (
 	"github.com/cilium/ebpf/internal/btf"
 	"github.com/cilium/ebpf/internal/testutils"
 	"github.com/cilium/ebpf/internal/unix"
+
+	qt "github.com/frankban/quicktest"
+)
+
+var (
+	spec1 = &MapSpec{
+		Name:       "foo",
+		Type:       Hash,
+		KeySize:    4,
+		ValueSize:  4,
+		MaxEntries: 1,
+		Pinning:    PinByName,
+	}
 )
 
 func TestMain(m *testing.M) {
@@ -97,6 +110,7 @@ func TestMapCloneNil(t *testing.T) {
 
 func TestMapPin(t *testing.T) {
 	m := createArray(t)
+	c := qt.New(t)
 	defer m.Close()
 
 	if err := m.Put(uint32(0), uint32(42)); err != nil {
@@ -113,6 +127,10 @@ func TestMapPin(t *testing.T) {
 	if err := m.Pin(path); err != nil {
 		t.Fatal(err)
 	}
+
+	pinned := m.IsPinned()
+	c.Assert(pinned, qt.Equals, true)
+
 	m.Close()
 
 	m, err := LoadPinnedMap(path)
@@ -166,6 +184,110 @@ func TestNestedMapPin(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer m.Close()
+}
+
+func TestMapPinMultiple(t *testing.T) {
+	tmp := tempBPFFS(t)
+	c := qt.New(t)
+
+	spec := spec1.Copy()
+
+	m1, err := NewMapWithOptions(spec, MapOptions{PinPath: tmp})
+	if err != nil {
+		t.Fatal("Can't create map:", err)
+	}
+	defer m1.Close()
+	pinned := m1.IsPinned()
+	c.Assert(pinned, qt.Equals, true)
+
+	newPath := filepath.Join(tmp, "bar")
+	err = m1.Pin(newPath)
+	c.Assert(err, qt.IsNil)
+	oldPath := filepath.Join(tmp, spec.Name)
+	if _, err := os.Stat(oldPath); err == nil {
+		t.Fatal("Previous pinned map path still exists:", err)
+	}
+	m2, err := LoadPinnedMap(newPath)
+	c.Assert(err, qt.IsNil)
+	defer m2.Close()
+}
+
+func TestMapPinWithEmptyPath(t *testing.T) {
+	m := createArray(t)
+	c := qt.New(t)
+	defer m.Close()
+
+	err := m.Pin("")
+
+	c.Assert(err, qt.Not(qt.IsNil))
+}
+
+func TestMapUnpin(t *testing.T) {
+	tmp := tempBPFFS(t)
+	c := qt.New(t)
+	spec := spec1.Copy()
+
+	m, err := NewMapWithOptions(spec, MapOptions{PinPath: tmp})
+	if err != nil {
+		t.Fatal("Failed to create map:", err)
+	}
+	defer m.Close()
+
+	pinned := m.IsPinned()
+	c.Assert(pinned, qt.Equals, true)
+	path := filepath.Join(tmp, spec.Name)
+	m2, err := LoadPinnedMap(path)
+	c.Assert(err, qt.IsNil)
+	defer m2.Close()
+
+	if err = m.Unpin(); err != nil {
+		t.Fatal("Failed to unpin map:", err)
+	}
+	if _, err := os.Stat(path); err == nil {
+		t.Fatal("Pinned map path still exists after unpinning:", err)
+	}
+}
+
+func TestMapLoadPinned(t *testing.T) {
+	tmp := tempBPFFS(t)
+	c := qt.New(t)
+
+	spec := spec1.Copy()
+
+	m1, err := NewMapWithOptions(spec, MapOptions{PinPath: tmp})
+	c.Assert(err, qt.IsNil)
+	defer m1.Close()
+	pinned := m1.IsPinned()
+	c.Assert(pinned, qt.Equals, true)
+
+	path := filepath.Join(tmp, spec.Name)
+	m2, err := LoadPinnedMap(path)
+	c.Assert(err, qt.IsNil)
+	defer m2.Close()
+	pinned = m2.IsPinned()
+	c.Assert(pinned, qt.Equals, true)
+}
+
+func TestMapLoadPinnedUnpin(t *testing.T) {
+	tmp := tempBPFFS(t)
+	c := qt.New(t)
+
+	spec := spec1.Copy()
+
+	m1, err := NewMapWithOptions(spec, MapOptions{PinPath: tmp})
+	c.Assert(err, qt.IsNil)
+	defer m1.Close()
+	pinned := m1.IsPinned()
+	c.Assert(pinned, qt.Equals, true)
+
+	path := filepath.Join(tmp, spec.Name)
+	m2, err := LoadPinnedMap(path)
+	c.Assert(err, qt.IsNil)
+	defer m2.Close()
+	err = m1.Unpin()
+	c.Assert(err, qt.IsNil)
+	err = m2.Unpin()
+	c.Assert(err, qt.IsNil)
 }
 
 func createArray(t *testing.T) *Map {
@@ -794,6 +916,7 @@ func TestNewMapFromID(t *testing.T) {
 
 func TestMapPinning(t *testing.T) {
 	tmp := tempBPFFS(t)
+	c := qt.New(t)
 
 	spec := &MapSpec{
 		Name:       "test",
@@ -809,6 +932,8 @@ func TestMapPinning(t *testing.T) {
 		t.Fatal("Can't create map:", err)
 	}
 	defer m1.Close()
+	pinned := m1.IsPinned()
+	c.Assert(pinned, qt.Equals, true)
 
 	if err := m1.Put(uint32(0), uint32(42)); err != nil {
 		t.Fatal("Can't write value:", err)


### PR DESCRIPTION
This is an inverse of the Pin method. Also, add a method to get Map's pinned path.

Signed-off-by: Aditi Ghag aditi@cilium.io