### PR TITLE
map: distinguish between keys and values when marshaling

### DIFF
--- a/map_test.go
+++ b/map_test.go
@@ -196,23 +196,13 @@ func TestMapQueue(t *testing.T) {
 	}
 	defer m.Close()
 
-	if err := m.Put(nil, uint32(42)); err != nil {
-		t.Fatal("Can't put 42:", err)
-	}
-
-	if err := m.Put(nil, uint32(4242)); err != nil {
-		t.Fatal("Can't put 4242:", err)
+	for _, v := range []uint32{42, 4242} {
+		if err := m.Put(nil, v); err != nil {
+			t.Fatalf("Can't put %d: %s", v, err)
+		}
 	}
 
 	var v uint32
-	if err := m.Lookup(nil, &v); err != nil {
-		t.Fatal("Can't lookup element:", err)
-	}
-	if v != 42 {
-		t.Error("Want value 42, got", v)
-	}
-
-	v = 0
 	if err := m.LookupAndDelete(nil, &v); err != nil {
 		t.Fatal("Can't lookup and delete element:", err)
 	}
@@ -220,16 +210,9 @@ func TestMapQueue(t *testing.T) {
 		t.Error("Want value 42, got", v)
 	}
 
-	if err := m.Lookup(nil, &v); err != nil {
-		t.Fatal("Can't lookup element:", err)
-	}
-	if v != 4242 {
-		t.Error("Want value 4242, got", v)
-	}
-
 	v = 0
-	if err := m.LookupAndDelete(nil, &v); err != nil {
-		t.Fatal("Can't lookup and delete element:", err)
+	if err := m.LookupAndDelete(nil, unsafe.Pointer(&v)); err != nil {
+		t.Fatal("Can't lookup and delete element using unsafe.Pointer:", err)
 	}
 	if v != 4242 {
 		t.Error("Want value 4242, got", v)

--- a/marshalers.go
+++ b/marshalers.go
@@ -13,14 +13,12 @@ import (
 	"github.com/cilium/ebpf/internal"
 )
 
+// marshalPtr converts an arbitrary value into a pointer suitable
+// to be passed to the kernel.
+//
+// As an optimization, it returns the original value if it is an
+// unsafe.Pointer.
 func marshalPtr(data interface{}, length int) (internal.Pointer, error) {
-	if data == nil {
-		if length == 0 {
-			return internal.NewPointer(nil), nil
-		}
-		return internal.Pointer{}, errors.New("can't use nil as key of map")
-	}
-
 	if ptr, ok := data.(unsafe.Pointer); ok {
 		return internal.NewPointer(ptr), nil
 	}
@@ -33,6 +31,13 @@ func marshalPtr(data interface{}, length int) (internal.Pointer, error) {
 	return internal.NewSlicePointer(buf), nil
 }
 
+// marshalBytes converts an arbitrary value into a byte buffer.
+//
+// Prefer using Map.marshalKey and Map.marshalValue if possible, since
+// those have special cases that allow more types to be encoded.
+//
+// Returns an error if the given value isn't representable in exactly
+// length bytes.
 func marshalBytes(data interface{}, length int) (buf []byte, err error) {
 	switch value := data.(type) {
 	case encoding.BinaryMarshaler:
@@ -43,6 +48,8 @@ func marshalBytes(data interface{}, length int) (buf []byte, err error) {
 		buf = value
 	case unsafe.Pointer:
 		err = errors.New("can't marshal from unsafe.Pointer")
+	case Map, *Map, Program, *Program:
+		err = fmt.Errorf("can't marshal %T", value)
 	default:
 		var wr bytes.Buffer
 		err = binary.Write(&wr, internal.NativeEndian, value)
@@ -70,6 +77,10 @@ func makeBuffer(dst interface{}, length int) (internal.Pointer, []byte) {
 	return internal.NewSlicePointer(buf), buf
 }
 
+// unmarshalBytes converts a byte buffer into an arbitrary value.
+//
+// Prefer using Map.unmarshalKey and Map.unmarshalValue if possible, since
+// those have special cases that allow more types to be encoded.
 func unmarshalBytes(data interface{}, buf []byte) error {
 	switch value := data.(type) {
 	case unsafe.Pointer:
@@ -83,6 +94,8 @@ func unmarshalBytes(data interface{}, buf []byte) error {
 		copy(dst, buf)
 		runtime.KeepAlive(value)
 		return nil
+	case Map, *Map, Program, *Program:
+		return fmt.Errorf("can't unmarshal into %T", value)
 	case encoding.BinaryUnmarshaler:
 		return value.UnmarshalBinary(buf)
 	case *string:

--- a/prog.go
+++ b/prog.go
@@ -496,8 +496,11 @@ func unmarshalProgram(buf []byte) (*Program, error) {
 	return NewProgramFromID(ProgramID(id))
 }
 
-// MarshalBinary implements BinaryMarshaler.
-func (p *Program) MarshalBinary() ([]byte, error) {
+func marshalProgram(p *Program, length int) ([]byte, error) {
+	if length != 4 {
+		return nil, fmt.Errorf("can't marshal program to %d bytes", length)
+	}
+
 	value, err := p.fd.Value()
 	if err != nil {
 		return nil, err

--- a/types.go
+++ b/types.go
@@ -85,10 +85,19 @@ const (
 
 // hasPerCPUValue returns true if the Map stores a value per CPU.
 func (mt MapType) hasPerCPUValue() bool {
-	if mt == PerCPUHash || mt == PerCPUArray || mt == LRUCPUHash {
-		return true
-	}
-	return false
+	return mt == PerCPUHash || mt == PerCPUArray || mt == LRUCPUHash
+}
+
+// canStoreMap returns true if the map type accepts a map fd
+// for update and returns a map id for lookup.
+func (mt MapType) canStoreMap() bool {
+	return mt == ArrayOfMaps || mt == HashOfMaps
+}
+
+// canStoreProgram returns true if the map type accepts a program fd
+// for update and returns a program id for lookup.
+func (mt MapType) canStoreProgram() bool {
+	return mt == ProgramArray
 }
 
 // ProgramType of the eBPF program


### PR DESCRIPTION
Marshaling and unmarshaling map keys and values is quite complicated:

* Queues allow nil keys
* Some maps allow storing map and program fds
* But looking them up returns map and program IDs, not fds
* We allow passing unsafe.Pointer for "zero copy" lookups

The current implementation isn't careful enough about these
constraints. For example, Map implements BinaryMarshaler which
encodes the map fd as a host endian uint32. This representation
only makes sense when inserting into an ArrayOfMaps or similar.
Since we don't distinguish between keys and values, you can use
a *Map as a key and get the same behaviour, except that the
key ends up being the value of the file descriptor. This doesn't
make a lot of sense.

Add helpers on Map that should be used when marshaling or unmarshaling
keys and values. Re-using the same code everywhere also fixes
an inconsistency with LookupAndDelete, which currently doesn't
allow unsafe.Pointer.