### PR TITLE
program: treat EINTR during BPG_PROG_TEST_RUN as supported

### DIFF
--- a/prog.go
+++ b/prog.go
@@ -417,6 +417,10 @@ var haveProgTestRun = internal.FeatureTest("BPF_PROG_TEST_RUN", "4.12", func() e
 		// otherwise misdetect due to insufficient permissions.
 		return internal.ErrNotSupported
 	}
+	if errors.Is(err, unix.EINTR) {
+		// We know that PROG_TEST_RUN is supported if we get EINTR.
+		return nil
+	}
 	return err
 })
 


### PR DESCRIPTION
BPF_PROG_TEST_RUN returns EINTR if the test is interrupted by a
signal. Therefore we know that BPF_PROG_REST_RUN is supported if
we see EINTR.

Fixes #203