### PR TITLE
Require Go 1.15 and test on 1.16

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -13,10 +13,15 @@ blocks:
         commands:
           - checkout
           - sem-version go 1.15
+          - cache restore
+          - go mod download
           - go build ./...
           - sudo pip3 install https://github.com/amluto/virtme/archive/538f1e756139a6b57a4780e7ceb3ac6bcaa4fe6f.zip
           - sudo apt-get install -y qemu-system-x86 clang-9
           - go generate ./cmd/bpf2go
+      epilogue:
+        commands:
+          - cache store
           - git diff --exit-code || { echo "generated files are not up to date" >&2; false; }
       env_vars:
         - name: TMPDIR

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -12,7 +12,9 @@ blocks:
       prologue:
         commands:
           - checkout
-          - sem-version go 1.15
+          # Until go 1.16 is available on semaphore.
+          - sudo mkdir -p /usr/local/golang/1.16 && curl -fL "https://golang.org/dl/go1.16.linux-amd64.tar.gz" | sudo tar -xz -C /usr/local/golang/1.16
+          - sem-version go 1.16
           - cache restore
           - go mod download
           - go build ./...
@@ -34,12 +36,11 @@ blocks:
           - GOARCH=arm64 go build ./... && for p in $(go list ./...) ; do GOARCH=arm64 go test -c $p ; done
       - name: Run unit tests on previous stable Go
         commands:
-          - sem-version go 1.14
+          - sem-version go 1.15
           - timeout -s KILL 600s ./run-tests.sh 5.10
       - name: Run unit tests
         matrix:
           - env_var: KERNEL_VERSION
             values: ["5.10", "5.9", "5.4", "4.19", "4.9"]
         commands:
-          - sem-version go 1.15
           - timeout -s KILL 600s ./run-tests.sh $KERNEL_VERSION

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cilium/ebpf
 
-go 1.14
+go 1.15
 
 require (
 	github.com/google/go-cmp v0.5.4


### PR DESCRIPTION
Go 1.16 is released, so 1.14 is EOL. Bump the minimum version to 1.15 and change CI to use 1.16 by default.