### PR TITLE
bpf2go: add -O2 to default cflags

### DIFF
--- a/cmd/bpf2go/compile.go
+++ b/cmd/bpf2go/compile.go
@@ -27,7 +27,12 @@ type compileArgs struct {
 }
 
 func compile(args compileArgs) error {
-	cmd := exec.Command(args.cc, args.cFlags...)
+	// Default cflags that can be overriden by args.cFlags
+	overrideFlags := []string {
+		"-O2",
+	}
+
+	cmd := exec.Command(args.cc, append(overrideFlags, args.cFlags...)...)
 	cmd.Stderr = os.Stderr
 
 	inputDir := filepath.Dir(args.source)


### PR DESCRIPTION
Currently, clang generates invalid opcodes when kernel helper functions
are used in BPF programs and they are compiled without optimizations.

This case is not detected built time so it's better to add safer default
cflags, i.e., with optimizations.