### PR TITLE
CI: submit coverage info

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -6,6 +6,10 @@ agent:
     type: e1-standard-2
     os_image: ubuntu1804
 
+global_job_config:
+  secrets:
+    - name: Coveralls
+
 blocks:
   - name: Run tests
     task:
@@ -15,6 +19,8 @@ blocks:
           # Until go 1.16 is available on semaphore.
           - sudo mkdir -p /usr/local/golang/1.16 && curl -fL "https://golang.org/dl/go1.16.linux-amd64.tar.gz" | sudo tar -xz -C /usr/local/golang/1.16
           - sem-version go 1.16
+          - go install github.com/mattn/goveralls@latest
+          - export PATH="$PATH:$HOME/go/bin"
           - cache restore
           - go mod download
           - go build ./...

--- a/elf_reader_test.go
+++ b/elf_reader_test.go
@@ -241,7 +241,7 @@ func TestLoadRawTracepoint(t *testing.T) {
 }
 
 var (
-	elfPath    = flag.String("elfs", "", "`Path` containing libbpf-compatible ELFs")
+	elfPath    = flag.String("elfs", os.Getenv("KERNEL_SELFTESTS"), "`Path` containing libbpf-compatible ELFs (defaults to $KERNEL_SELFTESTS)")
 	elfPattern = flag.String("elf-pattern", "*.o", "Glob `pattern` for object files that should be tested")
 )
 

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -16,14 +16,11 @@ if [[ "${1:-}" = "--in-vm" ]]; then
   export GOSUMDB=off
   export GOCACHE=/run/go-cache
 
-  elfs=""
   if [[ -d "/run/input/bpf" ]]; then
-    elfs="/run/input/bpf"
+    export KERNEL_SELFTESTS="/run/input/bpf"
   fi
 
   echo Running tests...
-  # TestLibBPFCompat runs separately to pass the "-elfs" flag only for it: https://github.com/cilium/ebpf/pull/119
-  go test -v -count 1 -run TestLibBPFCompat -elfs "$elfs"
   go test -v -count 1 ./...
   touch "$1/success"
   exit 0


### PR DESCRIPTION
Refactor the libbpf integration tests a bit to enable running a single test invocation that generates coverage info. Submit it to coveralls.io since that is what cilium proper seems to be using as well.