### PR TITLE
bpf: Enable per-CPU map support for BatchOps

### DIFF
--- a/info_test.go
+++ b/info_test.go
@@ -174,7 +174,7 @@ func TestStats(t *testing.T) {
 
 	disableStats, err := EnableStats(uint32(unix.BPF_STATS_RUN_TIME))
 	if err != nil {
-		t.Errorf("failed to enable stats: %v", err)
+		t.Fatalf("failed to enable stats: %v", err)
 	}
 	defer disableStats.Close()
 


### PR DESCRIPTION
BatchOps have already been enabled for this library.
However, per-CPU map support was deferred for the purposes
of having a distinct debate about what the interface for
the per-CPU maps should look like.

This commit adds support for per-CPU maps but does
fundamentally very little to add the support, taking
the libbpf approach of having the user of the library
add dittographic lists (in golang, slices) as the
"values" argument of Lookup (in that case empty)
or Update.

This commit also make a small change to the stats
tests so that they don't panic the tests when they fail on
a local machine that doesn't support them, but rather
*just* fail.

Signed-off-by: Nate Sweet <nathanjsweet@pm.me>