### PR TITLE
map: fix iterating empty sockmap

### DIFF
--- a/map.go
+++ b/map.go
@@ -1116,7 +1116,9 @@ func (mi *MapIterator) Next(keyOut, valueOut interface{}) bool {
 		return false
 	}
 
-	for ; mi.count < mi.maxEntries; mi.count++ {
+	// For array-like maps NextKeyBytes returns nil only on after maxEntries
+	// iterations.
+	for mi.count <= mi.maxEntries {
 		var nextBytes []byte
 		nextBytes, mi.err = mi.target.NextKeyBytes(mi.prevKey)
 		if mi.err != nil {
@@ -1135,6 +1137,7 @@ func (mi *MapIterator) Next(keyOut, valueOut interface{}) bool {
 		copy(mi.prevBytes, nextBytes)
 		mi.prevKey = mi.prevBytes
 
+		mi.count++
 		mi.err = mi.target.Lookup(nextBytes, valueOut)
 		if errors.Is(mi.err, ErrKeyNotExist) {
 			// Even though the key should be valid, we couldn't look up


### PR DESCRIPTION
When iterating a map, we first issue a GET_NEXT_KEY followed by a
LOOKUP_ELEM syscall. Depending on the map type these two return
different error codes.

A plain array returns ENOENT from GET_NEXT_KEY once you ask for
the key after max_entries-1. It returns ENOENT from LOOKUP_ELEM
when asking for max_entries.

A hash map never returns ENOENT from GET_NEXT_KEY, and sometimes
returns ENOENT from LOOKUP_ELEM if there was a concurrent deletion.

A sockmap returns ENOENT from GET_NEXT_KEY once you ask for the
key after max_entries-1. In contrast to the plain array it may
return ENOENT for any slot that doesn't contain a socket.

MapIterator contains an off by one error in the logic that protects
from forever iterating a hash map that is being modified concurrently.
We only allow max_entries-1 calls to GET_NEXT_KEY, which means we
never see the ENOENT from GET_NEXT_KEY for arrays and sockmaps.

This bug hasn't surfaced so far because there is a second bug in
the logic which obfuscated it. mi.count is only incremented when
LOOKUP_ELEM returns ENOENT. Since this never happens for arrays
we never reach the point where the iterator returns
ErrIterationAborted.

The idea behind mi.count is to do at most max_entries lookups.
If we haven't finished iteration at that point we likely ran into
a hash map that was concurrently modified. We inform the user
via the sentinel error and let them handle the situation. The
correct fix therefore is to bump mi.count for every LOOKUP_ELEM
and to allow max_entries iterations in total.