### PR TITLE
ci: Fix Stats Test

### DIFF
--- a/info_test.go
+++ b/info_test.go
@@ -174,7 +174,7 @@ func TestStats(t *testing.T) {
 
 	disableStats, err := EnableStats(uint32(unix.BPF_STATS_RUN_TIME))
 	if err != nil {
-		t.Errorf("failed to enable stats: %v", err)
+		t.Fatalf("failed to enable stats: %v", err)
 	}
 	defer disableStats.Close()
 


### PR DESCRIPTION
This PR fixes the stats test, which incorrectly
logged an error instead of failing out of the test
when stats were not enabled. This caused the test
to panic the whole test suite on the next invalid
function call.

Signed-off-by: Nate Sweet <nathanjsweet@pm.me>