### PR TITLE
cmd/bpf2go: set -mcpu=v1 by default

### DIFF
--- a/cmd/bpf2go/compile.go
+++ b/cmd/bpf2go/compile.go
@@ -28,8 +28,14 @@ type compileArgs struct {
 
 func compile(args compileArgs) error {
 	// Default cflags that can be overriden by args.cFlags
-	overrideFlags := []string {
+	overrideFlags := []string{
+		// Code needs to be optimized, otherwise the verifier will often fail
+		// to understand it.
 		"-O2",
+		// Clang defaults to mcpu=probe which checks the kernel that we are
+		// compiling on. This isn't appropriate for ahead of time
+		// compiled code so force the most compatible version.
+		"-mcpu=v1",
 	}
 
 	cmd := exec.Command(args.cc, append(overrideFlags, args.cFlags...)...)


### PR DESCRIPTION
Clang by default probes the kernel it is running on to determine whether
it can enable advanced features like 32 bit operations, which is kind of
similar to -march=native behaviour. This is a bad idea for ahead of time
compiled code, since there is no guarantee that the kernel we compile on
is older than the kernel we want to run on.