### PR TITLE
correct bpf2go/example link

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -29,7 +29,7 @@ includes debug aids like which source line corresponds to which instructions and
 what global variables are used.
 
 [BTF parsing](internal/btf/) lives in a separate internal package since exposing
-it would mean an additional maintenance burden, and because the API has still
+it would mean an additional maintenance burden, and because the API still
 has sharp corners. The most important concept is the `btf.Type` interface, which
 also describes things that aren't really types like `.rodata` or `.bss` sections.
 `btf.Type`s can form cyclical graphs, which can easily lead to infinite loops if
@@ -46,7 +46,7 @@ modify clang-compiled BPF code, for example to rewrite constants. At the same
 time the [asm](asm/) package provides an assembler that can be used to generate
 `ProgramSpec` on the fly.
 
-Creating a spec should never require any privileges or be restrictedin some way,
+Creating a spec should never require any privileges or be restricted in any way,
 for example by only allowing programs in native endianness. This ensures that
 the library stays flexible.
 

--- a/cmd/bpf2go/doc.go
+++ b/cmd/bpf2go/doc.go
@@ -21,5 +21,5 @@
 // Requires at least clang 9.
 //
 // For a full list of accepted options check the `-help` output. There is a
-// fully worked example at https://github.com/cilium/ebpf/tree/master/cmd/bpf2go/example.
+// fully worked example at https://github.com/cilium/ebpf/blob/master/cmd/bpf2go/example_test.go.
 package main

--- a/cmd/bpf2go/doc.go
+++ b/cmd/bpf2go/doc.go
@@ -21,5 +21,5 @@
 // Requires at least clang 9.
 //
 // For a full list of accepted options check the `-help` output. There is a
-// fully worked example at https://github.com/cilium/ebpf/blob/master/cmd/bpf2go/example_test.go.
+// fully working example at https://github.com/cilium/ebpf/blob/master/cmd/bpf2go/example_test.go.
 package main

--- a/prog.go
+++ b/prog.go
@@ -19,7 +19,7 @@ import (
 // ErrNotSupported is returned whenever the kernel doesn't support a feature.
 var ErrNotSupported = internal.ErrNotSupported
 
-// ProgramID represents the unique ID of an eBPF program
+// ProgramID represents the unique ID of an eBPF program.
 type ProgramID uint32
 
 const (
@@ -43,7 +43,7 @@ type ProgramOptions struct {
 	LogSize int
 }
 
-// ProgramSpec defines a Program
+// ProgramSpec defines a Program.
 type ProgramSpec struct {
 	// Name is passed to the kernel as a debug aid. Must only contain
 	// alpha numeric and '_' characters.

--- a/types.go
+++ b/types.go
@@ -143,7 +143,7 @@ const (
 // Will cause invalid argument (EINVAL) at program load time if set incorrectly.
 type AttachType uint32
 
-// AttachNone is an alias for AttachCGroupInetIngress for readability reasons
+// AttachNone is an alias for AttachCGroupInetIngress for readability reasons.
 const AttachNone AttachType = 0
 
 const (


### PR DESCRIPTION
PR corrects the currently dead link at the bottom of "Overview" in https://pkg.go.dev/github.com/cilium/ebpf/cmd/bpf2go#pkg-overview and adds a few very minor editorial changes to the documentation and comments.