### PR TITLE
cmd/bpf2go: pass -target bpf in tests

### DIFF
--- a/cmd/bpf2go/compile.go
+++ b/cmd/bpf2go/compile.go
@@ -22,6 +22,8 @@ type compileArgs struct {
 	source string
 	// Absolute output file name
 	dest string
+	// Target to compile for, defaults to "bpf".
+	target string
 	// Depfile will be written here if depName is not empty
 	dep io.Writer
 }
@@ -47,7 +49,13 @@ func compile(args compileArgs) error {
 		return err
 	}
 
+	target := args.target
+	if target == "" {
+		target = "bpf"
+	}
+
 	cmd.Args = append(cmd.Args,
+		"-target", target,
 		"-c", args.source,
 		"-o", args.dest,
 		// Don't include clang version

--- a/cmd/bpf2go/main.go
+++ b/cmd/bpf2go/main.go
@@ -149,7 +149,8 @@ func run(stdout io.Writer, pkg, outputDir string, args []string) (err error) {
 		var dep bytes.Buffer
 		err = compile(compileArgs{
 			cc:     *flagCC,
-			cFlags: append(cFlags, "-target", target),
+			cFlags: cFlags,
+			target: target,
 			dir:    cwd,
 			source: inputDir + inputFile,
 			dest:   objFileName,


### PR DESCRIPTION
Since 96fcfcf48d we include "-mcpu=v1" in the clang command line. The
bpf2go tests don't pass "-target bpf", so clang complains that the
flag is not recognized:

    clang-9: warning: argument unused during compilation: '-mcpu=v1' [-Wunused-command-line-argument]

Add a new target argument to the compile function, and default to
"bpf" if no target is given.