### PR TITLE
Run golangci-lint in CI, address linter errors

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,29 @@
+---
+issues:
+  exclude-rules:
+    # syscall param structs will have unused fields in Go code.
+    - path: syscall.*.go
+      linters:
+        - structcheck
+
+linters:
+  disable-all: true
+  enable:
+    - deadcode
+    - errcheck
+    - goimports
+    - gosimple
+    - govet
+    - ineffassign
+    - misspell
+    - staticcheck
+    - structcheck
+    - typecheck
+    - unused
+    - varcheck
+
+    # Could be enabled later:
+    # - gocyclo
+    # - prealloc
+    # - maligned
+    # - gosec

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -20,7 +20,8 @@ blocks:
           - sudo mkdir -p /usr/local/golang/1.16 && curl -fL "https://golang.org/dl/go1.16.linux-amd64.tar.gz" | sudo tar -xz -C /usr/local/golang/1.16
           - sem-version go 1.16
           - go install github.com/mattn/goveralls@latest
-          - export PATH="$PATH:$HOME/go/bin"
+          - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.38.0
+          - export PATH="$PATH:$(go env GOPATH)/bin"
           - cache restore
           - go mod tidy
           - go build ./...
@@ -41,6 +42,9 @@ blocks:
           - GOOS=darwin go build ./... && for p in $(go list ./...) ; do GOOS=darwin go test -c $p ; done
           - GOARCH=arm GOARM=6 go build ./... && for p in $(go list ./...) ; do GOARCH=arm GOARM=6 go test -c $p ; done
           - GOARCH=arm64 go build ./... && for p in $(go list ./...) ; do GOARCH=arm64 go test -c $p ; done
+      - name: Lint
+        commands:
+          - golangci-lint run
       - name: Run unit tests on previous stable Go
         commands:
           - sem-version go 1.15

--- a/asm/func.go
+++ b/asm/func.go
@@ -7,7 +7,7 @@ type BuiltinFunc int32
 
 // eBPF built-in functions
 //
-// You can renegerate this list using the following gawk script:
+// You can regenerate this list using the following gawk script:
 //
 //    /FN\(.+\),/ {
 //      match($1, /\((.+)\)/, r)

--- a/asm/instruction.go
+++ b/asm/instruction.go
@@ -337,7 +337,7 @@ func (insns Instructions) ReferenceOffsets() map[string][]int {
 // You can control indentation of symbols by
 // specifying a width. Setting a precision controls the indentation of
 // instructions.
-// The default character is a tab, which can be overriden by specifying
+// The default character is a tab, which can be overridden by specifying
 // the ' ' space flag.
 func (insns Instructions) Format(f fmt.State, c rune) {
 	if c != 's' && c != 'v' {
@@ -382,8 +382,6 @@ func (insns Instructions) Format(f fmt.State, c rune) {
 		}
 		fmt.Fprintf(f, "%s%*d: %v\n", indent, offsetWidth, iter.Offset, iter.Ins)
 	}
-
-	return
 }
 
 // Marshal encodes a BPF program into the kernel format.

--- a/cmd/bpf2go/compile.go
+++ b/cmd/bpf2go/compile.go
@@ -29,7 +29,7 @@ type compileArgs struct {
 }
 
 func compile(args compileArgs) error {
-	// Default cflags that can be overriden by args.cFlags
+	// Default cflags that can be overridden by args.cFlags
 	overrideFlags := []string{
 		// Code needs to be optimized, otherwise the verifier will often fail
 		// to understand it.
@@ -98,7 +98,9 @@ func compile(args compileArgs) error {
 		// Close our copy of the write end so that Copy will terminate
 		// when cc exits.
 		depWr.Close()
-		io.Copy(args.dep, depRd)
+		if _, err := io.Copy(args.dep, depRd); err != nil {
+			return fmt.Errorf("error writing depfile: %w", err)
+		}
 	}
 
 	if err := cmd.Wait(); err != nil {

--- a/cmd/bpf2go/output.go
+++ b/cmd/bpf2go/output.go
@@ -240,10 +240,6 @@ func writeCommon(args writeArgs) error {
 		programs[name] = identifier(name)
 	}
 
-	type typ struct {
-		Name string
-	}
-
 	ctx := struct {
 		Module   string
 		Package  string

--- a/internal/btf/btf_types.go
+++ b/internal/btf/btf_types.go
@@ -31,12 +31,14 @@ const (
 	kindDatasec
 )
 
+// btfFuncLinkage describes BTF function linkage metadata.
 type btfFuncLinkage uint8
 
+// Equivalent of enum btf_func_linkage.
 const (
 	linkageStatic btfFuncLinkage = iota
 	linkageGlobal
-	linkageExtern
+	// linkageExtern // Currently unused in libbpf.
 )
 
 const (

--- a/internal/btf/types_test.go
+++ b/internal/btf/types_test.go
@@ -54,24 +54,22 @@ func TestCopyType(t *testing.T) {
 // There currently is no better way to document which
 // types implement an interface.
 func ExampleType_validTypes() {
-	var t Type
-	t = &Void{}
-	t = &Int{}
-	t = &Pointer{}
-	t = &Array{}
-	t = &Struct{}
-	t = &Union{}
-	t = &Enum{}
-	t = &Fwd{}
-	t = &Typedef{}
-	t = &Volatile{}
-	t = &Const{}
-	t = &Restrict{}
-	t = &Func{}
-	t = &FuncProto{}
-	t = &Var{}
-	t = &Datasec{}
-	_ = t
+	var _ Type = &Void{}
+	var _ Type = &Int{}
+	var _ Type = &Pointer{}
+	var _ Type = &Array{}
+	var _ Type = &Struct{}
+	var _ Type = &Union{}
+	var _ Type = &Enum{}
+	var _ Type = &Fwd{}
+	var _ Type = &Typedef{}
+	var _ Type = &Volatile{}
+	var _ Type = &Const{}
+	var _ Type = &Restrict{}
+	var _ Type = &Func{}
+	var _ Type = &FuncProto{}
+	var _ Type = &Var{}
+	var _ Type = &Datasec{}
 }
 
 func TestType(t *testing.T) {

--- a/link/link_test.go
+++ b/link/link_test.go
@@ -29,12 +29,19 @@ func TestRawLink(t *testing.T) {
 
 	info, err := link.Info()
 	if err != nil {
-		t.Fatal("Can't get info:", err)
+		t.Fatal("Can't get link info:", err)
 	}
-	progID, err := prog.ID()
+
+	pi, err := prog.Info()
 	if err != nil {
-		t.Fatal("Can't get program ID:", err)
+		t.Fatal("Can't get program info:", err)
 	}
+
+	progID, ok := pi.ID()
+	if !ok {
+		t.Fatal("Program ID not available in program info")
+	}
+
 	if info.Program != progID {
 		t.Error("Link program ID doesn't match program ID")
 	}
@@ -146,7 +153,7 @@ func testLink(t *testing.T, link Link, opts testLinkOptions) {
 		func() {
 			// Panicking is OK
 			defer func() {
-				recover()
+				_ = recover()
 			}()
 
 			if err := link.Update(nil); err == nil {

--- a/map.go
+++ b/map.go
@@ -832,10 +832,7 @@ func (m *Map) Unpin() error {
 
 // IsPinned returns true if the map has a non-empty pinned path.
 func (m *Map) IsPinned() bool {
-	if m.pinnedPath == "" {
-		return false
-	}
-	return true
+	return m.pinnedPath != ""
 }
 
 // Freeze prevents a map to be modified from user space.
@@ -937,7 +934,9 @@ func (m *Map) unmarshalValue(value interface{}, buf []byte) error {
 			return err
 		}
 
-		(*value).Close()
+		// The caller might close the map externally, so ignore errors.
+		_ = (*value).Close()
+
 		*value = other
 		return nil
 
@@ -957,7 +956,9 @@ func (m *Map) unmarshalValue(value interface{}, buf []byte) error {
 			return err
 		}
 
-		(*value).Close()
+		// The caller might close the program externally, so ignore errors.
+		_ = (*value).Close()
+
 		*value = other
 		return nil
 

--- a/marshalers.go
+++ b/marshalers.go
@@ -84,7 +84,9 @@ func makeBuffer(dst interface{}, length int) (internal.Pointer, []byte) {
 func unmarshalBytes(data interface{}, buf []byte) error {
 	switch value := data.(type) {
 	case unsafe.Pointer:
-		sh := &reflect.SliceHeader{
+		// This could be solved in Go 1.17 by unsafe.Slice instead. (https://github.com/golang/go/issues/19367)
+		// We could opt for removing unsafe.Pointer support in the lib as well.
+		sh := &reflect.SliceHeader{ //nolint:govet
 			Data: uintptr(value),
 			Len:  len(buf),
 			Cap:  len(buf),

--- a/perf/reader.go
+++ b/perf/reader.go
@@ -437,7 +437,7 @@ func (uev *unknownEventError) Error() string {
 	return fmt.Sprintf("unknown event type: %d", uev.eventType)
 }
 
-// IsUnknownEvent returns true if the error occured
+// IsUnknownEvent returns true if the error occurred
 // because an unknown event was submitted to the perf event ring.
 func IsUnknownEvent(err error) bool {
 	var uee *unknownEventError

--- a/perf/ring.go
+++ b/perf/ring.go
@@ -78,8 +78,9 @@ func perfBufferSize(perCPUBuffer int) int {
 
 func (ring *perfEventRing) Close() {
 	runtime.SetFinalizer(ring, nil)
-	unix.Close(ring.fd)
-	unix.Munmap(ring.mmap)
+
+	_ = unix.Close(ring.fd)
+	_ = unix.Munmap(ring.mmap)
 
 	ring.fd = -1
 	ring.mmap = nil

--- a/prog.go
+++ b/prog.go
@@ -369,10 +369,7 @@ func (p *Program) Unpin() error {
 
 // IsPinned returns true if the Program has a non-empty pinned path.
 func (p *Program) IsPinned() bool {
-	if p.pinnedPath == "" {
-		return false
-	}
-	return true
+	return p.pinnedPath != ""
 }
 
 // Close unloads the program from the kernel.

--- a/prog_test.go
+++ b/prog_test.go
@@ -245,7 +245,7 @@ func TestProgramVerifierOutputOnError(t *testing.T) {
 		t.Fatal("Expected program to be invalid")
 	}
 
-	if strings.Index(err.Error(), "exit") == -1 {
+	if !strings.Contains(err.Error(), "exit") {
 		t.Error("No verifier output in error message")
 	}
 }


### PR DESCRIPTION
@lmb As discussed. I'd like us to consider adding gocyclo, prealloc, gosec and maligned later, since some of them flagged a few things that I didn't understand at first glance, and some are more invasive.

PTAL!