### PR TITLE
program: fix LoadPinnedProgram not setting pinnedPath

### DIFF
--- a/prog.go
+++ b/prog.go
@@ -609,7 +609,7 @@ func LoadPinnedProgram(fileName string) (*Program, error) {
 		return nil, fmt.Errorf("info for %s: %w", fileName, err)
 	}
 
-	return &Program{"", fd, filepath.Base(fileName), "", info.Type}, nil
+	return &Program{"", fd, filepath.Base(fileName), fileName, info.Type}, nil
 }
 
 // SanitizeName replaces all invalid characters in name with replacement.

--- a/prog_test.go
+++ b/prog_test.go
@@ -208,6 +208,10 @@ func TestProgramPin(t *testing.T) {
 	if prog.Type() != SocketFilter {
 		t.Error("Expected pinned program to have type SocketFilter, but got", prog.Type())
 	}
+
+	if !prog.IsPinned() {
+		t.Error("Expected IsPinned to be true")
+	}
 }
 
 func TestProgramUnpin(t *testing.T) {


### PR DESCRIPTION
Currently, loading a program from BPFFS doesn't set it's pinned path
and IsPinned returns false.