### PR TITLE
elf reader: iterate .maps via btf.datasec instead of elf.symbols

### DIFF
--- a/internal/btf/btf.go
+++ b/internal/btf/btf.go
@@ -32,7 +32,7 @@ type Spec struct {
 	rawTypes   []rawType
 	strings    stringTable
 	types      []Type
-	namedTypes map[string][]namedType
+	namedTypes map[string][]NamedType
 	funcInfos  map[string]extInfo
 	lineInfos  map[string]extInfo
 	coreRelos  map[string]bpfCoreRelos
@@ -476,7 +476,7 @@ func (s *Spec) FindType(name string, typ Type) error {
 		}
 
 		// Match against the full name, not just the essential one.
-		if typ.name() != name {
+		if typ.GetName() != name {
 			continue
 		}
 

--- a/internal/btf/core.go
+++ b/internal/btf/core.go
@@ -109,12 +109,12 @@ func coreRelocate(local, target *Spec, coreRelos bpfCoreRelos) (map[uint64]Reloc
 			continue
 		}
 
-		named, ok := typ.(namedType)
-		if !ok || named.name() == "" {
+		named, ok := typ.(NamedType)
+		if !ok || named.GetName() == "" {
 			return nil, fmt.Errorf("relocate anonymous type %s: %w", typ.String(), ErrNotSupported)
 		}
 
-		name := essentialName(named.name())
+		name := essentialName(named.GetName())
 		res, err := coreCalculateRelocation(typ, target.namedTypes[name], relo.ReloKind, accessor)
 		if err != nil {
 			return nil, fmt.Errorf("relocate %s: %w", name, err)
@@ -128,7 +128,7 @@ func coreRelocate(local, target *Spec, coreRelos bpfCoreRelos) (map[uint64]Reloc
 
 var errAmbiguousRelocation = errors.New("ambiguous relocation")
 
-func coreCalculateRelocation(local Type, targets []namedType, kind coreReloKind, localAccessor coreAccessor) (Relocation, error) {
+func coreCalculateRelocation(local Type, targets []NamedType, kind coreReloKind, localAccessor coreAccessor) (Relocation, error) {
 	var relos []Relocation
 	var matches []Type
 	for _, target := range targets {
@@ -348,11 +348,11 @@ func coreAreMembersCompatible(localType Type, targetType Type) (bool, error) {
 
 		case *Enum:
 			tv := targetType.(*Enum)
-			return doNamesMatch(lv.name(), tv.name()), nil
+			return doNamesMatch(lv.GetName(), tv.GetName()), nil
 
 		case *Fwd:
 			tv := targetType.(*Fwd)
-			return doNamesMatch(lv.name(), tv.name()), nil
+			return doNamesMatch(lv.GetName(), tv.GetName()), nil
 
 		case *Int:
 			tv := targetType.(*Int)

--- a/internal/btf/types.go
+++ b/internal/btf/types.go
@@ -31,12 +31,12 @@ type Type interface {
 	walk(*typeDeque)
 }
 
-// namedType is a type with a name.
+// NamedType is a type with a name.
 //
 // Most named types simply embed Name.
-type namedType interface {
+type NamedType interface {
 	Type
-	name() string
+	GetName() string
 }
 
 // Name identifies a type.
@@ -44,7 +44,7 @@ type namedType interface {
 // Anonymous types have an empty name.
 type Name string
 
-func (n Name) name() string {
+func (n Name) GetName() string {
 	return string(n)
 }
 
@@ -79,7 +79,7 @@ type Int struct {
 	Bits   byte
 }
 
-var _ namedType = (*Int)(nil)
+var _ NamedType = (*Int)(nil)
 
 func (i *Int) String() string {
 	var s strings.Builder
@@ -653,7 +653,7 @@ func (dq *typeDeque) all() []*Type {
 // Returns a map of named types (so, where NameOff is non-zero) and a slice of types
 // indexed by TypeID. Since BTF ignores compilation units, multiple types may share
 // the same name. A Type may form a cyclic graph by pointing at itself.
-func inflateRawTypes(rawTypes []rawType, rawStrings stringTable) (types []Type, namedTypes map[string][]namedType, err error) {
+func inflateRawTypes(rawTypes []rawType, rawStrings stringTable) (types []Type, namedTypes map[string][]NamedType, err error) {
 	type fixupDef struct {
 		id           TypeID
 		expectedKind btfKind
@@ -692,7 +692,7 @@ func inflateRawTypes(rawTypes []rawType, rawStrings stringTable) (types []Type, 
 
 	types = make([]Type, 0, len(rawTypes))
 	types = append(types, (*Void)(nil))
-	namedTypes = make(map[string][]namedType)
+	namedTypes = make(map[string][]NamedType)
 
 	for i, raw := range rawTypes {
 		var (
@@ -832,8 +832,8 @@ func inflateRawTypes(rawTypes []rawType, rawStrings stringTable) (types []Type, 
 
 		types = append(types, typ)
 
-		if named, ok := typ.(namedType); ok {
-			if name := essentialName(named.name()); name != "" {
+		if named, ok := typ.(NamedType); ok {
+			if name := essentialName(named.GetName()); name != "" {
 				namedTypes[name] = append(namedTypes[name], named)
 			}
 		}


### PR DESCRIPTION
https://github.com/cilium/ebpf/issues/239

@lmb do you know a better way of getting the map name via Datasec? I don't like doing what I did in `nameFromBTFVarSecinfo` but I didn't found a better way