### PR TITLE
prog: add Flags to ProgSpec

### DIFF
--- a/elf_reader.go
+++ b/elf_reader.go
@@ -272,11 +272,12 @@ func (ec *elfCode) loadPrograms() (map[string]*ProgramSpec, error) {
 			return nil, fmt.Errorf("program %s: %w", funcSym.Name, err)
 		}
 
-		progType, attachType, attachTo := getProgType(sec.Name)
+		progType, attachType, progFlags, attachTo := getProgType(sec.Name)
 
 		spec := &ProgramSpec{
 			Name:          funcSym.Name,
 			Type:          progType,
+			Flags:         progFlags,
 			AttachType:    attachType,
 			AttachTo:      attachTo,
 			License:       ec.license,
@@ -831,56 +832,61 @@ func (ec *elfCode) loadDataSections(maps map[string]*MapSpec) error {
 	return nil
 }
 
-func getProgType(sectionName string) (ProgramType, AttachType, string) {
+func getProgType(sectionName string) (ProgramType, AttachType, uint32, string) {
 	types := map[string]struct {
 		progType   ProgramType
 		attachType AttachType
+		progFlags  uint32
 	}{
 		// From https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/tools/lib/bpf/libbpf.c
-		"socket":                {SocketFilter, AttachNone},
-		"seccomp":               {SocketFilter, AttachNone},
-		"kprobe/":               {Kprobe, AttachNone},
-		"uprobe/":               {Kprobe, AttachNone},
-		"kretprobe/":            {Kprobe, AttachNone},
-		"uretprobe/":            {Kprobe, AttachNone},
-		"tracepoint/":           {TracePoint, AttachNone},
-		"raw_tracepoint/":       {RawTracepoint, AttachNone},
-		"xdp":                   {XDP, AttachNone},
-		"perf_event":            {PerfEvent, AttachNone},
-		"lwt_in":                {LWTIn, AttachNone},
-		"lwt_out":               {LWTOut, AttachNone},
-		"lwt_xmit":              {LWTXmit, AttachNone},
-		"lwt_seg6local":         {LWTSeg6Local, AttachNone},
-		"sockops":               {SockOps, AttachCGroupSockOps},
-		"sk_skb/stream_parser":  {SkSKB, AttachSkSKBStreamParser},
-		"sk_skb/stream_verdict": {SkSKB, AttachSkSKBStreamParser},
-		"sk_msg":                {SkMsg, AttachSkSKBStreamVerdict},
-		"lirc_mode2":            {LircMode2, AttachLircMode2},
-		"flow_dissector":        {FlowDissector, AttachFlowDissector},
-		"iter/":                 {Tracing, AttachTraceIter},
-		"sk_lookup/":            {SkLookup, AttachSkLookup},
-		"lsm/":                  {LSM, AttachLSMMac},
+		"socket":                {SocketFilter, AttachNone, 0},
+		"seccomp":               {SocketFilter, AttachNone, 0},
+		"kprobe/":               {Kprobe, AttachNone, 0},
+		"uprobe/":               {Kprobe, AttachNone, 0},
+		"kretprobe/":            {Kprobe, AttachNone, 0},
+		"uretprobe/":            {Kprobe, AttachNone, 0},
+		"tracepoint/":           {TracePoint, AttachNone, 0},
+		"raw_tracepoint/":       {RawTracepoint, AttachNone, 0},
+		"xdp":                   {XDP, AttachNone, 0},
+		"perf_event":            {PerfEvent, AttachNone, 0},
+		"lwt_in":                {LWTIn, AttachNone, 0},
+		"lwt_out":               {LWTOut, AttachNone, 0},
+		"lwt_xmit":              {LWTXmit, AttachNone, 0},
+		"lwt_seg6local":         {LWTSeg6Local, AttachNone, 0},
+		"sockops":               {SockOps, AttachCGroupSockOps, 0},
+		"sk_skb/stream_parser":  {SkSKB, AttachSkSKBStreamParser, 0},
+		"sk_skb/stream_verdict": {SkSKB, AttachSkSKBStreamParser, 0},
+		"sk_msg":                {SkMsg, AttachSkSKBStreamVerdict, 0},
+		"lirc_mode2":            {LircMode2, AttachLircMode2, 0},
+		"flow_dissector":        {FlowDissector, AttachFlowDissector, 0},
+		"iter/":                 {Tracing, AttachTraceIter, 0},
+		"fentry.s/":             {Tracing, AttachTraceFEntry, unix.BPF_F_SLEEPABLE},
+		"fmod_ret.s/":           {Tracing, AttachModifyReturn, unix.BPF_F_SLEEPABLE},
+		"fexit.s/":              {Tracing, AttachTraceFExit, unix.BPF_F_SLEEPABLE},
+		"sk_lookup/":            {SkLookup, AttachSkLookup, 0},
+		"lsm/":                  {LSM, AttachLSMMac, 0},
+		"lsm.s/":                {LSM, AttachLSMMac, unix.BPF_F_SLEEPABLE},
 
-		"cgroup_skb/ingress": {CGroupSKB, AttachCGroupInetIngress},
-		"cgroup_skb/egress":  {CGroupSKB, AttachCGroupInetEgress},
-		"cgroup/dev":         {CGroupDevice, AttachCGroupDevice},
-		"cgroup/skb":         {CGroupSKB, AttachNone},
-		"cgroup/sock":        {CGroupSock, AttachCGroupInetSockCreate},
-		"cgroup/post_bind4":  {CGroupSock, AttachCGroupInet4PostBind},
-		"cgroup/post_bind6":  {CGroupSock, AttachCGroupInet6PostBind},
-		"cgroup/bind4":       {CGroupSockAddr, AttachCGroupInet4Bind},
-		"cgroup/bind6":       {CGroupSockAddr, AttachCGroupInet6Bind},
-		"cgroup/connect4":    {CGroupSockAddr, AttachCGroupInet4Connect},
-		"cgroup/connect6":    {CGroupSockAddr, AttachCGroupInet6Connect},
-		"cgroup/sendmsg4":    {CGroupSockAddr, AttachCGroupUDP4Sendmsg},
-		"cgroup/sendmsg6":    {CGroupSockAddr, AttachCGroupUDP6Sendmsg},
-		"cgroup/recvmsg4":    {CGroupSockAddr, AttachCGroupUDP4Recvmsg},
-		"cgroup/recvmsg6":    {CGroupSockAddr, AttachCGroupUDP6Recvmsg},
-		"cgroup/sysctl":      {CGroupSysctl, AttachCGroupSysctl},
-		"cgroup/getsockopt":  {CGroupSockopt, AttachCGroupGetsockopt},
-		"cgroup/setsockopt":  {CGroupSockopt, AttachCGroupSetsockopt},
-		"classifier":         {SchedCLS, AttachNone},
-		"action":             {SchedACT, AttachNone},
+		"cgroup_skb/ingress": {CGroupSKB, AttachCGroupInetIngress, 0},
+		"cgroup_skb/egress":  {CGroupSKB, AttachCGroupInetEgress, 0},
+		"cgroup/dev":         {CGroupDevice, AttachCGroupDevice, 0},
+		"cgroup/skb":         {CGroupSKB, AttachNone, 0},
+		"cgroup/sock":        {CGroupSock, AttachCGroupInetSockCreate, 0},
+		"cgroup/post_bind4":  {CGroupSock, AttachCGroupInet4PostBind, 0},
+		"cgroup/post_bind6":  {CGroupSock, AttachCGroupInet6PostBind, 0},
+		"cgroup/bind4":       {CGroupSockAddr, AttachCGroupInet4Bind, 0},
+		"cgroup/bind6":       {CGroupSockAddr, AttachCGroupInet6Bind, 0},
+		"cgroup/connect4":    {CGroupSockAddr, AttachCGroupInet4Connect, 0},
+		"cgroup/connect6":    {CGroupSockAddr, AttachCGroupInet6Connect, 0},
+		"cgroup/sendmsg4":    {CGroupSockAddr, AttachCGroupUDP4Sendmsg, 0},
+		"cgroup/sendmsg6":    {CGroupSockAddr, AttachCGroupUDP6Sendmsg, 0},
+		"cgroup/recvmsg4":    {CGroupSockAddr, AttachCGroupUDP4Recvmsg, 0},
+		"cgroup/recvmsg6":    {CGroupSockAddr, AttachCGroupUDP6Recvmsg, 0},
+		"cgroup/sysctl":      {CGroupSysctl, AttachCGroupSysctl, 0},
+		"cgroup/getsockopt":  {CGroupSockopt, AttachCGroupGetsockopt, 0},
+		"cgroup/setsockopt":  {CGroupSockopt, AttachCGroupSetsockopt, 0},
+		"classifier":         {SchedCLS, AttachNone, 0},
+		"action":             {SchedACT, AttachNone, 0},
 	}
 
 	for prefix, t := range types {
@@ -889,13 +895,13 @@ func getProgType(sectionName string) (ProgramType, AttachType, string) {
 		}
 
 		if !strings.HasSuffix(prefix, "/") {
-			return t.progType, t.attachType, ""
+			return t.progType, t.attachType, t.progFlags, ""
 		}
 
-		return t.progType, t.attachType, sectionName[len(prefix):]
+		return t.progType, t.attachType, t.progFlags, sectionName[len(prefix):]
 	}
 
-	return UnspecifiedProgram, AttachNone, ""
+	return UnspecifiedProgram, AttachNone, 0, ""
 }
 
 func (ec *elfCode) loadRelocations(sec *elf.Section, symbols []elf.Symbol) (map[uint64]elf.Symbol, error) {

--- a/elf_reader_test.go
+++ b/elf_reader_test.go
@@ -315,31 +315,57 @@ func TestLibBPFCompat(t *testing.T) {
 }
 
 func TestGetProgType(t *testing.T) {
-	testcases := []struct {
-		section string
-		pt      ProgramType
-		at      AttachType
-		to      string
-	}{
-		{"socket/garbage", SocketFilter, AttachNone, ""},
-		{"kprobe/func", Kprobe, AttachNone, "func"},
-		{"xdp/foo", XDP, AttachNone, ""},
-		{"cgroup_skb/ingress", CGroupSKB, AttachCGroupInetIngress, ""},
-		{"iter/bpf_map", Tracing, AttachTraceIter, "bpf_map"},
+	type progTypeTestData struct {
+		Pt ProgramType
+		At AttachType
+		Fl uint32
+		To string
 	}
 
-	for _, tc := range testcases {
-		pt, at, to := getProgType(tc.section)
-		if pt != tc.pt {
-			t.Errorf("section %s: expected type %s, got %s", tc.section, tc.pt, pt)
-		}
+	testcases := map[string]progTypeTestData{
+		"socket/garbage": {
+			Pt: SocketFilter,
+			At: AttachNone,
+			To: "",
+		},
+		"kprobe/func": {
+			Pt: Kprobe,
+			At: AttachNone,
+			To: "func",
+		},
+		"xdp/foo": {
+			Pt: XDP,
+			At: AttachNone,
+			To: "",
+		},
+		"cgroup_skb/ingress": {
+			Pt: CGroupSKB,
+			At: AttachCGroupInetIngress,
+			To: "",
+		},
+		"iter/bpf_map": {
+			Pt: Tracing,
+			At: AttachTraceIter,
+			To: "bpf_map",
+		},
+		"lsm.s/file_ioctl_sleepable": {
+			Pt: LSM,
+			At: AttachLSMMac,
+			To: "file_ioctl_sleepable",
+			Fl: unix.BPF_F_SLEEPABLE,
+		},
+		"lsm/file_ioctl": {
+			Pt: LSM,
+			At: AttachLSMMac,
+			To: "file_ioctl",
+		},
+	}
 
-		if at != tc.at {
-			t.Errorf("section %s: expected attach type %s, got %s", tc.section, tc.at, at)
-		}
+	for section, want := range testcases {
+		pt, at, fl, to := getProgType(section)
 
-		if to != tc.to {
-			t.Errorf("section %s: expected attachment to be %q, got %q", tc.section, tc.to, to)
+		if diff := cmp.Diff(want, progTypeTestData{Pt: pt, At: at, Fl: fl, To: to}); diff != "" {
+			t.Errorf("getProgType mismatch (-want +got):\n%s", diff)
 		}
 	}
 }

--- a/internal/unix/types_linux.go
+++ b/internal/unix/types_linux.go
@@ -28,6 +28,7 @@ const (
 	BPF_F_NUMA_NODE          = linux.BPF_F_NUMA_NODE
 	BPF_F_RDONLY_PROG        = linux.BPF_F_RDONLY_PROG
 	BPF_F_WRONLY_PROG        = linux.BPF_F_WRONLY_PROG
+	BPF_F_SLEEPABLE          = linux.BPF_F_SLEEPABLE
 	BPF_OBJ_NAME_LEN         = linux.BPF_OBJ_NAME_LEN
 	BPF_TAG_SIZE             = linux.BPF_TAG_SIZE
 	SYS_BPF                  = linux.SYS_BPF

--- a/internal/unix/types_other.go
+++ b/internal/unix/types_other.go
@@ -28,6 +28,7 @@ const (
 	BPF_F_NUMA_NODE          = 0
 	BPF_F_RDONLY_PROG        = 0
 	BPF_F_WRONLY_PROG        = 0
+	BPF_F_SLEEPABLE          = 0
 	BPF_OBJ_NAME_LEN         = 0x10
 	BPF_TAG_SIZE             = 0x8
 	SYS_BPF                  = 321

--- a/map.go
+++ b/map.go
@@ -40,6 +40,8 @@ type MapSpec struct {
 	KeySize    uint32
 	ValueSize  uint32
 	MaxEntries uint32
+	// Flags is passed to the kernel and specifies additional map
+	// creation attributes.
 	Flags      uint32
 
 	// Automatically pin and load a map from MapOptions.PinPath.

--- a/prog.go
+++ b/prog.go
@@ -55,7 +55,9 @@ type ProgramSpec struct {
 	// depends on Type and AttachType.
 	AttachTo     string
 	Instructions asm.Instructions
-
+	// Flags is passed to the kernel and specifies additional program
+	// load attributes.
+	Flags uint32
 	// License of the program. Some helpers are only available if
 	// the license is deemed compatible with the GPL.
 	//
@@ -158,6 +160,7 @@ func newProgramWithOptions(spec *ProgramSpec, opts ProgramOptions, btfs btfHandl
 	insCount := uint32(len(bytecode) / asm.InstructionSize)
 	attr := &bpfProgLoadAttr{
 		progType:           spec.Type,
+		progFlags:          spec.Flags,
 		expectedAttachType: spec.AttachType,
 		insCount:           insCount,
 		instructions:       internal.NewSlicePointer(bytecode),

--- a/prog_test.go
+++ b/prog_test.go
@@ -551,21 +551,51 @@ func TestProgramSpecTag(t *testing.T) {
 }
 
 func TestProgramTypeLSM(t *testing.T) {
-	prog, err := NewProgram(&ProgramSpec{
-		AttachTo:   "task_getpgid",
-		AttachType: AttachLSMMac,
-		Instructions: asm.Instructions{
-			asm.LoadImm(asm.R0, 0, asm.DWord),
-			asm.Return(),
+	lsmTests := []struct {
+		attachFn    string
+		flags       uint32
+		expectedErr bool
+	}{
+		{
+			attachFn: "task_getpgid",
 		},
-		License: "GPL",
-		Type:    LSM,
-	})
-	testutils.SkipIfNotSupported(t, err)
-	if err != nil {
-		t.Fatal(err)
+		{
+			attachFn:    "task_setnice",
+			flags:       unix.BPF_F_SLEEPABLE,
+			expectedErr: true,
+		},
+		{
+			attachFn: "file_open",
+			flags:    unix.BPF_F_SLEEPABLE,
+		},
 	}
-	prog.Close()
+	for _, tt := range lsmTests {
+		t.Run(tt.attachFn, func(t *testing.T) {
+			prog, err := NewProgram(&ProgramSpec{
+				AttachTo:   tt.attachFn,
+				AttachType: AttachLSMMac,
+				Instructions: asm.Instructions{
+					asm.LoadImm(asm.R0, 0, asm.DWord),
+					asm.Return(),
+				},
+				License: "GPL",
+				Type:    LSM,
+				Flags:   tt.flags,
+			})
+			testutils.SkipIfNotSupported(t, err)
+
+			if tt.flags&unix.BPF_F_SLEEPABLE != 0 {
+				testutils.SkipOnOldKernel(t, "5.11", "BPF_F_SLEEPABLE for LSM progs")
+			}
+			if tt.expectedErr && err == nil {
+				t.Errorf("Test case '%s': expected error", tt.attachFn)
+			}
+			if !tt.expectedErr && err != nil {
+				t.Errorf("Test case '%s': expected success", tt.attachFn)
+			}
+			prog.Close()
+		})
+	}
 }
 
 func createProgramArray(t *testing.T) *Map {


### PR DESCRIPTION
Linux 5.10 added sleepable BPF programs.

Quoting uapi/linux/bpf.h:

"If BPF_F_SLEEPABLE is used in BPF_PROG_LOAD command, the verifier will
restrict map and helper usage for such programs. Sleepable BPF programs can
only be attached to hooks where kernel execution context allows sleeping.
Such programs are allowed to use helpers that may sleep like
bpf_copy_from_user()."

The sleepable BPF programs are used, e.g., with LSM hooks and these
are also detected using "lsm.s" ELF section. This commit adds that
capability to elf_reader too.

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>