### PR TITLE
perf: use constants from sys/unix

### DIFF
--- a/internal/unix/types_linux.go
+++ b/internal/unix/types_linux.go
@@ -47,6 +47,8 @@ const (
 	RLIM_INFINITY            = linux.RLIM_INFINITY
 	RLIMIT_MEMLOCK           = linux.RLIMIT_MEMLOCK
 	BPF_STATS_RUN_TIME       = linux.BPF_STATS_RUN_TIME
+	PERF_RECORD_LOST         = linux.PERF_RECORD_LOST
+	PERF_RECORD_SAMPLE       = linux.PERF_RECORD_SAMPLE
 )
 
 // Statfs_t is a wrapper

--- a/internal/unix/types_other.go
+++ b/internal/unix/types_other.go
@@ -48,6 +48,8 @@ const (
 	RLIM_INFINITY            = 0x7fffffffffffffff
 	RLIMIT_MEMLOCK           = 8
 	BPF_STATS_RUN_TIME       = 0
+	PERF_RECORD_LOST         = 2
+	PERF_RECORD_SAMPLE       = 9
 )
 
 // Statfs_t is a wrapper

--- a/perf/reader.go
+++ b/perf/reader.go
@@ -74,11 +74,6 @@ func readRecordFromRing(ring *perfEventRing) (Record, error) {
 }
 
 func readRecord(rd io.Reader, cpu int) (Record, error) {
-	const (
-		perfRecordLost   = 2
-		perfRecordSample = 9
-	)
-
 	var header perfEventHeader
 	err := binary.Read(rd, internal.NativeEndian, &header)
 	if err == io.EOF {
@@ -90,11 +85,11 @@ func readRecord(rd io.Reader, cpu int) (Record, error) {
 	}
 
 	switch header.Type {
-	case perfRecordLost:
+	case unix.PERF_RECORD_LOST:
 		lost, err := readLostRecords(rd)
 		return Record{CPU: cpu, LostSamples: lost}, err
 
-	case perfRecordSample:
+	case unix.PERF_RECORD_SAMPLE:
 		sample, err := readRawSample(rd)
 		return Record{CPU: cpu, RawSample: sample}, err
 


### PR DESCRIPTION
Replace the hard coded constants with the constants in sys/unix.

Signed-off-by: Florian Lehner <dev@der-flo.net>