### PR TITLE
btf: add VarSecinfo.Var

### DIFF
--- a/internal/btf/types.go
+++ b/internal/btf/types.go
@@ -475,6 +475,13 @@ type VarSecinfo struct {
 	Size   uint32
 }
 
+// Var returns the variable described by the VarSecinfo.
+func (vsi VarSecinfo) Var() *Var {
+	// Type is guaranteed to be a *Var due to the fixup happening in
+	// inflateRawTypes.
+	return vsi.Type.(*Var)
+}
+
 type sizer interface {
 	size() uint32
 }


### PR DESCRIPTION
VarSecinfo.Type is guaranteed to be a *Var. Unfortunately changing
the field to be *Var breaks type traversal via typeDeque, etc. As
a stopgap, add a getter that wraps a type assertion. This is more
convenient than just documenting that VarSecinfo.Type is a *Var.