### PR TITLE
internal - use BytePtrFromString from stdlib in NewStringPointer()

### DIFF
--- a/internal/ptr.go
+++ b/internal/ptr.go
@@ -1,6 +1,10 @@
 package internal
 
-import "unsafe"
+import (
+	"unsafe"
+
+	"github.com/cilium/ebpf/internal/unix"
+)
 
 // NewPointer creates a 64-bit pointer from an unsafe Pointer.
 func NewPointer(ptr unsafe.Pointer) Pointer {
@@ -22,9 +26,10 @@ func NewStringPointer(str string) Pointer {
 		return Pointer{}
 	}
 
-	// The kernel expects strings to be zero terminated
-	buf := make([]byte, len(str)+1)
-	copy(buf, str)
+	p, err := unix.BytePtrFromString(str)
+	if err != nil {
+		return Pointer{}
+	}
 
-	return Pointer{ptr: unsafe.Pointer(&buf[0])}
+	return Pointer{ptr: unsafe.Pointer(p)}
 }

--- a/internal/unix/types_linux.go
+++ b/internal/unix/types_linux.go
@@ -159,6 +159,11 @@ func Tgkill(tgid int, tid int, sig syscall.Signal) (err error) {
 	return linux.Tgkill(tgid, tid, sig)
 }
 
+// BytePtrFromString is a wrapper
+func BytePtrFromString(s string) (*byte, error) {
+	return linux.BytePtrFromString(s)
+}
+
 func KernelRelease() (string, error) {
 	var uname Utsname
 	err := Uname(&uname)

--- a/internal/unix/types_other.go
+++ b/internal/unix/types_other.go
@@ -225,6 +225,11 @@ func Tgkill(tgid int, tid int, sig syscall.Signal) (err error) {
 	return errNonLinux
 }
 
+// BytePtrFromString is a wrapper
+func BytePtrFromString(s string) (*byte, error) {
+	return nil, errNonLinux
+}
+
 func KernelRelease() (string, error) {
 	return "", errNonLinux
 }


### PR DESCRIPTION
As requested in https://github.com/cilium/ebpf/pull/265#discussion_r602169513.

@lmb 