### PR TITLE
CI: apt-get update before installing dependencies

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -26,7 +26,8 @@ blocks:
           - go mod tidy
           - go build ./...
           - sudo pip3 install https://github.com/amluto/virtme/archive/538f1e756139a6b57a4780e7ceb3ac6bcaa4fe6f.zip
-          - sudo apt-get install -y qemu-system-x86 clang-9
+          - sudo apt-get update
+          - sudo apt-get install -y --no-install-recommends qemu-system-x86 clang-9
           - go generate ./cmd/bpf2go
           - git diff --exit-code || { echo "generated files are not up to date" >&2; false; }
       epilogue:


### PR DESCRIPTION
CI runs are currently failing due to a Debian mirror going AWOL.