### PR TITLE
examples/ - Update tracepoint and kprobe examples to use cilium/ebpf/link

### DIFF
--- a/examples/go.mod
+++ b/examples/go.mod
@@ -3,7 +3,7 @@ module github.com/cilium/ebpf/examples
 go 1.15
 
 require (
-	github.com/cilium/ebpf v0.4.0
+	github.com/cilium/ebpf v0.4.1-0.20210401155455-cb5b8b6084b4 // indirect
 	github.com/elastic/go-perf v0.0.0-20191212140718-9c656876f595
 	golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c
 )

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -1,5 +1,7 @@
 github.com/cilium/ebpf v0.4.0 h1:QlHdikaxALkqWasW8hAC1mfR0jdmvbfaBdBPFmRSglA=
 github.com/cilium/ebpf v0.4.0/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJXRs=
+github.com/cilium/ebpf v0.4.1-0.20210401155455-cb5b8b6084b4 h1:MUWurYS35XWJsrE8atN/7egvooNBiSKHcIIYDOA3BHk=
+github.com/cilium/ebpf v0.4.1-0.20210401155455-cb5b8b6084b4/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJXRs=
 github.com/elastic/go-perf v0.0.0-20191212140718-9c656876f595 h1:q8n4QjcLa4q39Q3fqHRknTBXBtegjriHFrB42YKgXGI=
 github.com/elastic/go-perf v0.0.0-20191212140718-9c656876f595/go.mod h1:s09U1b4P1ZxnKx2OsqY7KlHdCesqZWIhyq0Gs/QC/Us=
 github.com/frankban/quicktest v1.11.3 h1:8sXhOn0uLys67V8EsXLc6eszDs8VXWxL3iRvebPhedY=

--- a/examples/tracepoint/main.go
+++ b/examples/tracepoint/main.go
@@ -1,83 +1,88 @@
 // +build linux
 
 // This program demonstrates how to attach an eBPF program to a tracepoint.
-// The program will be attached to the sys_enter_open syscall and print out the integer
-// 123 everytime the sycall is used.
+// The program is attached to the syscall/sys_enter_openat tracepoint and
+// prints out the integer 123 every time the sycall is entered.
 package main
 
 import (
-	"context"
-	"fmt"
+	"log"
 	"os"
-	"runtime"
-	"time"
+	"os/signal"
+	"syscall"
+
+	"golang.org/x/sys/unix"
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/asm"
-	ringbuffer "github.com/cilium/ebpf/perf"
-	"golang.org/x/sys/unix"
-
-	"github.com/elastic/go-perf"
+	"github.com/cilium/ebpf/link"
+	"github.com/cilium/ebpf/perf"
 )
 
+// Metadata for the eBPF program used in this example.
+var progSpec = &ebpf.ProgramSpec{
+	Name:    "my_trace_prog", // non-unique name, will appear in `bpftool prog list` while attached
+	Type:    ebpf.TracePoint, // only TracePoint programs can be attached to trace events created by link.Tracepoint()
+	License: "GPL",           // license must be GPL for calling kernel helpers like perf_event_output
+}
+
 func main() {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
+
+	// Subscribe to signals for terminating the program.
+	stopper := make(chan os.Signal, 1)
+	signal.Notify(stopper, os.Interrupt, syscall.SIGTERM)
 
 	// Increase rlimit so the eBPF map and program can be loaded.
 	if err := unix.Setrlimit(unix.RLIMIT_MEMLOCK, &unix.Rlimit{
 		Cur: unix.RLIM_INFINITY,
 		Max: unix.RLIM_INFINITY,
 	}); err != nil {
-		panic(fmt.Errorf("failed to set temporary rlimit: %v", err))
+		log.Fatalf("setting temporary rlimit: %s", err)
 	}
 
+	// Create a perf event array for the kernel to write perf records to.
+	// These records will be read by userspace below.
 	events, err := ebpf.NewMap(&ebpf.MapSpec{
 		Type: ebpf.PerfEventArray,
-		Name: "pureGo",
+		Name: "my_perf_array",
 	})
 	if err != nil {
-		panic(fmt.Errorf("could not create event map: %v", err))
+		log.Fatalf("creating perf event array: %s", err)
 	}
 	defer events.Close()
 
-	rd, err := ringbuffer.NewReader(events, os.Getpagesize())
+	// Open a perf reader from userspace into the perf event array
+	// created earlier.
+	rd, err := perf.NewReader(events, os.Getpagesize())
 	if err != nil {
-		panic(fmt.Errorf("could not create event reader: %v", err))
+		log.Fatalf("creating event reader: %s", err)
 	}
 	defer rd.Close()
 
+	// Close the reader when the process receives a signal, which will exit
+	// the read loop.
 	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			default:
-			}
-			record, err := rd.Read()
-			if err != nil {
-				if ringbuffer.IsClosed(err) {
-					return
-				}
-				panic(fmt.Errorf("could not read from reader: %v", err))
-			}
-			fmt.Println(record)
-		}
+		<-stopper
+		rd.Close()
 	}()
 
-	ins := asm.Instructions{
+	// Minimal program that writes the static value '123' to the perf ring on
+	// each event. Note that this program refers to the file descriptor of
+	// the perf event array created above, which needs to be created prior to the
+	// program being verified by and inserted into the kernel.
+	progSpec.Instructions = asm.Instructions{
 		// store the integer 123 at FP[-8]
 		asm.Mov.Imm(asm.R2, 123),
 		asm.StoreMem(asm.RFP, -8, asm.R2, asm.Word),
 
 		// load registers with arguments for call of FnPerfEventOutput
-		asm.LoadMapPtr(asm.R2, events.FD()),
+		asm.LoadMapPtr(asm.R2, events.FD()), // file descriptor of the perf event array
 		asm.LoadImm(asm.R3, 0xffffffff, asm.DWord),
 		asm.Mov.Reg(asm.R4, asm.RFP),
 		asm.Add.Imm(asm.R4, -8),
 		asm.Mov.Imm(asm.R5, 4),
 
-		// call FnPerfEventOutput
+		// call FnPerfEventOutput, an eBPF kernel helper
 		asm.FnPerfEventOutput.Call(),
 
 		// set exit code to 0
@@ -85,38 +90,35 @@ func main() {
 		asm.Return(),
 	}
 
-	prog, err := ebpf.NewProgram(&ebpf.ProgramSpec{
-		Name:         "trace_open",
-		Type:         ebpf.TracePoint,
-		License:      "GPL",
-		Instructions: ins,
-	})
+	// Instantiate and insert the program into the kernel.
+	prog, err := ebpf.NewProgram(progSpec)
 	if err != nil {
-		panic(fmt.Errorf("could not create new ebpf program: %v", err))
+		log.Fatalf("creating ebpf program: %s", err)
 	}
 	defer prog.Close()
 
-	ga := new(perf.Attr)
-	gtp := perf.Tracepoint("syscalls", "sys_enter_open")
-	if err := gtp.Configure(ga); err != nil {
-		panic(fmt.Errorf("failed to configure tracepoint: %v", err))
-	}
-
-	runtime.LockOSThread()
-	defer runtime.UnlockOSThread()
-
-	openTracepoint, err := perf.Open(ga, perf.AllThreads, 0, nil)
+	// Open a trace event based on a pre-existing kernel hook (tracepoint).
+	// Each time a userspace program uses the 'openat()' syscall, the eBPF
+	// program specified above will be executed and a '123' value will appear
+	// in the perf ring.
+	tp, err := link.Tracepoint("syscalls", "sys_enter_openat", prog)
 	if err != nil {
-		panic(fmt.Errorf("failed to open perf event on tracepoint: %v", err))
+		log.Fatalf("opening tracepoint: %s", err)
 	}
-	defer openTracepoint.Close()
+	defer tp.Close()
 
-	if err := openTracepoint.SetBPF(uint32(prog.FD())); err != nil {
-		panic(fmt.Errorf("failed to attach eBPF to tracepoint: %v", err))
-	}
-	if err := openTracepoint.Enable(); err != nil {
-		panic(fmt.Errorf("failed to enable eBPF to tracepoint: %v", err))
-	}
+	log.Println("Waiting for events..")
 
-	<-ctx.Done()
+	for {
+		record, err := rd.Read()
+		if err != nil {
+			if perf.IsClosed(err) {
+				log.Println("Received signal, exiting..")
+				return
+			}
+			log.Fatalf("reading from reader: %s", err)
+		}
+
+		log.Println("Record:", record)
+	}
 }


### PR DESCRIPTION
Now using link's nice Tracepoint() and Kprobe() API instead of go-perf!

Also added some documentation in the tracepoint and kprobe examples, since it was quite sparse. This should make it clearer to newcomers.