### PR TITLE
pinning: Disallow replace during pinning

### DIFF
--- a/internal/unix/types_linux.go
+++ b/internal/unix/types_linux.go
@@ -53,6 +53,8 @@ const (
 	BPF_STATS_RUN_TIME       = linux.BPF_STATS_RUN_TIME
 	PERF_RECORD_LOST         = linux.PERF_RECORD_LOST
 	PERF_RECORD_SAMPLE       = linux.PERF_RECORD_SAMPLE
+	AT_FDCWD                 = linux.AT_FDCWD
+	RENAME_NOREPLACE         = linux.RENAME_NOREPLACE
 )
 
 // Statfs_t is a wrapper
@@ -171,6 +173,11 @@ func Tgkill(tgid int, tid int, sig syscall.Signal) (err error) {
 // BytePtrFromString is a wrapper
 func BytePtrFromString(s string) (*byte, error) {
 	return linux.BytePtrFromString(s)
+}
+
+// Renameat2 is a wrapper
+func Renameat2(olddirfd int, oldpath string, newdirfd int, newpath string, flags uint) error {
+	return linux.Renameat2(olddirfd, oldpath, newdirfd, newpath, flags)
 }
 
 func KernelRelease() (string, error) {

--- a/internal/unix/types_other.go
+++ b/internal/unix/types_other.go
@@ -54,6 +54,8 @@ const (
 	BPF_STATS_RUN_TIME       = 0
 	PERF_RECORD_LOST         = 2
 	PERF_RECORD_SAMPLE       = 9
+	AT_FDCWD                 = -0x2
+	RENAME_NOREPLACE         = 0x1
 )
 
 // Statfs_t is a wrapper
@@ -237,6 +239,11 @@ func Tgkill(tgid int, tid int, sig syscall.Signal) (err error) {
 // BytePtrFromString is a wrapper
 func BytePtrFromString(s string) (*byte, error) {
 	return nil, errNonLinux
+}
+
+// Renameat2 is a wrapper
+func Renameat2(olddirfd int, oldpath string, newdirfd int, newpath string, flags uint) error {
+	return errNonLinux
 }
 
 func KernelRelease() (string, error) {

--- a/map.go
+++ b/map.go
@@ -805,7 +805,8 @@ func (m *Map) Clone() (*Map, error) {
 // Pin persists the map on the BPF virtual file system past the lifetime of
 // the process that created it .
 //
-// Calling Pin on a previously pinned map will override the path.
+// Calling Pin on a previously pinned map will overwrite the path, except when
+// the new path already exists. Re-pinning across filesystems is not supported.
 // You can Clone a map to pin it to a different path.
 //
 // This requires bpffs to be mounted above fileName. See https://docs.cilium.io/en/k8s-doc/admin/#admin-mount-bpffs

--- a/map_test.go
+++ b/map_test.go
@@ -433,6 +433,30 @@ func TestMapPinWithEmptyPath(t *testing.T) {
 	c.Assert(err, qt.Not(qt.IsNil))
 }
 
+func TestMapPinFailReplace(t *testing.T) {
+	tmp := tempBPFFS(t)
+	c := qt.New(t)
+	spec := spec1.Copy()
+	spec2 := spec1.Copy()
+	spec2.Name = spec1.Name + "bar"
+
+	m, err := NewMapWithOptions(spec, MapOptions{PinPath: tmp})
+	if err != nil {
+		t.Fatal("Failed to create map:", err)
+	}
+	defer m.Close()
+	m2, err := NewMapWithOptions(spec2, MapOptions{PinPath: tmp})
+	if err != nil {
+		t.Fatal("Failed to create map2:", err)
+	}
+	defer m2.Close()
+	c.Assert(m.IsPinned(), qt.Equals, true)
+	newPath := filepath.Join(tmp, spec2.Name)
+
+	c.Assert(m.Pin(newPath), qt.Not(qt.IsNil), qt.Commentf("Pin didn't"+
+		" fail new path from replacing an existing path"))
+}
+
 func TestMapUnpin(t *testing.T) {
 	tmp := tempBPFFS(t)
 	c := qt.New(t)

--- a/prog.go
+++ b/prog.go
@@ -345,6 +345,9 @@ func (p *Program) Clone() (*Program, error) {
 // Pin persists the Program on the BPF virtual file system past the lifetime of
 // the process that created it
 //
+// Calling Pin on a previously pinned program will overwrite the path, except when
+// the new path already exists. Re-pinning across filesystems is not supported.
+//
 // This requires bpffs to be mounted above fileName. See https://docs.cilium.io/en/k8s-doc/admin/#admin-mount-bpffs
 func (p *Program) Pin(fileName string) error {
 	if err := pin(p.pinnedPath, fileName, p.fd); err != nil {


### PR DESCRIPTION
The current implementation uses `os.Rename` which calls `rename` to overwrite an existing pinned path. If the new path already existed before the overwrite, it'll simply be replaced with this syscall. Hence, use the `renameat2` syscall instead that can disallow the replace behavior.

Note to reviewers: Do we want to expose an API that gives user the option to instead replace the new pinned path (i.e. call `renameat2 `with `RENAME_EXCHANGE`), which is the default behavior of the `rename`* syscalls?

Fixes: #263 
Suggested-by : @lmb 