### PR TITLE
link: set a finalizer on perfEvent

### DIFF
--- a/link/perf_event.go
+++ b/link/perf_event.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strconv"
 	"strings"
 	"unsafe"
@@ -161,6 +162,8 @@ func (pe *perfEvent) attach(prog *ebpf.Program) error {
 		return fmt.Errorf("enable perf event: %s", err)
 	}
 
+	// Close the perf event when its reference is lost to avoid leaking system resources.
+	runtime.SetFinalizer(pe, (*perfEvent).Close)
 	return nil
 }
 

--- a/link/tracepoint.go
+++ b/link/tracepoint.go
@@ -48,6 +48,7 @@ func Tracepoint(group, name string, prog *ebpf.Program) (Link, error) {
 	}
 
 	if err := pe.attach(prog); err != nil {
+		pe.Close()
 		return nil, err
 	}
 


### PR DESCRIPTION
Try to clean up perfEvent even if it's leaked by setting a finalizer
on it.