### PR TITLE
Increase coverage from libbpf selftests

### DIFF
--- a/cmd/bpf2go/api_test.go
+++ b/cmd/bpf2go/api_test.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"testing"
+
+	// Raise RLIMIT_MEMLOCK
+	_ "github.com/cilium/ebpf/internal/testutils"
 )
 
 func TestLoadingSpec(t *testing.T) {

--- a/elf_reader.go
+++ b/elf_reader.go
@@ -847,6 +847,8 @@ func getProgType(sectionName string) (ProgramType, AttachType, uint32, string) {
 		"uretprobe/":            {Kprobe, AttachNone, 0},
 		"tracepoint/":           {TracePoint, AttachNone, 0},
 		"raw_tracepoint/":       {RawTracepoint, AttachNone, 0},
+		"raw_tp/":               {RawTracepoint, AttachNone, 0},
+		"tp_btf/":               {Tracing, AttachTraceRawTp, 0},
 		"xdp":                   {XDP, AttachNone, 0},
 		"perf_event":            {PerfEvent, AttachNone, 0},
 		"lwt_in":                {LWTIn, AttachNone, 0},

--- a/elf_reader_test.go
+++ b/elf_reader_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 
 	"github.com/cilium/ebpf/internal"
@@ -119,7 +120,7 @@ func TestLoadCollectionSpec(t *testing.T) {
 		}),
 	)
 
-	testutils.TestFiles(t, "testdata/loader-*.elf", func(t *testing.T, file string) {
+	testutils.Files(t, testutils.Glob(t, "testdata/loader-*.elf"), func(t *testing.T, file string) {
 		have, err := LoadCollectionSpec(file)
 		if err != nil {
 			t.Fatal("Can't parse ELF:", err)
@@ -208,7 +209,7 @@ func TestCollectionSpecDetach(t *testing.T) {
 }
 
 func TestLoadInvalidMap(t *testing.T) {
-	testutils.TestFiles(t, "testdata/invalid_map-*.elf", func(t *testing.T, file string) {
+	testutils.Files(t, testutils.Glob(t, "testdata/invalid_map-*.elf"), func(t *testing.T, file string) {
 		_, err := LoadCollectionSpec(file)
 		t.Log(err)
 		if err == nil {
@@ -218,7 +219,7 @@ func TestLoadInvalidMap(t *testing.T) {
 }
 
 func TestLoadInvalidMapMissingSymbol(t *testing.T) {
-	testutils.TestFiles(t, "testdata/invalid_map_static-el.elf", func(t *testing.T, file string) {
+	testutils.Files(t, testutils.Glob(t, "testdata/invalid_map_static-el.elf"), func(t *testing.T, file string) {
 		_, err := LoadCollectionSpec(file)
 		t.Log(err)
 		if err == nil {
@@ -228,7 +229,7 @@ func TestLoadInvalidMapMissingSymbol(t *testing.T) {
 }
 
 func TestLoadInitializedBTFMap(t *testing.T) {
-	testutils.TestFiles(t, "testdata/initialized_btf_map-*.elf", func(t *testing.T, file string) {
+	testutils.Files(t, testutils.Glob(t, "testdata/initialized_btf_map-*.elf"), func(t *testing.T, file string) {
 		_, err := LoadCollectionSpec(file)
 		t.Log(err)
 		if !errors.Is(err, internal.ErrNotSupported) {
@@ -238,7 +239,7 @@ func TestLoadInitializedBTFMap(t *testing.T) {
 }
 
 func TestStringSection(t *testing.T) {
-	testutils.TestFiles(t, "testdata/strings-*.elf", func(t *testing.T, file string) {
+	testutils.Files(t, testutils.Glob(t, "testdata/strings-*.elf"), func(t *testing.T, file string) {
 		_, err := LoadCollectionSpec(file)
 		t.Log(err)
 		if !errors.Is(err, ErrNotSupported) {
@@ -253,7 +254,7 @@ func TestStringSection(t *testing.T) {
 func TestLoadRawTracepoint(t *testing.T) {
 	testutils.SkipOnOldKernel(t, "4.17", "BPF_RAW_TRACEPOINT API")
 
-	testutils.TestFiles(t, "testdata/raw_tracepoint-*.elf", func(t *testing.T, file string) {
+	testutils.Files(t, testutils.Glob(t, "testdata/raw_tracepoint-*.elf"), func(t *testing.T, file string) {
 		spec, err := LoadCollectionSpec(file)
 		if err != nil {
 			t.Fatal("Can't parse ELF:", err)
@@ -290,27 +291,116 @@ func TestLibBPFCompat(t *testing.T) {
 		t.Skip("No path specified")
 	}
 
-	testutils.TestFiles(t, filepath.Join(*elfPath, *elfPattern), func(t *testing.T, path string) {
+	load := func(t *testing.T, spec *CollectionSpec, opts CollectionOptions, valid bool) {
+		// Disable retrying a program load with the log enabled, it leads
+		// to OOM kills.
+		opts.Programs.LogSize = -1
+		coll, err := NewCollectionWithOptions(spec, opts)
+		testutils.SkipIfNotSupported(t, err)
+		var errno syscall.Errno
+		if errors.As(err, &errno) {
+			// This error is most likely from a syscall and caused by us not
+			// replicating some fixups done in the selftests. This is expected,
+			// so skip the test instead of failing.
+			t.Skip("Skipping since the kernel rejected the program:", errno)
+		}
+		if err == nil {
+			coll.Close()
+		}
+		if !valid {
+			if err == nil {
+				t.Fatal("Expected an error during load")
+			}
+		} else if err != nil {
+			t.Fatal("Error during loading:", err)
+		}
+	}
+
+	files := testutils.Glob(t, filepath.Join(*elfPath, *elfPattern),
+		// These files are only used as a source of btf.
+		"btf__core_reloc_*",
+	)
+
+	testutils.Files(t, files, func(t *testing.T, path string) {
 		file := filepath.Base(path)
 		switch file {
-		case "test_ksyms.o":
-			// Issue #114
-			t.Skip("Kernel symbols not supported")
 		case "test_sk_assign.o":
-			t.Skip("Incompatible struct bpf_map_def")
-		case "test_ringbuf_multi.o", "map_ptr_kern.o", "test_btf_map_in_map.o":
-			// Issue #155
-			t.Skip("BTF .values not supported")
+			t.Skip("Skipping due to incompatible struct bpf_map_def")
+		case "test_map_in_map.o", "test_select_reuseport_kern.o":
+			t.Skip("Skipping due to missing InnerMap in map definition")
+		case "test_core_autosize.o":
+			t.Skip("Skipping since the test generates dynamic BTF")
 		}
 
 		t.Parallel()
 
-		_, err := LoadCollectionSpec(path)
+		spec, err := LoadCollectionSpec(path)
 		testutils.SkipIfNotSupported(t, err)
 		if err != nil {
 			t.Fatalf("Can't read %s: %s", file, err)
 		}
+
+		var opts CollectionOptions
+		for _, mapSpec := range spec.Maps {
+			if mapSpec.Pinning != PinNone {
+				opts.Maps.PinPath = testutils.TempBPFFS(t)
+				break
+			}
+		}
+
+		coreFiles := sourceOfBTF(t, path)
+		if len(coreFiles) == 0 {
+			// NB: test_core_reloc_kernel.o doesn't have dedicated BTF and
+			// therefore goes via this code path.
+			load(t, spec, opts, true)
+			return
+		}
+
+		for _, coreFile := range coreFiles {
+			name := filepath.Base(coreFile)
+			t.Run(name, func(t *testing.T) {
+				// Some files like btf__core_reloc_arrays___err_too_small.o
+				// trigger an error on purpose. Use the name to infer whether
+				// the test should succeed.
+				var valid bool
+				switch name {
+				case "btf__core_reloc_type_based___all_missing.o",
+					"btf__core_reloc_type_id___missing_targets.o", "btf__core_reloc_flavors__err_wrong_name.o":
+					valid = false
+				default:
+					valid = !strings.Contains(name, "___err_")
+				}
+
+				fh, err := os.Open(coreFile)
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer fh.Close()
+
+				opts := opts // copy
+				opts.Programs.TargetBTF = fh
+				load(t, spec, opts, valid)
+			})
+		}
 	})
+}
+
+func sourceOfBTF(tb testing.TB, path string) []string {
+	const testPrefix = "test_core_reloc_"
+	const btfPrefix = "btf__core_reloc_"
+
+	dir, base := filepath.Split(path)
+	if !strings.HasPrefix(base, testPrefix) {
+		return nil
+	}
+
+	base = strings.TrimSuffix(base[len(testPrefix):], ".o")
+	switch base {
+	case "bitfields_direct", "bitfields_probed":
+		base = "bitfields"
+	}
+
+	return testutils.Glob(tb, filepath.Join(dir, btfPrefix+base+"*.o"))
 }
 
 func TestGetProgType(t *testing.T) {

--- a/internal/btf/btf_test.go
+++ b/internal/btf/btf_test.go
@@ -79,7 +79,7 @@ func TestParseCurrentKernelBTF(t *testing.T) {
 }
 
 func TestLoadSpecFromElf(t *testing.T) {
-	testutils.TestFiles(t, "../../testdata/loader-clang-9-*.elf", func(t *testing.T, file string) {
+	testutils.Files(t, testutils.Glob(t, "../../testdata/loader-clang-9-*.elf"), func(t *testing.T, file string) {
 		fh, err := os.Open(file)
 		if err != nil {
 			t.Fatal(err)

--- a/internal/btf/core.go
+++ b/internal/btf/core.go
@@ -109,7 +109,7 @@ func coreRelocate(local, target *Spec, coreRelos bpfCoreRelos) (map[uint64]Reloc
 		name := essentialName(named.name())
 		res, err := coreCalculateRelocation(typ, target.namedTypes[name], relo.ReloKind, accessor)
 		if err != nil {
-			return nil, fmt.Errorf("relocate %s: %w", name, err)
+			return nil, fmt.Errorf("relocate %s: %w", typ, err)
 		}
 
 		relocations[uint64(relo.InsnOff)] = res

--- a/internal/btf/core_test.go
+++ b/internal/btf/core_test.go
@@ -178,7 +178,7 @@ func TestCoreAccessor(t *testing.T) {
 }
 
 func TestCoreRelocation(t *testing.T) {
-	testutils.TestFiles(t, "testdata/*.elf", func(t *testing.T, file string) {
+	testutils.Files(t, testutils.Glob(t, "testdata/*.elf"), func(t *testing.T, file string) {
 		rd, err := os.Open(file)
 		if err != nil {
 			t.Fatal(err)

--- a/internal/errors.go
+++ b/internal/errors.go
@@ -29,6 +29,10 @@ type VerifierError struct {
 	log   string
 }
 
+func (le *VerifierError) Unwrap() error {
+	return le.cause
+}
+
 func (le *VerifierError) Error() string {
 	if le.log == "" {
 		return le.cause.Error()

--- a/internal/ptr.go
+++ b/internal/ptr.go
@@ -22,10 +22,6 @@ func NewSlicePointer(buf []byte) Pointer {
 
 // NewStringPointer creates a 64-bit pointer from a string.
 func NewStringPointer(str string) Pointer {
-	if str == "" {
-		return Pointer{}
-	}
-
 	p, err := unix.BytePtrFromString(str)
 	if err != nil {
 		return Pointer{}

--- a/internal/testutils/glob.go
+++ b/internal/testutils/glob.go
@@ -5,19 +5,14 @@ import (
 	"testing"
 )
 
-// TestFiles calls fn for each file matching pattern.
+// Files calls fn for each given file.
 //
 // The function errors out if the pattern matches no files.
-func TestFiles(t *testing.T, pattern string, fn func(*testing.T, string)) {
+func Files(t *testing.T, files []string, fn func(*testing.T, string)) {
 	t.Helper()
 
-	files, err := filepath.Glob(pattern)
-	if err != nil {
-		t.Fatal("Can't glob files:", err)
-	}
-
 	if len(files) == 0 {
-		t.Fatalf("Pattern %s matched no files", pattern)
+		t.Fatalf("No files given")
 	}
 
 	for _, f := range files {
@@ -27,4 +22,37 @@ func TestFiles(t *testing.T, pattern string, fn func(*testing.T, string)) {
 			fn(t, file)
 		})
 	}
+}
+
+// Glob finds files matching a pattern.
+//
+// The pattern should may include full path. Excludes use the same syntax as
+// pattern, but are only applied to the basename instead of the full path.
+func Glob(tb testing.TB, pattern string, excludes ...string) []string {
+	tb.Helper()
+
+	files, err := filepath.Glob(pattern)
+	if err != nil {
+		tb.Fatal("Can't glob files:", err)
+	}
+
+	if len(excludes) == 0 {
+		return files
+	}
+
+	var filtered []string
+nextFile:
+	for _, file := range files {
+		base := filepath.Base(file)
+		for _, exclude := range excludes {
+			if matched, err := filepath.Match(exclude, base); err != nil {
+				tb.Fatal(err)
+			} else if matched {
+				continue nextFile
+			}
+		}
+		filtered = append(filtered, file)
+	}
+
+	return filtered
 }

--- a/internal/testutils/rlimit.go
+++ b/internal/testutils/rlimit.go
@@ -1,0 +1,20 @@
+package testutils
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/cilium/ebpf/internal/unix"
+)
+
+func init() {
+	// Increase the memlock for all tests unconditionally. It's a great source of
+	// weird bugs, since different distros have different default limits.
+	err := unix.Setrlimit(unix.RLIMIT_MEMLOCK, &unix.Rlimit{
+		Cur: unix.RLIM_INFINITY,
+		Max: unix.RLIM_INFINITY,
+	})
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "WARNING: Failed to adjust rlimit, tests may fail")
+	}
+}

--- a/linker.go
+++ b/linker.go
@@ -108,12 +108,16 @@ func fixupJumpsAndCalls(insns asm.Instructions) error {
 		offset := iter.Offset
 		ins := iter.Ins
 
+		if ins.Reference == "" {
+			continue
+		}
+
 		switch {
 		case ins.IsFunctionCall() && ins.Constant == -1:
 			// Rewrite bpf to bpf call
 			callOffset, ok := symbolOffsets[ins.Reference]
 			if !ok {
-				return fmt.Errorf("instruction %d: reference to missing symbol %q", i, ins.Reference)
+				return fmt.Errorf("call at %d: reference to missing symbol %q", i, ins.Reference)
 			}
 
 			ins.Constant = int64(callOffset - offset - 1)
@@ -122,7 +126,7 @@ func fixupJumpsAndCalls(insns asm.Instructions) error {
 			// Rewrite jump to label
 			jumpOffset, ok := symbolOffsets[ins.Reference]
 			if !ok {
-				return fmt.Errorf("instruction %d: reference to missing symbol %q", i, ins.Reference)
+				return fmt.Errorf("jump at %d: reference to missing symbol %q", i, ins.Reference)
 			}
 
 			ins.Offset = int16(jumpOffset - offset - 1)

--- a/map.go
+++ b/map.go
@@ -214,7 +214,7 @@ func newMapWithOptions(spec *MapSpec, opts MapOptions, handles *handleCache) (_ 
 		// Nothing to do here
 
 	default:
-		return nil, fmt.Errorf("unsupported pin type %d", int(spec.Pinning))
+		return nil, fmt.Errorf("pin type %d: %w", int(spec.Pinning), ErrNotSupported)
 	}
 
 	var innerFd *internal.FD

--- a/map_test.go
+++ b/map_test.go
@@ -32,17 +32,6 @@ var (
 	}
 )
 
-func TestMain(m *testing.M) {
-	err := unix.Setrlimit(unix.RLIMIT_MEMLOCK, &unix.Rlimit{
-		Cur: unix.RLIM_INFINITY,
-		Max: unix.RLIM_INFINITY,
-	})
-	if err != nil {
-		fmt.Println("WARNING: Failed to adjust rlimit, tests may fail")
-	}
-	os.Exit(m.Run())
-}
-
 func TestMap(t *testing.T) {
 	m := createArray(t)
 	defer m.Close()

--- a/perf/reader_test.go
+++ b/perf/reader_test.go
@@ -20,17 +20,6 @@ var (
 	readTimeout = 250 * time.Millisecond
 )
 
-func TestMain(m *testing.M) {
-	err := unix.Setrlimit(unix.RLIMIT_MEMLOCK, &unix.Rlimit{
-		Cur: unix.RLIM_INFINITY,
-		Max: unix.RLIM_INFINITY,
-	})
-	if err != nil {
-		fmt.Println("WARNING: Failed to adjust rlimit, tests may fail")
-	}
-	os.Exit(m.Run())
-}
-
 func TestPerfReader(t *testing.T) {
 	prog, events := mustOutputSamplesProg(t, 5)
 	defer prog.Close()

--- a/prog.go
+++ b/prog.go
@@ -261,7 +261,7 @@ func newProgramWithOptions(spec *ProgramSpec, opts ProgramOptions, handles *hand
 	}
 
 	logErr := err
-	if opts.LogLevel == 0 {
+	if opts.LogLevel == 0 && opts.LogSize >= 0 {
 		// Re-run with the verifier enabled to get better error messages.
 		logBuf = make([]byte, logSize)
 		attr.logLevel = 1

--- a/prog.go
+++ b/prog.go
@@ -143,10 +143,6 @@ func newProgramWithOptions(spec *ProgramSpec, opts ProgramOptions, handles *hand
 		return nil, errors.New("Instructions cannot be empty")
 	}
 
-	if len(spec.License) == 0 {
-		return nil, errors.New("License cannot be empty")
-	}
-
 	if spec.ByteOrder != nil && spec.ByteOrder != internal.NativeEndian {
 		return nil, fmt.Errorf("can't load %s program on %s", spec.ByteOrder, internal.NativeEndian)
 	}

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -39,7 +39,7 @@ if [[ "${1:-}" = "--exec-vm" ]]; then
   output="$(mktemp -d)"
   printf -v cmd "%q " "$@"
 
-  $sudo virtme-run --kimg "${input}/bzImage" --memory 512M --pwd \
+  $sudo virtme-run --kimg "${input}/bzImage" --memory 768M --pwd \
   --rwdir="${testdir}=${testdir}" \
   --rodir=/run/input="${input}" \
   --rwdir=/run/output="${output}" \
@@ -62,7 +62,11 @@ elif [[ "${1:-}" = "--exec-test" ]]; then
     export KERNEL_SELFTESTS="/run/input/bpf"
   fi
 
-  "$@"
+  dmesg -C
+  if ! "$@"; then
+    dmesg
+    exit 1
+  fi
   touch "/run/output/success"
   exit 0
 fi


### PR DESCRIPTION
elf: increase coverage of libbpf integration test
    
    The libbpf integration tests currently only test the ELF loader, since
    we never attempt to load the collection into the kernel. This leaves
    out a good chunck of code, e.g. CO-RE relocation handling.
    
    Attempt to load kernel selftests into the kernel. Since we don't want
    to replicate the user space portion of the selftests we have to be
    quite lax in what we consider an error. The following cases lead
    to a skipped test:
    
    * ErrIsNotSupported indicates that we've hit a known deficiency in the
      library.
    * syscall.Errno indicates that we've made it all the way up to loading
      a map or program, but don't have the necessary set up code.
    
    All other errors are considered bugs.

program: allow specifying a custom target for CO-RE relocations
    
    We need a target BTF when calculating CO-RE relocations for a program.
    By default this is the BTF for the current kernel. This is too inflexible:
    
    Sometimes the kernel doesn't have BTF and so the BTF has to come from a
    separate file. The library might also be used in a container where the
    canonical paths aren't available.
    
    Furthermore, some programs actually relocate against themselves for
    testing purposes.
    
    Allow specifing an io.ReaderAt in ProgramOptions which is used as the
    target BTF for CO-RE relocations.
    
Fixes #254

internal: allow unwrapping VerifierError
    
    VerifierError hides the underlying syscall error from inspection.
    Implement Unwrap() so that callers can check for syscall.Errno.

program: allow empty License
    
    The kernel has a requirement to provide a license string, but the
    string itself can be empty. Allow empty License to be able to load
    a bunch of kernel selftests.

map: return ErrNotSupported for unknown pin types

linker: don't fix up instructions without a Reference
    
    The kernel selftests contain the follwing assembly in test_get_stack_rawtp_err.o:
    
        ;   while (1) {
        6:  05 00 ff ff 00 00 00 00 goto -1 <LBB0_1>
    
    which is generated for the following C snippet:
    
        while (1) {
            error++;
        }
    
    Basically, the infinite loop is turned into a jump to -1, aka the
    jump instruction itself. The linker currently interprets the -1 to
    mean "requires relocation" and so gives a somewhat cryptic error.
    
    Stop trying to fix up jumps and calls if they don't have a refernce.
