### PR TITLE
run-test.sh cleanups

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -32,7 +32,7 @@ fi
 
 # Pull all dependencies, so that we can run tests without the
 # vm having network access.
-go mod download
+go mod tidy
 
 # Use sudo if /dev/kvm isn't accessible by the current user.
 sudo=""

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 # Test the current package under a different kernel.
 # Requires virtme and qemu to be installed.
+# Examples:
+#     Run all tests on a 5.4 kernel
+#     $ ./run-tests.sh 5.4
+#     Run a subset of tests:
+#     $ ./run-tests.sh 5.4 go test ./link
 
 set -eu
 set -o pipefail
@@ -21,12 +26,8 @@ if [[ "${1:-}" = "--in-vm" ]]; then
     export KERNEL_SELFTESTS="/run/input/bpf"
   fi
 
-  readonly output="${1}"
-  shift
-
-  echo Running tests...
-  go test -v -coverpkg=./... -coverprofile="$output/coverage.txt" -count 1 ./...
-  touch "$output/success"
+  eval "$@"
+  touch "/run/output/success"
   exit 0
 fi
 
@@ -46,6 +47,7 @@ if [[ -z "${kernel_version}" ]]; then
   echo "Expecting kernel version as first argument"
   exit 1
 fi
+shift
 
 readonly kernel="linux-${kernel_version}.bz"
 readonly selftests="linux-${kernel_version}-selftests-bpf.bz"
@@ -68,6 +70,12 @@ else
   echo "No selftests found, disabling"
 fi
 
+if (( $# > 0 )); then
+  printf -v cmd " %q" "$@"
+else
+  printf -v cmd " %q" go test -v -coverpkg=./... -coverprofile="/run/output/coverage.txt" -count 1 ./...
+fi
+
 echo Testing on "${kernel_version}"
 $sudo virtme-run --kimg "${tmp_dir}/${kernel}" --memory 512M --pwd \
   --rw \
@@ -75,7 +83,7 @@ $sudo virtme-run --kimg "${tmp_dir}/${kernel}" --memory 512M --pwd \
   --rwdir=/run/output="${output}" \
   --rodir=/run/go-path="$(go env GOPATH)" \
   --rwdir=/run/go-cache="$(go env GOCACHE)" \
-  --script-sh "PATH=\"$PATH\" $(realpath "$0") --in-vm /run/output" \
+  --script-sh "PATH=\"$PATH\" $(realpath "$0") --in-vm $cmd" \
   --qemu-opts -smp 2 # need at least two CPUs for some tests
 
 if [[ ! -e "${output}/success" ]]; then
@@ -83,7 +91,7 @@ if [[ ! -e "${output}/success" ]]; then
   exit 1
 else
   echo "Test successful on ${kernel_version}"
-  if [[ -v COVERALLS_TOKEN ]]; then
+  if [[ -v COVERALLS_TOKEN && -f "${output}/coverage.txt" ]]; then
     goveralls -coverprofile="${output}/coverage.txt" -service=semaphore -repotoken "$COVERALLS_TOKEN"
   fi
 fi


### PR DESCRIPTION
run-tests: run a custom command in the vm
    
    Let the user specify the command to execute in the VM. This is useful
    if you want to run only a subset of tests, for example.

run-tests: use go mod tidy
    
    go mod download for some reason modifies go.mod. According to an upstream
    Golang issue "go mod tidy" is the preferred command to prime the module
    cache.
