### PR TITLE
CI: remove 5.9

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -53,6 +53,6 @@ blocks:
       - name: Run unit tests
         matrix:
           - env_var: KERNEL_VERSION
-            values: ["5.10", "5.9", "5.4", "4.19", "4.9"]
+            values: ["5.10", "5.4", "4.19", "4.9"]
         commands:
           - timeout -s KILL 600s ./run-tests.sh $KERNEL_VERSION


### PR DESCRIPTION
The 5.9 series is not maintained anymore per kernel.org, remove it from
CI builds.