### PR TITLE
Uprobe and Tracepoint integration tests

### DIFF
--- a/link/tracepoint_test.go
+++ b/link/tracepoint_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cilium/ebpf/asm"
 	"github.com/cilium/ebpf/internal"
 	"github.com/cilium/ebpf/internal/testutils"
+	"github.com/cilium/ebpf/internal/unix"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -73,5 +74,46 @@ func TestTraceGetEventID(t *testing.T) {
 	_, err = getTraceEventID("totally", "bogus")
 	if !errors.Is(err, internal.ErrNotSupported) {
 		t.Fatal("Doesn't return ErrNotSupported")
+	}
+}
+
+func TestTracepointProgramCall(t *testing.T) {
+	// Create ebpf map. Will contain only one key with initial value 0.
+	m, err := ebpf.NewMap(&ebpf.MapSpec{
+		Type:       ebpf.Array,
+		KeySize:    4,
+		ValueSize:  4,
+		MaxEntries: 1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create ebpf program. When called, will set the value of key 0 in
+	// the map created above to 1.
+	p := newMapUpdaterProg(t, m, ebpf.TracePoint)
+
+	// Open Tracepoint at /sys/kernel/debug/tracing/events/syscalls/sys_enter_getpid
+	// and attach it to the ebpf program created above.
+	tp, err := Tracepoint("syscalls", "sys_enter_getpid", p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func(l Link) {
+		if err := l.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}(tp)
+
+	// Trigger ebpf program call.
+	unix.Getpid()
+
+	// Assert that the value has been updated to 1.
+	var val uint32
+	if err := m.Lookup(uint32(0), &val); err != nil {
+		t.Fatal(err)
+	}
+	if val != 1 {
+		t.Fatalf("unexpected value: want '1', got '%d'", val)
 	}
 }

--- a/link/uprobe_test.go
+++ b/link/uprobe_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
@@ -246,5 +247,46 @@ func TestUprobePathOffset(t *testing.T) {
 				t.Errorf("Expected path:offset to be '%s', got '%s'", tt.expected, po)
 			}
 		})
+	}
+}
+
+func TestUprobeProgramCall(t *testing.T) {
+	// Create ebpf map. Will contain only one key with initial value 0.
+	m, err := ebpf.NewMap(&ebpf.MapSpec{
+		Type:       ebpf.Array,
+		KeySize:    4,
+		ValueSize:  4,
+		MaxEntries: 1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create ebpf program. When called, will set the value of key 0 in
+	// the map created above to 1.
+	p := newMapUpdaterProg(t, m, ebpf.Kprobe)
+
+	// Open Uprobe on '/bin/bash' for the symbol 'main'
+	// and attach it to the ebpf program created above.
+	u, err := bashEx.Uprobe(bashSym, p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func(l Link) {
+		if err := l.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}(u)
+
+	// Trigger ebpf program call.
+	exec.Command("/bin/bash", "42").Run()
+
+	// Assert that the value has been updated to 1.
+	var val uint32
+	if err := m.Lookup(uint32(0), &val); err != nil {
+		t.Fatal(err)
+	}
+	if val != 1 {
+		t.Fatalf("unexpected value: want '1', got '%d'", val)
 	}
 }


### PR DESCRIPTION
This PR adds the remaining integration tests for Uprobe (non dynamic symbols) and Tracepoint.

Closes https://github.com/cilium/ebpf/issues/295
