### PR TITLE
program: better error when loading a single program

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,8 @@ clean:
 	-$(RM) internal/btf/testdata/*.elf
 
 all: $(addsuffix -el.elf,$(TARGETS)) $(addsuffix -eb.elf,$(TARGETS))
+	ln -srf testdata/loader-$(CLANG)-el.elf testdata/loader-el.elf
+	ln -srf testdata/loader-$(CLANG)-eb.elf testdata/loader-eb.elf
 
 testdata/loader-%-el.elf: testdata/loader.c
 	$* $(CFLAGS) -mlittle-endian -c $< -o $@

--- a/asm/load_store.go
+++ b/asm/load_store.go
@@ -111,7 +111,7 @@ func LoadMapPtr(dst Register, fd int) Instruction {
 		OpCode:   LoadImmOp(DWord),
 		Dst:      dst,
 		Src:      PseudoMapFD,
-		Constant: int64(fd),
+		Constant: int64(uint32(fd)),
 	}
 }
 

--- a/linker.go
+++ b/linker.go
@@ -130,6 +130,9 @@ func fixupJumpsAndCalls(insns asm.Instructions) error {
 			}
 
 			ins.Offset = int16(jumpOffset - offset - 1)
+
+		case ins.IsLoadFromMap() && ins.MapPtr() == -1:
+			return fmt.Errorf("map %s: %w", ins.Reference, errUnsatisfiedReference)
 		}
 	}
 

--- a/prog_test.go
+++ b/prog_test.go
@@ -330,6 +330,23 @@ func TestProgramVerifierOutput(t *testing.T) {
 	}
 }
 
+func TestProgramWithUnsatisfiedReference(t *testing.T) {
+	coll, err := LoadCollectionSpec("testdata/loader-el.elf")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The program will have at least one map reference.
+	progSpec := coll.Programs["xdp_prog"]
+	progSpec.ByteOrder = nil
+
+	_, err = NewProgram(progSpec)
+	if !errors.Is(err, errUnsatisfiedReference) {
+		t.Fatal("Expected an error wrapping errUnsatisfiedReference, got", err)
+	}
+	t.Log(err)
+}
+
 func TestProgramName(t *testing.T) {
 	if err := haveObjName(); err != nil {
 		t.Skip(err)

--- a/testdata/loader-eb.elf
+++ b/testdata/loader-eb.elf
@@ -1,0 +1,1 @@
+loader-clang-12-eb.elf

--- a/testdata/loader-el.elf
+++ b/testdata/loader-el.elf
@@ -1,0 +1,1 @@
+loader-clang-12-el.elf


### PR DESCRIPTION
Sometimes a user assumes that a ProgramSpec from a CollectionSpec can
be loaded with NewProgram instead of using NewCollection. This isn't
true unfortunately, and leads to a hard to understand error issued
by the verifier:

    bad file descriptor: fd -1 is not pointing to valid bpf_map

We can catch an unresolved map reference when loading a program and
use that to give a better error message to callers of NewProgram.

Fixes #210