### PR TITLE
collection: fix map load check when loading programs

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -387,7 +387,7 @@ func lazyLoadCollection(coll *CollectionSpec, opts *CollectionOptions) (
 		for i := range progSpec.Instructions {
 			ins := &progSpec.Instructions[i]
 
-			if ins.OpCode != asm.LoadImmOp(asm.DWord) || ins.Reference == "" {
+			if !ins.IsLoadFromMap() || ins.Reference == "" {
 				continue
 			}
 


### PR DESCRIPTION
The loader currently tries to rewrite any dword-sized load with a
non-empty reference and a constant value of -1 to a map load. This
breaks when trying to rewrite a relocation generated by inline
assembly to MaxUint32 aka -1.

The fix is to check that the instruction has the correct source
register in addition to being a dword load.