### PR TITLE
link: return os.ErrNotExist when symbol doesn't exist

### DIFF
--- a/link/kprobe.go
+++ b/link/kprobe.go
@@ -266,8 +266,7 @@ func tracefsProbe(typ probeType, symbol, path string, offset uint64, ret bool) (
 	if err == nil {
 		return nil, fmt.Errorf("trace event already exists: %s/%s", group, symbol)
 	}
-	// The read is expected to fail with ErrNotSupported due to a non-existing event.
-	if err != nil && !errors.Is(err, ErrNotSupported) {
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return nil, fmt.Errorf("checking trace event %s/%s: %w", group, symbol, err)
 	}
 
@@ -346,7 +345,7 @@ func createTraceFSProbeEvent(typ probeType, group, symbol, path string, offset u
 	// when trying to create a kretprobe for a missing symbol. Make sure ENOENT
 	// is returned to the caller.
 	if errors.Is(err, os.ErrNotExist) || errors.Is(err, unix.EINVAL) {
-		return fmt.Errorf("kernel symbol %s not found: %w", symbol, os.ErrNotExist)
+		return fmt.Errorf("symbol %s not found: %w", symbol, os.ErrNotExist)
 	}
 	if err != nil {
 		return fmt.Errorf("writing '%s' to '%s': %w", pe, typ.EventsPath(), err)

--- a/link/perf_event_test.go
+++ b/link/perf_event_test.go
@@ -2,6 +2,7 @@ package link
 
 import (
 	"errors"
+	"os"
 	"testing"
 
 	"github.com/cilium/ebpf/internal/testutils"
@@ -38,8 +39,8 @@ func TestTraceReadID(t *testing.T) {
 	}
 
 	_, err = uint64FromFile("/base/path/not", "../not/escaped")
-	if !errors.Is(err, ErrNotSupported) {
-		t.Errorf("expected error %s, got: %s", ErrNotSupported, err)
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("expected os.ErrNotExist, got: %s", err)
 	}
 }
 

--- a/link/tracepoint_test.go
+++ b/link/tracepoint_test.go
@@ -2,11 +2,11 @@ package link
 
 import (
 	"errors"
+	"os"
 	"testing"
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/asm"
-	"github.com/cilium/ebpf/internal"
 	"github.com/cilium/ebpf/internal/testutils"
 	"github.com/cilium/ebpf/internal/unix"
 
@@ -48,6 +48,19 @@ func TestTracepoint(t *testing.T) {
 	}
 }
 
+func TestNonexistantTracepoint(t *testing.T) {
+	prog, err := ebpf.NewProgram(&tracepointSpec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer prog.Close()
+
+	_, err = Tracepoint("missing", "foobazbar", prog)
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Error("Expected os.ErrNotExist, got", err)
+	}
+}
+
 func TestTracepointErrors(t *testing.T) {
 	c := qt.New(t)
 
@@ -72,8 +85,8 @@ func TestTraceGetEventID(t *testing.T) {
 	}
 
 	_, err = getTraceEventID("totally", "bogus")
-	if !errors.Is(err, internal.ErrNotSupported) {
-		t.Fatal("Doesn't return ErrNotSupported")
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatal("Expected os.ErrNotExist, got", err)
 	}
 }
 


### PR DESCRIPTION
Some of the tracing related links currently return ErrNotSupported
when trying to attach to a non-existant symbol. This is misleading.
Consistently return os.ErrNotExist in such cases.