### PR TITLE
link: wrap errors for Raw{At,De}tachProgram 

### DIFF
--- a/link/program.go
+++ b/link/program.go
@@ -43,7 +43,7 @@ func RawAttachProgram(opts RawAttachProgramOptions) error {
 	}
 
 	if err := internal.BPFProgAttach(&attr); err != nil {
-		return fmt.Errorf("can't attach program: %s", err)
+		return fmt.Errorf("can't attach program: %w", err)
 	}
 	return nil
 }
@@ -69,7 +69,7 @@ func RawDetachProgram(opts RawDetachProgramOptions) error {
 		AttachType:  uint32(opts.Attach),
 	}
 	if err := internal.BPFProgDetach(&attr); err != nil {
-		return fmt.Errorf("can't detach program: %s", err)
+		return fmt.Errorf("can't detach program: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
This allows callers to detect the underlying syscall error, which is
necessary for being able to implement safe fallbacks based on the error
during program loading and unloading. runc in particular needs this to
be able to implement BPF_F_REPLACE fallbacks correctly.

Ref: opencontainers/runc#3008
Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>