### PR TITLE
examples/kprobe: mention sys_execve in package godoc

### DIFF
--- a/examples/kprobe/main.go
+++ b/examples/kprobe/main.go
@@ -1,7 +1,7 @@
 // +build linux
 
 // This program demonstrates attaching an eBPF program to a kernel symbol.
-// The eBPF program will be attached to the start of the
+// The eBPF program will be attached to the start of the sys_execve
 // kernel function and prints out the number of times it has been called
 // every second.
 package main


### PR DESCRIPTION
Commit 1e7f01c7124c ("arch: support arm64") changed the example to
attach to sys_execve instead of __x64_sys_execve, but didn't update the
package godoc accordingly.