### PR TITLE
map: fix flaky test on Go 1.17beta1

### DIFF
--- a/map_test.go
+++ b/map_test.go
@@ -303,7 +303,7 @@ func TestMapPin(t *testing.T) {
 	// Issue 51: pad path out to a power of two, to avoid having a
 	// trailing zero at the end of the allocation which holds the string.
 	path := tmp + string(filepath.Separator)
-	path += strings.Repeat("a", 32-len(path))
+	path += strings.Repeat("a", 64-len(path))
 
 	if err := m.Pin(path); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
It seems like the output of os.TempDir is now sometimes exactly 32 bytes
long, which makes TestMapPinning fail with

    pin object /sys/fs/bpf/ebpf-test2297582189/: file exists

Fix this by padding to 64 bytes.