### PR TITLE
Add feature test for BPF_F_INNER_MAP maps

### DIFF
--- a/internal/unix/types_linux.go
+++ b/internal/unix/types_linux.go
@@ -32,6 +32,7 @@ const (
 	BPF_F_WRONLY_PROG        = linux.BPF_F_WRONLY_PROG
 	BPF_F_SLEEPABLE          = linux.BPF_F_SLEEPABLE
 	BPF_F_MMAPABLE           = linux.BPF_F_MMAPABLE
+	BPF_F_INNER_MAP          = linux.BPF_F_INNER_MAP
 	BPF_OBJ_NAME_LEN         = linux.BPF_OBJ_NAME_LEN
 	BPF_TAG_SIZE             = linux.BPF_TAG_SIZE
 	SYS_BPF                  = linux.SYS_BPF

--- a/internal/unix/types_other.go
+++ b/internal/unix/types_other.go
@@ -32,6 +32,7 @@ const (
 	BPF_F_WRONLY_PROG        = 0
 	BPF_F_SLEEPABLE          = 0
 	BPF_F_MMAPABLE           = 0
+	BPF_F_INNER_MAP          = 0
 	BPF_OBJ_NAME_LEN         = 0x10
 	BPF_TAG_SIZE             = 0x8
 	SYS_BPF                  = 321

--- a/map.go
+++ b/map.go
@@ -321,6 +321,11 @@ func createMap(spec *MapSpec, inner *internal.FD, opts MapOptions, handles *hand
 			return nil, fmt.Errorf("map create: %w", err)
 		}
 	}
+	if spec.Flags&unix.BPF_F_INNER_MAP > 0 {
+		if err := haveInnerMaps(); err != nil {
+			return nil, fmt.Errorf("map create: %w", err)
+		}
+	}
 
 	attr := internal.BPFMapCreateAttr{
 		MapType:    uint32(spec.Type),

--- a/syscalls.go
+++ b/syscalls.go
@@ -230,6 +230,22 @@ var haveMmapableMaps = internal.FeatureTest("mmapable maps", "5.5", func() error
 	return nil
 })
 
+var haveInnerMaps = internal.FeatureTest("inner maps", "5.10", func() error {
+	// This checks BPF_F_INNER_MAP, which appeared in 5.10.
+	m, err := internal.BPFMapCreate(&internal.BPFMapCreateAttr{
+		MapType:    uint32(Array),
+		KeySize:    4,
+		ValueSize:  4,
+		MaxEntries: 1,
+		Flags:      unix.BPF_F_INNER_MAP,
+	})
+	if err != nil {
+		return internal.ErrNotSupported
+	}
+	_ = m.Close()
+	return nil
+})
+
 func bpfMapLookupElem(m *internal.FD, key, valueOut internal.Pointer) error {
 	fd, err := m.Value()
 	if err != nil {

--- a/syscalls_test.go
+++ b/syscalls_test.go
@@ -46,3 +46,7 @@ func TestHaveMapMutabilityModifiers(t *testing.T) {
 func TestHaveMmapableMaps(t *testing.T) {
 	testutils.CheckFeatureTest(t, haveMmapableMaps)
 }
+
+func TestHaveInnerMaps(t *testing.T) {
+	testutils.CheckFeatureTest(t, haveInnerMaps)
+}


### PR DESCRIPTION
Introduced in
https://github.com/torvalds/linux/commit/4a8f87e60f6db40e640f1db555d063b2c4dea5f1.

In Cilium, following the merge of https://github.com/cilium/cilium/pull/15546, we need to add this feature test as Maglev mode uses inner maps (map-in-map).

Signed-off-by: Chris Tarazi <chris@isovalent.com>
