### PR TITLE
syscalls: do not conceal BPF_PROG_* syscall errors

### DIFF
--- a/syscalls.go
+++ b/syscalls.go
@@ -357,10 +357,9 @@ func wrapObjError(err error) error {
 		return nil
 	}
 	if errors.Is(err, unix.ENOENT) {
-		return fmt.Errorf("%w", ErrNotExist)
+		err = ErrNotExist
 	}
-
-	return errors.New(err.Error())
+	return fmt.Errorf("%w", err)
 }
 
 func wrapMapError(err error) error {

--- a/syscalls_test.go
+++ b/syscalls_test.go
@@ -1,10 +1,12 @@
 package ebpf
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
 	"github.com/cilium/ebpf/internal/testutils"
+	"golang.org/x/sys/unix"
 )
 
 func TestObjNameCharacters(t *testing.T) {
@@ -19,6 +21,22 @@ func TestObjNameCharacters(t *testing.T) {
 		result := strings.IndexFunc(in, invalidBPFObjNameChar) == -1
 		if result != valid {
 			t.Errorf("Name '%s' classified incorrectly", in)
+		}
+	}
+}
+
+func TestWrapObjError(t *testing.T) {
+	customError := errors.New("custom error for test")
+	for inErr, outErr := range map[error]error{
+		unix.ENOENT: ErrNotExist,
+		unix.EPERM:  unix.EPERM,
+		unix.EACCES: unix.EACCES,
+		unix.ENOANO: unix.ENOANO, // dummy error -- never actually returned
+		customError: customError,
+	} {
+		gotErr := wrapObjError(inErr)
+		if !errors.Is(gotErr, outErr) {
+			t.Errorf("wrapObjError(%v) doesn't wrap %v: got %v", inErr, outErr, gotErr)
 		}
 	}
 }


### PR DESCRIPTION
The error wrapping code for BPF_PROG_* syscall-related errors would mask
the true source of all underlying syscall errors, which meant that you
couldn't detect several fairly important cases (such as -EACESS and
-EPERM). It seems that this behaviour wasn't intentional (prior to
commit de57e915ff34, the behaviour was to bubble up the syscall error)
and the similar wrapping of BPF_MAP_* errors did bubble up the syscall
error too.

This is needed for runc to be able to detect permission errors due to
SELinux labels blocking certain operations (mainly NewProgramFromID),
and unifies the behaviour for BPF_PROG_* and BPF_MAP_* syscalls.

It turns out that wrapMapError doesn't actually wrap the either error,
but @lmb said they will come up with a better long term solution, so
leave this alone for now.

Ref: opencontainers/runc#3055
Fixes: de57e915ff34 ("Add *GetNextID")
Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>