### PR TITLE
Mark PerCPUCGroupStorage as per-cpu

### DIFF
--- a/internal/testutils/cgroup.go
+++ b/internal/testutils/cgroup.go
@@ -1,17 +1,59 @@
 package testutils
 
 import (
+	"errors"
 	"io/ioutil"
 	"os"
+	"strings"
+	"sync"
 	"testing"
 
 	"golang.org/x/sys/unix"
 )
 
+var cgroup2 = struct {
+	once sync.Once
+	path string
+	err  error
+}{}
+
+func cgroup2Path() (string, error) {
+	cgroup2.once.Do(func() {
+		mounts, err := ioutil.ReadFile("/proc/mounts")
+		if err != nil {
+			cgroup2.err = err
+			return
+		}
+
+		for _, line := range strings.Split(string(mounts), "\n") {
+			mount := strings.SplitN(line, " ", 3)
+			if mount[0] == "cgroup2" {
+				cgroup2.path = mount[1]
+				return
+			}
+
+			continue
+		}
+
+		cgroup2.err = errors.New("cgroup2 not mounted")
+	})
+
+	if cgroup2.err != nil {
+		return "", cgroup2.err
+	}
+
+	return cgroup2.path, nil
+}
+
 func CreateCgroup(tb testing.TB) *os.File {
 	tb.Helper()
 
-	cgdir, err := ioutil.TempDir("/sys/fs/cgroup/unified", "ebpf-link")
+	cg2, err := cgroup2Path()
+	if err != nil {
+		tb.Fatal("Can't locate cgroup2 mount:", err)
+	}
+
+	cgdir, err := ioutil.TempDir(cg2, "ebpf-link")
 	if err != nil {
 		tb.Fatal("Can't create cgroupv2:", err)
 	}

--- a/internal/testutils/cgroup.go
+++ b/internal/testutils/cgroup.go
@@ -1,0 +1,40 @@
+package testutils
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func CreateCgroup(tb testing.TB) *os.File {
+	tb.Helper()
+
+	cgdir, err := ioutil.TempDir("/sys/fs/cgroup/unified", "ebpf-link")
+	if err != nil {
+		tb.Fatal("Can't create cgroupv2:", err)
+	}
+
+	cgroup, err := os.Open(cgdir)
+	if err != nil {
+		os.Remove(cgdir)
+		tb.Fatal(err)
+	}
+	tb.Cleanup(func() {
+		cgroup.Close()
+		os.Remove(cgdir)
+	})
+
+	return cgroup
+}
+
+func GetCgroupIno(t *testing.T, cgroup *os.File) uint64 {
+	cgroupStat := unix.Stat_t{}
+	err := unix.Fstat(int(cgroup.Fd()), &cgroupStat)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return cgroupStat.Ino
+}

--- a/map_test.go
+++ b/map_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"unsafe"
 
+	"github.com/cilium/ebpf/asm"
 	"github.com/cilium/ebpf/internal"
 	"github.com/cilium/ebpf/internal/btf"
 	"github.com/cilium/ebpf/internal/testutils"
@@ -1030,6 +1031,99 @@ func TestPerCPUMarshaling(t *testing.T) {
 			}
 
 		})
+	}
+}
+
+type bpfCgroupStorageKey struct {
+	CgroupInodeId uint64
+	AttachType    AttachType
+	_             [4]byte // Padding
+}
+
+func TestCgroupPerCPUStorageMarshaling(t *testing.T) {
+	numCPU, err := internal.PossibleCPUs()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if numCPU < 2 {
+		t.Skip("Test requires at least two CPUs")
+	}
+	testutils.SkipOnOldKernel(t, "5.9", "per-CPU CGoup storage with write from user space support")
+
+	cgroup := testutils.CreateCgroup(t)
+
+	arr, err := NewMap(&MapSpec{
+		Type:      PerCPUCGroupStorage,
+		KeySize:   uint32(unsafe.Sizeof(bpfCgroupStorageKey{})),
+		ValueSize: uint32(unsafe.Sizeof(uint64(0))),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		arr.Close()
+	})
+
+	prog, err := NewProgram(&ProgramSpec{
+		Type:       CGroupSKB,
+		AttachType: AttachCGroupInetEgress,
+		License:    "MIT",
+		Instructions: asm.Instructions{
+			asm.LoadMapPtr(asm.R1, arr.FD()),
+			asm.Mov.Imm(asm.R2, 0),
+			asm.FnGetLocalStorage.Call(),
+			asm.Mov.Imm(asm.R0, 0),
+			asm.Return(),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer prog.Close()
+
+	progAttachAttrs := internal.BPFProgAttachAttr{
+		TargetFd:     uint32(cgroup.Fd()),
+		AttachBpfFd:  uint32(prog.FD()),
+		AttachType:   uint32(AttachCGroupInetEgress),
+		AttachFlags:  0,
+		ReplaceBpfFd: 0,
+	}
+	err = internal.BPFProgAttach(&progAttachAttrs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		attr := internal.BPFProgDetachAttr{
+			TargetFd:    uint32(cgroup.Fd()),
+			AttachBpfFd: uint32(prog.FD()),
+			AttachType:  uint32(AttachCGroupInetEgress),
+		}
+		if err := internal.BPFProgDetach(&attr); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	var mapKey = &bpfCgroupStorageKey{
+		CgroupInodeId: testutils.GetCgroupIno(t, cgroup),
+		AttachType:    AttachCGroupInetEgress,
+	}
+
+	values := []uint64{1, 2}
+	if err := arr.Put(mapKey, values); err != nil {
+		t.Fatalf("Can't set cgroup %s storage: %s", cgroup.Name(), err)
+	}
+
+	var retrieved []uint64
+	if err := arr.Lookup(mapKey, &retrieved); err != nil {
+		t.Fatalf("Can't retrieve cgroup %s storage: %s", cgroup.Name(), err)
+	}
+
+	for i, want := range []uint64{1, 2} {
+		if retrieved[i] == 0 {
+			t.Errorf("Item %d is 0", i)
+		} else if have := retrieved[i]; have != want {
+			t.Errorf("PerCPUCGroupStorage map is not correctly unmarshaled, expected %d but got %d", want, have)
+		}
 	}
 }
 

--- a/types.go
+++ b/types.go
@@ -105,7 +105,7 @@ const (
 
 // hasPerCPUValue returns true if the Map stores a value per CPU.
 func (mt MapType) hasPerCPUValue() bool {
-	return mt == PerCPUHash || mt == PerCPUArray || mt == LRUCPUHash
+	return mt == PerCPUHash || mt == PerCPUArray || mt == LRUCPUHash || mt == PerCPUCGroupStorage
 }
 
 // canStoreMap returns true if the map type accepts a map fd


### PR DESCRIPTION
Currently, using "some_map->Lookup" on a PerCPUCGroupStorage only allows retrieving the first value of the per-cpu storage area. This PR adds the missing declaration.