### PR TITLE
link/uprobe: handle ENOTSUPP from the kernel's prepare_uprobe()

### DIFF
--- a/link/kprobe.go
+++ b/link/kprobe.go
@@ -230,6 +230,11 @@ func pmuProbe(typ probeType, symbol, path string, offset uint64, ret bool) (*per
 	if errors.Is(err, os.ErrNotExist) || errors.Is(err, unix.EINVAL) {
 		return nil, fmt.Errorf("symbol '%s' not found: %w", symbol, os.ErrNotExist)
 	}
+	// Since at least commit cb9a19fe4aa51, ENOTSUPP is returned
+	// when attempting to set a uprobe on a trap instruction.
+	if errors.Is(err, unix.ENOTSUPP) {
+		return nil, fmt.Errorf("failed setting uprobe on offset %#x (possible trap insn): %w", offset, err)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("opening perf event: %w", err)
 	}

--- a/link/uprobe_test.go
+++ b/link/uprobe_test.go
@@ -81,7 +81,7 @@ func TestUprobeExtWithOpts(t *testing.T) {
 
 	// This Uprobe is broken and will not work because the offset is not
 	// correct. This is expected since the offset is provided by the user.
-	up, err := bashEx.Uprobe("open", prog, &UprobeOptions{Offset: 0x12345})
+	up, err := bashEx.Uprobe("open", prog, &UprobeOptions{Offset: 0x1})
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
When running the uprobe tests, I noticed this was failing with my copy of Bash. Offset 0x12345 seems to contain a trap instruction and is rejected by prepare_uprobe(): https://elixir.bootlin.com/linux/v5.13.3/source/kernel/events/uprobes.c#L854

This patch changes the dummy offset to 0x1 and adds some error context to the slightly esoteric ENOTSUPP.