### PR TITLE
Find the cgroupv2 mount point in unit tests

### DIFF
--- a/link/link_test.go
+++ b/link/link_test.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
+	"sync"
 	"testing"
 
 	"github.com/cilium/ebpf"
@@ -14,6 +16,12 @@ import (
 	"github.com/cilium/ebpf/internal/testutils"
 	"github.com/cilium/ebpf/internal/unix"
 )
+
+var cgroup2Mount = struct {
+	once sync.Once
+	path string
+	err  error
+}{}
 
 func TestRawLink(t *testing.T) {
 	cgroup, prog := mustCgroupFixtures(t)
@@ -91,7 +99,7 @@ func mustCgroupFixtures(t *testing.T) (*os.File, *ebpf.Program) {
 	testutils.SkipIfNotSupported(t, haveProgAttach())
 
 	prog := mustCgroupEgressProgram(t)
-	cgdir, err := ioutil.TempDir("/sys/fs/cgroup/unified", "ebpf-link")
+	cgdir, err := ioutil.TempDir(cgroup2Path(t), "ebpf-link")
 	if err != nil {
 		prog.Close()
 		t.Fatal("Can't create cgroupv2:", err)
@@ -128,6 +136,33 @@ func mustCgroupEgressProgram(t *testing.T) *ebpf.Program {
 		t.Fatal(err)
 	}
 	return prog
+}
+
+func cgroup2Path(t *testing.T) string {
+	cgroup2Mount.once.Do(func() {
+		mounts, err := ioutil.ReadFile("/proc/mounts")
+		if err != nil {
+			cgroup2Mount.err = err
+			return
+		}
+		for _, line := range strings.Split(string(mounts), "\n") {
+			mount := strings.SplitN(line, " ", 3)
+			if mount[0] == "cgroup2" {
+				cgroup2Mount.path = mount[1]
+				return
+			}
+
+			continue
+		}
+
+		cgroup2Mount.err = errors.New("cgroup2 not mounted")
+	})
+
+	if cgroup2Mount.err != nil {
+		t.Fatal(cgroup2Mount.err)
+	}
+
+	return cgroup2Mount.path
 }
 
 type testLinkOptions struct {


### PR DESCRIPTION
Previous unit tests assumed that cgroupv2 was mounted at
/sys/fs/cgroup/unified. While this is usually the case for systems
supporting both cgroupv1 and cgroupv2, systems don't have to mount
cgroupv2 to that path, and systems that don't mount cgroupv1 usually don't
(or, at least, Fedora doesn't). This assumption broke unit tests on
systems where cgroupv2 was mounted elsewhere.

Fortunately /proc/mounts will list the cgroupv2 mount point with the
file system type of `cgroup2` which makes it convenient for locating the
cgroupv2 file system. Unit tests now lookup (once) the mount point instead
of assuming its location, fixing unit tests on modern Fedora systems.