### PR TITLE
features: add HaveProgType API

### DIFF
--- a/features/prog.go
+++ b/features/prog.go
@@ -1,0 +1,156 @@
+package features
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"sync"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/asm"
+	"github.com/cilium/ebpf/internal"
+	"github.com/cilium/ebpf/internal/unix"
+)
+
+func init() {
+	pc.progTypes = make(map[ebpf.ProgramType]error)
+}
+
+var (
+	pc progCache
+)
+
+type progCache struct {
+	sync.Mutex
+	progTypes map[ebpf.ProgramType]error
+}
+
+func createProgLoadAttr(pt ebpf.ProgramType) (*internal.BPFProgLoadAttr, error) {
+	var expectedAttachType ebpf.AttachType
+
+	insns := asm.Instructions{
+		asm.LoadImm(asm.R0, 0, asm.DWord),
+		asm.Return(),
+	}
+
+	buf := bytes.NewBuffer(make([]byte, 0, len(insns)*asm.InstructionSize))
+	if err := insns.Marshal(buf, internal.NativeEndian); err != nil {
+		return nil, err
+	}
+
+	bytecode := buf.Bytes()
+	instructions := internal.NewSlicePointer(bytecode)
+
+	// Some programs have expected attach types which are checked during the
+	// BPD_PROG_LOAD syscall.
+	switch pt {
+	case ebpf.CGroupSockAddr:
+		expectedAttachType = ebpf.AttachCGroupInet4Connect
+	case ebpf.CGroupSockopt:
+		expectedAttachType = ebpf.AttachCGroupGetsockopt
+	case ebpf.SkLookup:
+		expectedAttachType = ebpf.AttachSkLookup
+	default:
+		expectedAttachType = ebpf.AttachNone
+	}
+
+	// Kernels before 5.0 (6c4fc209fcf9 "bpf: remove useless version check for prog load")
+	// require the version field to be set to the value of the KERNEL_VERSION
+	// macro for kprobe-type programs.
+	v, err := internal.KernelVersion()
+	if err != nil {
+		return nil, fmt.Errorf("detecting kernel version: %w", err)
+	}
+	kv := v.Kernel()
+
+	return &internal.BPFProgLoadAttr{
+		ProgType:           uint32(pt),
+		Instructions:       instructions,
+		InsCount:           uint32(len(bytecode) / asm.InstructionSize),
+		ExpectedAttachType: uint32(expectedAttachType),
+		License:            internal.NewStringPointer("GPL"),
+		KernelVersion:      kv,
+	}, nil
+}
+
+// HaveProgType probes the running kernel for the availability of the specified program type.
+// Return values have the following semantics:
+//
+//   err == nil: The feature is available.
+//   errors.Is(err, ebpf.ErrNotSupported): The feature is not available.
+//   err != nil: Any errors encountered during probe execution, wrapped.
+//
+// Note that the latter case may include false negatives, and that program creation may
+// succeed despite an error being returned. Some program types cannot reliably be probed and
+// will also return error. Only `nil` and `ebpf.ErrNotSupported` are conclusive.
+//
+// Probe results are cached and persist throughout any process capability changes.
+func HaveProgType(pt ebpf.ProgramType) error {
+	if err := validateProgType(pt); err != nil {
+		return err
+	}
+
+	return haveProgType(pt)
+
+}
+
+func validateProgType(pt ebpf.ProgramType) error {
+	if pt > pt.Max() {
+		return os.ErrInvalid
+	}
+
+	if progLoadProbeNotImplemented(pt) {
+		// A probe for a these prog types has BTF requirements we currently cannot meet
+		// Once we figure out how to add a working probe in this package, we can remove
+		// this check
+		return fmt.Errorf("a probe for ProgType %s isn't implemented", pt.String())
+	}
+
+	return nil
+}
+
+func haveProgType(pt ebpf.ProgramType) error {
+	pc.Lock()
+	defer pc.Unlock()
+	err, ok := pc.progTypes[pt]
+	if ok {
+		return err
+	}
+
+	attr, err := createProgLoadAttr(pt)
+	if err != nil {
+		return fmt.Errorf("couldn't create the program load attribute: %w", err)
+	}
+
+	_, err = internal.BPFProgLoad(attr)
+
+	switch {
+	// EINVAL occurs when attempting to create a program with an unknown type.
+	// E2BIG occurs when BPFProgLoadAttr contains non-zero bytes past the end
+	// of the struct known by the running kernel, meaning the kernel is too old
+	// to support the given map type.
+	case errors.Is(err, unix.EINVAL), errors.Is(err, unix.E2BIG):
+		err = ebpf.ErrNotSupported
+
+	// EPERM is kept as-is and is not converted or wrapped.
+	case errors.Is(err, unix.EPERM):
+		break
+
+	// Wrap unexpected errors.
+	case err != nil:
+		err = fmt.Errorf("unexpected error during feature probe: %w", err)
+	}
+
+	pc.progTypes[pt] = err
+
+	return err
+}
+
+func progLoadProbeNotImplemented(pt ebpf.ProgramType) bool {
+	switch pt {
+	case ebpf.Tracing, ebpf.StructOps, ebpf.Extension, ebpf.LSM:
+		return true
+	}
+	return false
+}

--- a/features/prog_test.go
+++ b/features/prog_test.go
@@ -1,0 +1,92 @@
+package features
+
+import (
+	"fmt"
+	"math"
+	"os"
+	"testing"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/internal/testutils"
+)
+
+var progTypeMinVersion = map[ebpf.ProgramType]string{
+	ebpf.SocketFilter:          "3.19",
+	ebpf.Kprobe:                "4.1",
+	ebpf.SchedCLS:              "4.1",
+	ebpf.SchedACT:              "4.1",
+	ebpf.TracePoint:            "4.7",
+	ebpf.XDP:                   "4.8",
+	ebpf.PerfEvent:             "4.9",
+	ebpf.CGroupSKB:             "4.10",
+	ebpf.CGroupSock:            "4.10",
+	ebpf.LWTIn:                 "4.10",
+	ebpf.LWTOut:                "4.10",
+	ebpf.LWTXmit:               "4.10",
+	ebpf.SockOps:               "4.13",
+	ebpf.SkSKB:                 "4.14",
+	ebpf.CGroupDevice:          "4.15",
+	ebpf.SkMsg:                 "4.17",
+	ebpf.RawTracepoint:         "4.17",
+	ebpf.CGroupSockAddr:        "4.17",
+	ebpf.LWTSeg6Local:          "4.18",
+	ebpf.LircMode2:             "4.18",
+	ebpf.SkReuseport:           "4.19",
+	ebpf.FlowDissector:         "4.20",
+	ebpf.CGroupSysctl:          "5.2",
+	ebpf.RawTracepointWritable: "5.2",
+	ebpf.CGroupSockopt:         "5.3",
+	ebpf.Tracing:               "5.5",
+	ebpf.StructOps:             "5.6",
+	ebpf.Extension:             "5.6",
+	ebpf.LSM:                   "5.7",
+	ebpf.SkLookup:              "5.9",
+}
+
+func TestHaveProgType(t *testing.T) {
+	for progType := ebpf.UnspecifiedProgram + 1; progType <= progType.Max(); progType++ {
+		// Need inner loop copy to make use of t.Parallel()
+		pt := progType
+
+		minVersion, ok := progTypeMinVersion[pt]
+		if !ok {
+			// In cases where a new prog type wasn't added to progTypeMinVersion
+			// we should make sure the test runs anyway and fails on old kernels
+			minVersion = "0.0"
+		}
+
+		feature := fmt.Sprintf("program type %s", pt.String())
+
+		t.Run(pt.String(), func(t *testing.T) {
+			t.Parallel()
+
+			if progLoadProbeNotImplemented(pt) {
+				t.Skipf("Test for prog type %s requires working probe", pt.String())
+			}
+			testutils.SkipOnOldKernel(t, minVersion, feature)
+
+			if err := HaveProgType(pt); err != nil {
+				if pt == ebpf.LircMode2 {
+					// The probe for LircMode2 technically works but needs to be skipped if unsuccessful
+					// because the current testing kernels don't support it.
+					testutils.SkipIfNotSupported(t, err)
+				}
+
+				t.Fatalf("Program type %s isn't supported even though kernel is at least %s: %v", pt.String(), minVersion, err)
+			}
+		})
+
+	}
+}
+
+func TestHaveProgTypeUnsupported(t *testing.T) {
+	if err := haveProgType(ebpf.ProgramType(math.MaxUint32)); err != ebpf.ErrNotSupported {
+		t.Fatalf("Expected ebpf.ErrNotSupported but was: %v", err)
+	}
+}
+
+func TestHaveProgTypeInvalid(t *testing.T) {
+	if err := HaveProgType(ebpf.ProgramType(math.MaxUint32)); err != os.ErrInvalid {
+		t.Fatalf("Expected os.ErrInvalid but was: %v", err)
+	}
+}

--- a/prog.go
+++ b/prog.go
@@ -171,16 +171,16 @@ func newProgramWithOptions(spec *ProgramSpec, opts ProgramOptions, handles *hand
 		kv = v.Kernel()
 	}
 
-	attr := &bpfProgLoadAttr{
-		progType:           spec.Type,
-		progFlags:          spec.Flags,
-		expectedAttachType: spec.AttachType,
-		license:            internal.NewStringPointer(spec.License),
-		kernelVersion:      kv,
+	attr := &internal.BPFProgLoadAttr{
+		ProgType:           uint32(spec.Type),
+		ProgFlags:          spec.Flags,
+		ExpectedAttachType: uint32(spec.AttachType),
+		License:            internal.NewStringPointer(spec.License),
+		KernelVersion:      kv,
 	}
 
 	if haveObjName() == nil {
-		attr.progName = internal.NewBPFObjName(spec.Name)
+		attr.ProgName = internal.NewBPFObjName(spec.Name)
 	}
 
 	var err error
@@ -207,23 +207,23 @@ func newProgramWithOptions(spec *ProgramSpec, opts ProgramOptions, handles *hand
 		}
 
 		if handle != nil {
-			attr.progBTFFd = uint32(handle.FD())
+			attr.ProgBTFFd = uint32(handle.FD())
 
 			recSize, bytes, err := btf.ProgramLineInfos(spec.BTF)
 			if err != nil {
 				return nil, fmt.Errorf("get BTF line infos: %w", err)
 			}
-			attr.lineInfoRecSize = recSize
-			attr.lineInfoCnt = uint32(uint64(len(bytes)) / uint64(recSize))
-			attr.lineInfo = internal.NewSlicePointer(bytes)
+			attr.LineInfoRecSize = recSize
+			attr.LineInfoCnt = uint32(uint64(len(bytes)) / uint64(recSize))
+			attr.LineInfo = internal.NewSlicePointer(bytes)
 
 			recSize, bytes, err = btf.ProgramFuncInfos(spec.BTF)
 			if err != nil {
 				return nil, fmt.Errorf("get BTF function infos: %w", err)
 			}
-			attr.funcInfoRecSize = recSize
-			attr.funcInfoCnt = uint32(uint64(len(bytes)) / uint64(recSize))
-			attr.funcInfo = internal.NewSlicePointer(bytes)
+			attr.FuncInfoRecSize = recSize
+			attr.FuncInfoCnt = uint32(uint64(len(bytes)) / uint64(recSize))
+			attr.FuncInfo = internal.NewSlicePointer(bytes)
 		}
 	}
 
@@ -243,8 +243,8 @@ func newProgramWithOptions(spec *ProgramSpec, opts ProgramOptions, handles *hand
 	}
 
 	bytecode := buf.Bytes()
-	attr.instructions = internal.NewSlicePointer(bytecode)
-	attr.insCount = uint32(len(bytecode) / asm.InstructionSize)
+	attr.Instructions = internal.NewSlicePointer(bytecode)
+	attr.InsCount = uint32(len(bytecode) / asm.InstructionSize)
 
 	if spec.AttachTo != "" {
 		if spec.AttachTarget != nil {
@@ -273,10 +273,10 @@ func newProgramWithOptions(spec *ProgramSpec, opts ProgramOptions, handles *hand
 			return nil, err
 		}
 		if target != nil {
-			attr.attachBTFID = target.ID()
+			attr.AttachBTFID = uint32(target.ID())
 		}
 		if spec.AttachTarget != nil {
-			attr.attachProgFd = uint32(spec.AttachTarget.FD())
+			attr.AttachProgFd = uint32(spec.AttachTarget.FD())
 		}
 	}
 
@@ -288,12 +288,12 @@ func newProgramWithOptions(spec *ProgramSpec, opts ProgramOptions, handles *hand
 	var logBuf []byte
 	if opts.LogLevel > 0 {
 		logBuf = make([]byte, logSize)
-		attr.logLevel = opts.LogLevel
-		attr.logSize = uint32(len(logBuf))
-		attr.logBuf = internal.NewSlicePointer(logBuf)
+		attr.LogLevel = opts.LogLevel
+		attr.LogSize = uint32(len(logBuf))
+		attr.LogBuf = internal.NewSlicePointer(logBuf)
 	}
 
-	fd, err := bpfProgLoad(attr)
+	fd, err := internal.BPFProgLoad(attr)
 	if err == nil {
 		return &Program{internal.CString(logBuf), fd, spec.Name, "", spec.Type}, nil
 	}
@@ -302,11 +302,11 @@ func newProgramWithOptions(spec *ProgramSpec, opts ProgramOptions, handles *hand
 	if opts.LogLevel == 0 && opts.LogSize >= 0 {
 		// Re-run with the verifier enabled to get better error messages.
 		logBuf = make([]byte, logSize)
-		attr.logLevel = 1
-		attr.logSize = uint32(len(logBuf))
-		attr.logBuf = internal.NewSlicePointer(logBuf)
+		attr.LogLevel = 1
+		attr.LogSize = uint32(len(logBuf))
+		attr.LogBuf = internal.NewSlicePointer(logBuf)
 
-		_, logErr = bpfProgLoad(attr)
+		_, logErr = internal.BPFProgLoad(attr)
 	}
 
 	if errors.Is(logErr, unix.EPERM) && logBuf[0] == 0 {

--- a/types.go
+++ b/types.go
@@ -123,6 +123,11 @@ func (mt MapType) canStoreProgram() bool {
 // ProgramType of the eBPF program
 type ProgramType uint32
 
+// Max return the latest supported ProgramType.
+func (_ ProgramType) Max() ProgramType {
+	return maxProgramType - 1
+}
+
 // eBPF program types
 const (
 	UnspecifiedProgram ProgramType = iota
@@ -156,6 +161,7 @@ const (
 	Extension
 	LSM
 	SkLookup
+	maxProgramType
 )
 
 // AttachType of the eBPF program, needed to differentiate allowed context accesses in


### PR DESCRIPTION
With this commit we add `HaveProgType(pt ebpf.ProgramType) error`,
which allows to probe for available BPF program types. As with the
HaveMapType API, results are cached and probes run at most once.

Signed-off-by: Robin Gögge <r.goegge@outlook.com>