### PR TITLE
Export `CollectionSpec.ByteOrder`

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -27,7 +27,9 @@ type CollectionSpec struct {
 	Maps     map[string]*MapSpec
 	Programs map[string]*ProgramSpec
 
-	byteOrder binary.ByteOrder
+	// ByteOrder specifies whether the ELF was compiled for
+	// big-endian or little-endian architectures.
+	ByteOrder binary.ByteOrder
 }
 
 // Copy returns a recursive copy of the spec.
@@ -39,7 +41,7 @@ func (cs *CollectionSpec) Copy() *CollectionSpec {
 	cpy := CollectionSpec{
 		Maps:      make(map[string]*MapSpec, len(cs.Maps)),
 		Programs:  make(map[string]*ProgramSpec, len(cs.Programs)),
-		byteOrder: cs.byteOrder,
+		ByteOrder: cs.ByteOrder,
 	}
 
 	for name, spec := range cs.Maps {

--- a/elf_reader_test.go
+++ b/elf_reader_test.go
@@ -118,7 +118,7 @@ func TestLoadCollectionSpec(t *testing.T) {
 
 	defaultOpts := cmp.Options{
 		cmpopts.IgnoreTypes(new(btf.Map), new(btf.Program)),
-		cmpopts.IgnoreFields(CollectionSpec{}, "byteOrder"),
+		cmpopts.IgnoreFields(CollectionSpec{}, "ByteOrder"),
 		cmpopts.IgnoreFields(ProgramSpec{}, "Instructions", "ByteOrder"),
 		cmpopts.IgnoreMapEntries(func(key string, _ *MapSpec) bool {
 			switch key {
@@ -166,7 +166,7 @@ func TestLoadCollectionSpec(t *testing.T) {
 			t.Errorf("MapSpec mismatch (-want +got):\n%s", diff)
 		}
 
-		if have.byteOrder != internal.NativeEndian {
+		if have.ByteOrder != internal.NativeEndian {
 			return
 		}
 
@@ -333,7 +333,7 @@ func TestLoadRawTracepoint(t *testing.T) {
 			t.Fatal("Can't parse ELF:", err)
 		}
 
-		if spec.byteOrder != internal.NativeEndian {
+		if spec.ByteOrder != internal.NativeEndian {
 			return
 		}
 

--- a/link/freplace.go
+++ b/link/freplace.go
@@ -12,7 +12,7 @@ type FreplaceLink struct {
 }
 
 // AttachFreplace attaches the given eBPF program to the function it replaces.
-
+//
 // The program and name can either be provided at link time, or can be provided
 // at program load time. If they were provided at load time, they should be nil
 // and empty respectively here, as they will be ignored by the kernel.

--- a/link/freplace_test.go
+++ b/link/freplace_test.go
@@ -17,7 +17,7 @@ func TestFreplace(t *testing.T) {
 			t.Fatal("Can't parse ELF:", err)
 		}
 
-		if spec.Programs["sched_process_exec"].ByteOrder != internal.NativeEndian {
+		if spec.ByteOrder != internal.NativeEndian {
 			return
 		}
 


### PR DESCRIPTION
This is necessary to be able to access it from package `link`.