### PR TITLE
feature: add call fixups for bpf_probe_read_kernel, etc

### DIFF
--- a/asm/instruction.go
+++ b/asm/instruction.go
@@ -181,6 +181,11 @@ func (ins *Instruction) IsFunctionCall() bool {
 	return ins.OpCode.JumpOp() == Call && ins.Src == PseudoCall
 }
 
+// IsBuiltinCall returns true if the instruction is a built-in call, i.e. BPF helper call.
+func (ins *Instruction) IsBuiltinCall() bool {
+	return ins.OpCode.JumpOp() == Call && ins.Src == R0 && ins.Dst == R0
+}
+
 // IsConstantLoad returns true if the instruction loads a constant of the
 // given size.
 func (ins *Instruction) IsConstantLoad(size Size) bool {

--- a/syscalls_test.go
+++ b/syscalls_test.go
@@ -50,3 +50,7 @@ func TestHaveMmapableMaps(t *testing.T) {
 func TestHaveInnerMaps(t *testing.T) {
 	testutils.CheckFeatureTest(t, haveInnerMaps)
 }
+
+func TestHaveProbeReadKernel(t *testing.T) {
+	testutils.CheckFeatureTest(t, haveProbeReadKernel)
+}


### PR DESCRIPTION
I met the `invalid func unknown#113` error yesterday when deploying bpf programs to a 4.19 kernel, and found that libbpf have this bpf_probe_read_kernel auto replacement feature when it loads program.
https://github.com/libbpf/libbpf/blob/master/src/libbpf.c#L6009

So I added this feature to this project and have it tested.

```
$ go test -run TestHaveProbeReadKernel
PASS
ok  	github.com/cilium/ebpf	0.003s
```

Please let me know if any problem with this implementation 🙇  Thanks a lot!