### PR TITLE
collection: remove the abomination that is lazyLoadCollection

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -208,20 +208,20 @@ func (cs *CollectionSpec) LoadAndAssign(to interface{}, opts *CollectionOptions)
 		opts = &CollectionOptions{}
 	}
 
-	loadMap, loadProgram, populateMaps, done, cleanup := lazyLoadCollection(cs, opts)
-	defer cleanup()
+	loader := newCollectionLoader(cs, opts)
+	defer loader.close()
 
 	valueOf := func(typ reflect.Type, name string) (reflect.Value, error) {
 		switch typ {
 		case reflect.TypeOf((*Program)(nil)):
-			p, err := loadProgram(name)
+			p, err := loader.loadProgram(name)
 			if err != nil {
 				return reflect.Value{}, err
 			}
 			return reflect.ValueOf(p), nil
 
 		case reflect.TypeOf((*Map)(nil)):
-			m, err := loadMap(name)
+			m, err := loader.loadMap(name)
 			if err != nil {
 				return reflect.Value{}, err
 			}
@@ -237,12 +237,13 @@ func (cs *CollectionSpec) LoadAndAssign(to interface{}, opts *CollectionOptions)
 		return err
 	}
 
-	// Finally, autopopulate the requested maps.
-	if err := populateMaps(); err != nil {
+	// Finally, populate the requested maps.
+	if err := loader.populateMaps(); err != nil {
 		return err
 	}
 
-	done()
+	loader.finalize()
+
 	return nil
 }
 
@@ -260,29 +261,32 @@ func NewCollection(spec *CollectionSpec) (*Collection, error) {
 
 // NewCollectionWithOptions creates a Collection from a specification.
 func NewCollectionWithOptions(spec *CollectionSpec, opts CollectionOptions) (*Collection, error) {
-	loadMap, loadProgram, populateMaps, done, cleanup := lazyLoadCollection(spec, &opts)
-	defer cleanup()
+	loader := newCollectionLoader(spec, &opts)
+	defer loader.close()
 
 	// Create maps first, as their fds need to be linked into programs.
 	for mapName := range spec.Maps {
-		if _, err := loadMap(mapName); err != nil {
+		if _, err := loader.loadMap(mapName); err != nil {
 			return nil, err
 		}
 	}
 
 	for progName := range spec.Programs {
-		if _, err := loadProgram(progName); err != nil {
+		if _, err := loader.loadProgram(progName); err != nil {
 			return nil, err
 		}
 	}
 
-	// Maps can contain pointers to Programs, so populate them after
+	// Maps can contain Program and Map stubs, so populate them after
 	// all Maps and Programs have been successfully loaded.
-	if err := populateMaps(); err != nil {
+	if err := loader.populateMaps(); err != nil {
 		return nil, err
 	}
 
-	maps, progs := done()
+	maps, progs := loader.maps, loader.programs
+
+	loader.finalize()
+
 	return &Collection{
 		progs,
 		maps,
@@ -335,149 +339,145 @@ func (hc handleCache) close() {
 	}
 }
 
-func lazyLoadCollection(coll *CollectionSpec, opts *CollectionOptions) (
-	loadMap func(string) (*Map, error),
-	loadProgram func(string) (*Program, error),
-	populateMaps func() error,
-	done func() (map[string]*Map, map[string]*Program),
-	cleanup func(),
-) {
-	var (
-		maps             = make(map[string]*Map)
-		progs            = make(map[string]*Program)
-		handles          = newHandleCache()
-		skipMapsAndProgs = false
-	)
+type collectionLoader struct {
+	coll     *CollectionSpec
+	opts     *CollectionOptions
+	maps     map[string]*Map
+	programs map[string]*Program
+	handles  *handleCache
+}
 
-	cleanup = func() {
-		handles.close()
-
-		if skipMapsAndProgs {
-			return
-		}
-
-		for _, m := range maps {
-			m.Close()
-		}
-
-		for _, p := range progs {
-			p.Close()
-		}
+func newCollectionLoader(coll *CollectionSpec, opts *CollectionOptions) *collectionLoader {
+	return &collectionLoader{
+		coll,
+		opts,
+		make(map[string]*Map),
+		make(map[string]*Program),
+		newHandleCache(),
 	}
+}
 
-	done = func() (map[string]*Map, map[string]*Program) {
-		skipMapsAndProgs = true
-		return maps, progs
+// finalize should be called when all the collectionLoader's resources
+// have been successfully loaded into the kernel and populated with values.
+func (cl *collectionLoader) finalize() {
+	cl.maps, cl.programs = nil, nil
+}
+
+func (cl *collectionLoader) close() {
+	cl.handles.close()
+	for _, m := range cl.maps {
+		m.Close()
 	}
+	for _, p := range cl.programs {
+		p.Close()
+	}
+}
 
-	loadMap = func(mapName string) (*Map, error) {
-		if m := maps[mapName]; m != nil {
-			return m, nil
-		}
-
-		mapSpec := coll.Maps[mapName]
-		if mapSpec == nil {
-			return nil, fmt.Errorf("missing map %s", mapName)
-		}
-
-		m, err := newMapWithOptions(mapSpec, opts.Maps, handles)
-		if err != nil {
-			return nil, fmt.Errorf("map %s: %w", mapName, err)
-		}
-
-		maps[mapName] = m
+func (cl *collectionLoader) loadMap(mapName string) (*Map, error) {
+	if m := cl.maps[mapName]; m != nil {
 		return m, nil
 	}
 
-	loadProgram = func(progName string) (*Program, error) {
-		if prog := progs[progName]; prog != nil {
-			return prog, nil
+	mapSpec := cl.coll.Maps[mapName]
+	if mapSpec == nil {
+		return nil, fmt.Errorf("missing map %s", mapName)
+	}
+
+	m, err := newMapWithOptions(mapSpec, cl.opts.Maps, cl.handles)
+	if err != nil {
+		return nil, fmt.Errorf("map %s: %w", mapName, err)
+	}
+
+	cl.maps[mapName] = m
+	return m, nil
+}
+
+func (cl *collectionLoader) loadProgram(progName string) (*Program, error) {
+	if prog := cl.programs[progName]; prog != nil {
+		return prog, nil
+	}
+
+	progSpec := cl.coll.Programs[progName]
+	if progSpec == nil {
+		return nil, fmt.Errorf("unknown program %s", progName)
+	}
+
+	progSpec = progSpec.Copy()
+
+	// Rewrite any reference to a valid map.
+	for i := range progSpec.Instructions {
+		ins := &progSpec.Instructions[i]
+
+		if !ins.IsLoadFromMap() || ins.Reference == "" {
+			continue
 		}
 
-		progSpec := coll.Programs[progName]
-		if progSpec == nil {
-			return nil, fmt.Errorf("unknown program %s", progName)
+		if uint32(ins.Constant) != math.MaxUint32 {
+			// Don't overwrite maps already rewritten, users can
+			// rewrite programs in the spec themselves
+			continue
 		}
 
-		progSpec = progSpec.Copy()
-
-		// Rewrite any reference to a valid map.
-		for i := range progSpec.Instructions {
-			ins := &progSpec.Instructions[i]
-
-			if !ins.IsLoadFromMap() || ins.Reference == "" {
-				continue
-			}
-
-			if uint32(ins.Constant) != math.MaxUint32 {
-				// Don't overwrite maps already rewritten, users can
-				// rewrite programs in the spec themselves
-				continue
-			}
-
-			m, err := loadMap(ins.Reference)
-			if err != nil {
-				return nil, fmt.Errorf("program %s: %w", progName, err)
-			}
-
-			fd := m.FD()
-			if fd < 0 {
-				return nil, fmt.Errorf("map %s: %w", ins.Reference, internal.ErrClosedFd)
-			}
-			if err := ins.RewriteMapPtr(m.FD()); err != nil {
-				return nil, fmt.Errorf("progam %s: map %s: %w", progName, ins.Reference, err)
-			}
-		}
-
-		prog, err := newProgramWithOptions(progSpec, opts.Programs, handles)
+		m, err := cl.loadMap(ins.Reference)
 		if err != nil {
 			return nil, fmt.Errorf("program %s: %w", progName, err)
 		}
 
-		progs[progName] = prog
-		return prog, nil
+		fd := m.FD()
+		if fd < 0 {
+			return nil, fmt.Errorf("map %s: %w", ins.Reference, internal.ErrClosedFd)
+		}
+		if err := ins.RewriteMapPtr(m.FD()); err != nil {
+			return nil, fmt.Errorf("progam %s: map %s: %w", progName, ins.Reference, err)
+		}
 	}
 
-	populateMaps = func() error {
-		for mapName, m := range maps {
-			mapSpec, ok := coll.Maps[mapName]
-			if !ok {
-				return fmt.Errorf("missing map spec %s", mapName)
-			}
+	prog, err := newProgramWithOptions(progSpec, cl.opts.Programs, cl.handles)
+	if err != nil {
+		return nil, fmt.Errorf("program %s: %w", progName, err)
+	}
 
-			mapSpec = mapSpec.Copy()
+	cl.programs[progName] = prog
+	return prog, nil
+}
 
-			// Replace any object stubs with loaded objects.
-			for i, kv := range mapSpec.Contents {
-				switch v := kv.Value.(type) {
-				case programStub:
-					// loadProgram is idempotent and could return an existing Program.
-					prog, err := loadProgram(string(v))
-					if err != nil {
-						return fmt.Errorf("loading program %s, for map %s: %w", v, mapName, err)
-					}
-					mapSpec.Contents[i] = MapKV{kv.Key, prog}
+func (cl *collectionLoader) populateMaps() error {
+	for mapName, m := range cl.maps {
+		mapSpec, ok := cl.coll.Maps[mapName]
+		if !ok {
+			return fmt.Errorf("missing map spec %s", mapName)
+		}
 
-				case mapStub:
-					// loadMap is idempotent and could return an existing Map.
-					innerMap, err := loadMap(string(v))
-					if err != nil {
-						return fmt.Errorf("loading inner map %s, for map %s: %w", v, mapName, err)
-					}
-					mapSpec.Contents[i] = MapKV{kv.Key, innerMap}
+		mapSpec = mapSpec.Copy()
+
+		// Replace any object stubs with loaded objects.
+		for i, kv := range mapSpec.Contents {
+			switch v := kv.Value.(type) {
+			case programStub:
+				// loadProgram is idempotent and could return an existing Program.
+				prog, err := cl.loadProgram(string(v))
+				if err != nil {
+					return fmt.Errorf("loading program %s, for map %s: %w", v, mapName, err)
 				}
-			}
+				mapSpec.Contents[i] = MapKV{kv.Key, prog}
 
-			// Populate and freeze the map if specified.
-			if err := m.finalize(mapSpec); err != nil {
-				return fmt.Errorf("populating map %s: %w", mapName, err)
+			case mapStub:
+				// loadMap is idempotent and could return an existing Map.
+				innerMap, err := cl.loadMap(string(v))
+				if err != nil {
+					return fmt.Errorf("loading inner map %s, for map %s: %w", v, mapName, err)
+				}
+				mapSpec.Contents[i] = MapKV{kv.Key, innerMap}
 			}
 		}
 
-		return nil
+		// Populate and freeze the map if specified.
+		if err := m.finalize(mapSpec); err != nil {
+			return fmt.Errorf("populating map %s: %w", mapName, err)
+		}
 	}
 
-	return
+	return nil
 }
 
 // LoadCollection parses an object file and converts it to a collection.


### PR DESCRIPTION
@lmb I ended up reinstating an equivalent of `done()` in `cs.finalize()`, since the `loader.maps, loader.programs = nil, nil` looked a little out of place and it wasn't immediately clear why these fields were nilled out.