### PR TITLE
features: add HaveProgramHelper API

### DIFF
--- a/asm/func.go
+++ b/asm/func.go
@@ -5,6 +5,10 @@ package asm
 // BuiltinFunc is a built-in eBPF function.
 type BuiltinFunc int32
 
+func (_ BuiltinFunc) Max() BuiltinFunc {
+	return maxBuiltinFunc - 1
+}
+
 // eBPF built-in functions
 //
 // You can regenerate this list using the following gawk script:
@@ -197,6 +201,8 @@ const (
 	FnGetFuncIp
 	FnGetAttachCookie
 	FnTaskPtRegs
+
+	maxBuiltinFunc
 )
 
 // Call emits a function call.

--- a/features/prog_test.go
+++ b/features/prog_test.go
@@ -1,12 +1,15 @@
 package features
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"os"
 	"testing"
 
 	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/asm"
+	"github.com/cilium/ebpf/internal"
 	"github.com/cilium/ebpf/internal/testutils"
 )
 
@@ -90,5 +93,88 @@ func TestHaveProgTypeUnsupported(t *testing.T) {
 func TestHaveProgTypeInvalid(t *testing.T) {
 	if err := HaveProgType(ebpf.ProgramType(math.MaxUint32)); err != os.ErrInvalid {
 		t.Fatalf("Expected os.ErrInvalid but was: %v", err)
+	}
+}
+
+func TestHaveProgramHelper(t *testing.T) {
+	type testCase struct {
+		prog     ebpf.ProgramType
+		helper   asm.BuiltinFunc
+		expected error
+		version  string
+	}
+
+	// Referencing linux kernel commits to track the kernel version required to pass these test cases.
+	// They cases are derived from libbpf's selftests and helper/prog combinations that are
+	// probed for in cilium/cilium.
+	// Still missing since those helpers are not available in the lib yet, are:
+	// - Kprobe, GetBranchSnapshot
+	// - SchedCLS, SkbSetTstamp
+	// These two test cases depend on CI kernels supporting those:
+	// {ebpf.Kprobe, asm.FnKtimeGetCoarseNs, ebpf.ErrNotSupported, "5.16"}, // 5e0bc3082e2e
+	// {ebpf.CGroupSockAddr, asm.FnGetCgroupClassid, nil, "5.10"},    // b426ce83baa7
+	testCases := []testCase{
+		{ebpf.Kprobe, asm.FnMapLookupElem, nil, "3.19"},               // d0003ec01c66
+		{ebpf.SocketFilter, asm.FnKtimeGetCoarseNs, nil, "5.11"},      // d05512618056
+		{ebpf.SchedCLS, asm.FnSkbVlanPush, nil, "4.3"},                // 4e10df9a60d9
+		{ebpf.Kprobe, asm.FnSkbVlanPush, ebpf.ErrNotSupported, "4.3"}, // 4e10df9a60d9
+		{ebpf.Kprobe, asm.FnSysBpf, ebpf.ErrNotSupported, "5.14"},     // 79a7f8bdb159
+		{ebpf.Syscall, asm.FnSysBpf, nil, "5.14"},                     // 79a7f8bdb159
+		{ebpf.XDP, asm.FnJiffies64, nil, "5.5"},                       // 5576b991e9c1
+		{ebpf.XDP, asm.FnKtimeGetBootNs, nil, "5.7"},                  // 71d19214776e
+		{ebpf.SchedCLS, asm.FnSkbChangeHead, nil, "5.8"},              // 6f3f65d80dac
+		{ebpf.SchedCLS, asm.FnRedirectNeigh, nil, "5.10"},             // b4ab31414970
+		{ebpf.SchedCLS, asm.FnSkbEcnSetCe, nil, "5.1"},                // f7c917ba11a6
+		{ebpf.SchedACT, asm.FnSkAssign, nil, "5.6"},                   // cf7fbe660f2d
+		{ebpf.SchedACT, asm.FnFibLookup, nil, "4.18"},                 // 87f5fc7e48dd
+		{ebpf.Kprobe, asm.FnFibLookup, ebpf.ErrNotSupported, "4.18"},  // 87f5fc7e48dd
+		{ebpf.CGroupSockAddr, asm.FnGetsockopt, nil, "5.8"},           // beecf11bc218
+		{ebpf.CGroupSockAddr, asm.FnSkLookupTcp, nil, "4.20"},         // 6acc9b432e67
+		{ebpf.CGroupSockAddr, asm.FnGetNetnsCookie, nil, "5.7"},       // f318903c0bf4
+		{ebpf.CGroupSock, asm.FnGetNetnsCookie, nil, "5.7"},           // f318903c0bf4
+	}
+
+	for _, tc := range testCases {
+		minVersion := progTypeMinVersion[tc.prog]
+
+		progVersion, err := internal.NewVersion(minVersion)
+		if err != nil {
+			t.Fatalf("Could not read kernel version required for program: %v", err)
+		}
+
+		helperVersion, err := internal.NewVersion(tc.version)
+		if err != nil {
+			t.Fatalf("Could not read kernel version required for helper: %v", err)
+		}
+
+		if progVersion.Less(helperVersion) {
+			minVersion = tc.version
+		}
+
+		t.Run(fmt.Sprintf("%s/%s", tc.prog.String(), tc.helper.String()), func(t *testing.T) {
+			feature := fmt.Sprintf("helper %s for program type %s", tc.helper.String(), tc.prog.String())
+
+			testutils.SkipOnOldKernel(t, minVersion, feature)
+
+			err := HaveProgramHelper(tc.prog, tc.helper)
+			if !errors.Is(err, tc.expected) {
+				t.Fatalf("%s/%s: %v", tc.prog.String(), tc.helper.String(), err)
+			}
+
+		})
+
+	}
+}
+
+func TestHaveProgramHelperUnsupported(t *testing.T) {
+	pt := ebpf.SocketFilter
+	minVersion := progTypeMinVersion[pt]
+
+	feature := fmt.Sprintf("program type %s", pt.String())
+
+	testutils.SkipOnOldKernel(t, minVersion, feature)
+
+	if err := haveProgramHelper(pt, asm.BuiltinFunc(math.MaxInt32)); err != ebpf.ErrNotSupported {
+		t.Fatalf("Expected ebpf.ErrNotSupported but was: %v", err)
 	}
 }

--- a/features/prog_test.go
+++ b/features/prog_test.go
@@ -47,7 +47,7 @@ var progTypeMinVersion = map[ebpf.ProgramType]string{
 	ebpf.Syscall:               "5.14",
 }
 
-func TestHaveProgType(t *testing.T) {
+func TestHaveProgramType(t *testing.T) {
 	for progType := ebpf.UnspecifiedProgram + 1; progType <= progType.Max(); progType++ {
 		// Need inner loop copy to make use of t.Parallel()
 		pt := progType
@@ -69,7 +69,7 @@ func TestHaveProgType(t *testing.T) {
 			}
 			testutils.SkipOnOldKernel(t, minVersion, feature)
 
-			if err := HaveProgType(pt); err != nil {
+			if err := HaveProgramType(pt); err != nil {
 				if pt == ebpf.LircMode2 {
 					// CI kernels are built with CONFIG_BPF_LIRC_MODE2, but some
 					// mainstream distro's don't ship with it. Make this prog type
@@ -84,14 +84,14 @@ func TestHaveProgType(t *testing.T) {
 	}
 }
 
-func TestHaveProgTypeUnsupported(t *testing.T) {
-	if err := haveProgType(ebpf.ProgramType(math.MaxUint32)); err != ebpf.ErrNotSupported {
+func TestHaveProgramTypeUnsupported(t *testing.T) {
+	if err := haveProgramType(ebpf.ProgramType(math.MaxUint32)); err != ebpf.ErrNotSupported {
 		t.Fatalf("Expected ebpf.ErrNotSupported but was: %v", err)
 	}
 }
 
-func TestHaveProgTypeInvalid(t *testing.T) {
-	if err := HaveProgType(ebpf.ProgramType(math.MaxUint32)); err != os.ErrInvalid {
+func TestHaveProgramTypeInvalid(t *testing.T) {
+	if err := HaveProgramType(ebpf.ProgramType(math.MaxUint32)); err != os.ErrInvalid {
 		t.Fatalf("Expected os.ErrInvalid but was: %v", err)
 	}
 }

--- a/internal/unix/types_linux.go
+++ b/internal/unix/types_linux.go
@@ -23,6 +23,7 @@ const (
 	EBADF   = linux.EBADF
 	E2BIG   = linux.E2BIG
 	EFAULT  = linux.EFAULT
+	EACCES  = linux.EACCES
 	// ENOTSUPP is not the same as ENOTSUP or EOPNOTSUP
 	ENOTSUPP = syscall.Errno(0x20c)
 

--- a/internal/unix/types_other.go
+++ b/internal/unix/types_other.go
@@ -24,6 +24,7 @@ const (
 	EBADF  = syscall.Errno(0)
 	E2BIG  = syscall.Errno(0)
 	EFAULT = syscall.EFAULT
+	EACCES = syscall.Errno(0)
 	// ENOTSUPP is not the same as ENOTSUP or EOPNOTSUP
 	ENOTSUPP = syscall.Errno(0x20c)
 


### PR DESCRIPTION
`HaveProgHelper(pt ebpf.ProgramType, helper asm.BuiltinFunc) error`
allows to probe the available BPF helpers to a given BPF program
type. Probe results are cached and run at most once.

Signed-off-by: Robin Gögge <r.goegge@gmail.com>