### PR TITLE
changed slack channel link

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ be used in long running processes.
 
 The library is maintained by [Cloudflare](https://www.cloudflare.com) and
 [Cilium](https://www.cilium.io). Feel free to
-[join](https://cilium.herokuapp.com/) the
+[join](https://ebpf.io/slack) the
 [#ebpf-go](https://cilium.slack.com/messages/ebpf-go) channel on Slack.
 
 ## Current status

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ be used in long running processes.
 The library is maintained by [Cloudflare](https://www.cloudflare.com) and
 [Cilium](https://www.cilium.io). Feel free to
 [join](https://cilium.herokuapp.com/) the
-[#libbpf-go](https://cilium.slack.com/messages/libbpf-go) channel on Slack.
+[#ebpf-go](https://cilium.slack.com/messages/ebpf-go) channel on Slack.
 
 ## Current status
 


### PR DESCRIPTION
since the channel was renamed yesterday from #libbpf-go to #ebpf-go