### PR TITLE
Rename 'StructOpts' to StructOpsMap

### DIFF
--- a/features/map.go
+++ b/features/map.go
@@ -121,10 +121,11 @@ func validateMaptype(mt ebpf.MapType) error {
 		return os.ErrInvalid
 	}
 
-	if mt == ebpf.StructOpts {
-		// A probe for a StructOpts map has vmlinux BTF requirements we currently cannot meet
-		// Once we figure out how to add a working probe in this package, we can remove this check
-		return errors.New("a probe for MapType StructOpts isn't implemented")
+	if mt == ebpf.StructOpsMap {
+		// A probe for StructOpsMap has vmlinux BTF requirements we currently
+		// cannot meet. Once we figure out how to add a working probe in this
+		// package, we can remove this check.
+		return errors.New("a probe for MapType StructOpsMap isn't implemented")
 	}
 
 	return nil

--- a/features/map_test.go
+++ b/features/map_test.go
@@ -36,7 +36,7 @@ var mapTypeMinVersion = map[ebpf.MapType]string{
 	ebpf.Stack:               "4.20",
 	ebpf.SkStorage:           "5.2",
 	ebpf.DevMapHash:          "5.4",
-	ebpf.StructOpts:          "5.6", // requires vmlinux BTF, skip for now
+	ebpf.StructOpsMap:        "5.6", // requires vmlinux BTF, skip for now
 	ebpf.RingBuf:             "5.8",
 	ebpf.InodeStorage:        "5.10",
 	ebpf.TaskStorage:         "5.11",
@@ -54,9 +54,8 @@ func TestHaveMapType(t *testing.T) {
 		feature := fmt.Sprintf("map type %s", mt.String())
 
 		t.Run(mt.String(), func(t *testing.T) {
-			// skip StructOpts test as its not implemented
-			if mt == ebpf.StructOpts {
-				t.Skip("Test for map type StructOpts requires working probe")
+			if mt == ebpf.StructOpsMap {
+				t.Skip("Test for map type StructOpsMap requires working probe")
 			}
 
 			testutils.SkipOnOldKernel(t, minVersion, feature)
@@ -81,7 +80,7 @@ func TestHaveMapTypeInvalid(t *testing.T) {
 		t.Fatalf("Expected os.ErrInvalid but was: %v", err)
 	}
 
-	if err := HaveMapType(ebpf.MapType(ebpf.StructOpts)); err == nil {
+	if err := HaveMapType(ebpf.MapType(ebpf.StructOpsMap)); err == nil {
 		t.Fatal("Expected but was nil")
 	}
 }

--- a/types.go
+++ b/types.go
@@ -90,9 +90,9 @@ const (
 	SkStorage
 	// DevMapHash - Hash-based indexing scheme for references to network devices.
 	DevMapHash
-	// StructOps - This map holds a kernel struct with its function pointer implemented in a BPF
+	// StructOpsMap - This map holds a kernel struct with its function pointer implemented in a BPF
 	// program.
-	StructOpts
+	StructOpsMap
 	// RingBuf - Similar to PerfEventArray, but shared across all CPUs.
 	RingBuf
 	// InodeStorage - Specialized local storage map for inodes.
@@ -102,6 +102,12 @@ const (
 	// maxMapType - Bound enum of MapTypes, has to be last in enum.
 	maxMapType
 )
+
+// Deprecated: StructOpts was a typo, use StructOpsMap instead.
+//
+// Declared as a variable to prevent stringer from picking it up
+// as an enum value.
+var StructOpts MapType = StructOpsMap
 
 // hasPerCPUValue returns true if the Map stores a value per CPU.
 func (mt MapType) hasPerCPUValue() bool {

--- a/types_string.go
+++ b/types_string.go
@@ -34,16 +34,16 @@ func _() {
 	_ = x[Stack-23]
 	_ = x[SkStorage-24]
 	_ = x[DevMapHash-25]
-	_ = x[StructOpts-26]
+	_ = x[StructOpsMap-26]
 	_ = x[RingBuf-27]
 	_ = x[InodeStorage-28]
 	_ = x[TaskStorage-29]
 	_ = x[maxMapType-30]
 }
 
-const _MapType_name = "UnspecifiedMapHashArrayProgramArrayPerfEventArrayPerCPUHashPerCPUArrayStackTraceCGroupArrayLRUHashLRUCPUHashLPMTrieArrayOfMapsHashOfMapsDevMapSockMapCPUMapXSKMapSockHashCGroupStorageReusePortSockArrayPerCPUCGroupStorageQueueStackSkStorageDevMapHashStructOptsRingBufInodeStorageTaskStoragemaxMapType"
+const _MapType_name = "UnspecifiedMapHashArrayProgramArrayPerfEventArrayPerCPUHashPerCPUArrayStackTraceCGroupArrayLRUHashLRUCPUHashLPMTrieArrayOfMapsHashOfMapsDevMapSockMapCPUMapXSKMapSockHashCGroupStorageReusePortSockArrayPerCPUCGroupStorageQueueStackSkStorageDevMapHashStructOpsMapRingBufInodeStorageTaskStoragemaxMapType"
 
-var _MapType_index = [...]uint16{0, 14, 18, 23, 35, 49, 59, 70, 80, 91, 98, 108, 115, 126, 136, 142, 149, 155, 161, 169, 182, 200, 219, 224, 229, 238, 248, 258, 265, 277, 288, 298}
+var _MapType_index = [...]uint16{0, 14, 18, 23, 35, 49, 59, 70, 80, 91, 98, 108, 115, 126, 136, 142, 149, 155, 161, 169, 182, 200, 219, 224, 229, 238, 248, 260, 267, 279, 290, 300}
 
 func (i MapType) String() string {
 	if i >= MapType(len(_MapType_index)-1) {
@@ -86,11 +86,12 @@ func _() {
 	_ = x[Extension-28]
 	_ = x[LSM-29]
 	_ = x[SkLookup-30]
+	_ = x[maxProgramType-31]
 }
 
-const _ProgramType_name = "UnspecifiedProgramSocketFilterKprobeSchedCLSSchedACTTracePointXDPPerfEventCGroupSKBCGroupSockLWTInLWTOutLWTXmitSockOpsSkSKBCGroupDeviceSkMsgRawTracepointCGroupSockAddrLWTSeg6LocalLircMode2SkReuseportFlowDissectorCGroupSysctlRawTracepointWritableCGroupSockoptTracingStructOpsExtensionLSMSkLookup"
+const _ProgramType_name = "UnspecifiedProgramSocketFilterKprobeSchedCLSSchedACTTracePointXDPPerfEventCGroupSKBCGroupSockLWTInLWTOutLWTXmitSockOpsSkSKBCGroupDeviceSkMsgRawTracepointCGroupSockAddrLWTSeg6LocalLircMode2SkReuseportFlowDissectorCGroupSysctlRawTracepointWritableCGroupSockoptTracingStructOpsExtensionLSMSkLookupmaxProgramType"
 
-var _ProgramType_index = [...]uint16{0, 18, 30, 36, 44, 52, 62, 65, 74, 83, 93, 98, 104, 111, 118, 123, 135, 140, 153, 167, 179, 188, 199, 212, 224, 245, 258, 265, 274, 283, 286, 294}
+var _ProgramType_index = [...]uint16{0, 18, 30, 36, 44, 52, 62, 65, 74, 83, 93, 98, 104, 111, 118, 123, 135, 140, 153, 167, 179, 188, 199, 212, 224, 245, 258, 265, 274, 283, 286, 294, 308}
 
 func (i ProgramType) String() string {
 	if i >= ProgramType(len(_ProgramType_index)-1) {


### PR DESCRIPTION
This seems to have been a typo that slipped in unnoticed. The old 'StructOpts' has been kept around as a deprecated alias
to preserve backwards-compatibility and will be removed in a subsequent release.

@mythi @rgo3 