### PR TITLE
link/uprobe: fix offsets for statically linked binaries

### DIFF
--- a/link/uprobe.go
+++ b/link/uprobe.go
@@ -31,8 +31,8 @@ var (
 type Executable struct {
 	// Path of the executable on the filesystem.
 	path string
-	// Parsed ELF symbols and dynamic symbols.
-	symbols map[string]elf.Symbol
+	// Parsed ELF symbols and dynamic symbols offsets.
+	offsets map[string]uint64
 }
 
 // UprobeOptions defines additional parameters that will be used
@@ -67,42 +67,84 @@ func OpenExecutable(path string) (*Executable, error) {
 		return nil, fmt.Errorf("parse ELF file: %w", err)
 	}
 
-	var ex = Executable{
-		path:    path,
-		symbols: make(map[string]elf.Symbol),
-	}
-	if err := ex.addSymbols(se.Symbols); err != nil {
-		return nil, err
+	if se.Type != elf.ET_EXEC && se.Type != elf.ET_DYN {
+		// ELF is not an executable or a shared object.
+		return nil, errors.New("the given file is not an executable or a shared object")
 	}
 
-	if err := ex.addSymbols(se.DynamicSymbols); err != nil {
+	ex := Executable{
+		path:    path,
+		offsets: make(map[string]uint64),
+	}
+
+	if err := ex.load(se); err != nil {
 		return nil, err
 	}
 
 	return &ex, nil
 }
 
-func (ex *Executable) addSymbols(f func() ([]elf.Symbol, error)) error {
-	// elf.Symbols and elf.DynamicSymbols return ErrNoSymbols if the section is not found.
-	syms, err := f()
+func (ex *Executable) load(f *internal.SafeELFFile) error {
+	syms, err := f.Symbols()
 	if err != nil && !errors.Is(err, elf.ErrNoSymbols) {
 		return err
 	}
+
+	dynsyms, err := f.DynamicSymbols()
+	if err != nil && !errors.Is(err, elf.ErrNoSymbols) {
+		return err
+	}
+
+	syms = append(syms, dynsyms...)
+
 	for _, s := range syms {
 		if elf.ST_TYPE(s.Info) != elf.STT_FUNC {
 			// Symbol not associated with a function or other executable code.
 			continue
 		}
-		ex.symbols[s.Name] = s
+
+		off := s.Value
+
+		// Loop over ELF segments.
+		for _, prog := range f.Progs {
+			// Skip uninteresting segments.
+			if prog.Type != elf.PT_LOAD || (prog.Flags&elf.PF_X) == 0 {
+				continue
+			}
+
+			if prog.Vaddr <= s.Value && s.Value < (prog.Vaddr+prog.Memsz) {
+				// If the symbol value is contained in the segment, calculate
+				// the symbol offset.
+				//
+				// fn symbol offset = fn symbol VA - .text VA + .text offset
+				//
+				// stackoverflow.com/a/40249502
+				off = s.Value - prog.Vaddr + prog.Off
+				break
+			}
+		}
+
+		ex.offsets[s.Name] = off
 	}
+
 	return nil
 }
 
-func (ex *Executable) symbol(symbol string) (*elf.Symbol, error) {
-	if s, ok := ex.symbols[symbol]; ok {
-		return &s, nil
+func (ex *Executable) offset(symbol string) (uint64, error) {
+	if off, ok := ex.offsets[symbol]; ok {
+		// Symbols with location 0 from section undef are shared library calls and
+		// are relocated before the binary is executed. Dynamic linking is not
+		// implemented by the library, so mark this as unsupported for now.
+		//
+		// Since only offset values are stored and not elf.Symbol, if the value is 0,
+		// assume it's an external symbol.
+		if off == 0 {
+			return 0, fmt.Errorf("cannot resolve %s library call '%s', "+
+				"consider providing the offset via options: %w", ex.path, symbol, ErrNotSupported)
+		}
+		return off, nil
 	}
-	return nil, fmt.Errorf("symbol %s not found", symbol)
+	return 0, fmt.Errorf("symbol %s not found", symbol)
 }
 
 // Uprobe attaches the given eBPF program to a perf event that fires when the
@@ -184,20 +226,11 @@ func (ex *Executable) uprobe(symbol string, prog *ebpf.Program, opts *UprobeOpti
 	if opts != nil && opts.Offset != 0 {
 		offset = opts.Offset
 	} else {
-		sym, err := ex.symbol(symbol)
+		off, err := ex.offset(symbol)
 		if err != nil {
-			return nil, fmt.Errorf("symbol '%s' not found: %w", symbol, err)
+			return nil, err
 		}
-
-		// Symbols with location 0 from section undef are shared library calls and
-		// are relocated before the binary is executed. Dynamic linking is not
-		// implemented by the library, so mark this as unsupported for now.
-		if sym.Section == elf.SHN_UNDEF && sym.Value == 0 {
-			return nil, fmt.Errorf("cannot resolve %s library call '%s', "+
-				"consider providing the offset via options: %w", ex.path, symbol, ErrNotSupported)
-		}
-
-		offset = sym.Value
+		offset = off
 	}
 
 	pid := perfAllThreads

--- a/link/uprobe_test.go
+++ b/link/uprobe_test.go
@@ -333,6 +333,11 @@ func TestUprobeProgramCall(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			if tt.name == "go-binary" {
+				// https://github.com/cilium/ebpf/issues/406
+				testutils.SkipOnOldKernel(t, "4.14", "uprobes on Go binaries silently fail on kernel < 4.14")
+			}
+
 			m, p := newUpdaterMapProg(t, ebpf.Kprobe)
 
 			// Load the executable.

--- a/link/uprobe_test.go
+++ b/link/uprobe_test.go
@@ -3,8 +3,10 @@ package link
 import (
 	"errors"
 	"fmt"
+	"go/build"
 	"os"
 	"os/exec"
+	"path"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
@@ -14,8 +16,10 @@ import (
 	"github.com/cilium/ebpf/internal/unix"
 )
 
-var bashEx, _ = OpenExecutable("/bin/bash")
-var bashSym = "main"
+var (
+	bashEx, _ = OpenExecutable("/bin/bash")
+	bashSym   = "main"
+)
 
 func TestExecutable(t *testing.T) {
 	_, err := OpenExecutable("")
@@ -27,15 +31,12 @@ func TestExecutable(t *testing.T) {
 		t.Fatalf("create executable: unexpected path '%s'", bashEx.path)
 	}
 
-	sym, err := bashEx.symbol(bashSym)
+	_, err = bashEx.offset(bashSym)
 	if err != nil {
-		t.Fatalf("find symbol: %v", err)
-	}
-	if sym.Name != bashSym {
-		t.Fatalf("find symbol: unexpected symbol '%s'", sym.Name)
+		t.Fatalf("find offset: %v", err)
 	}
 
-	_, err = bashEx.symbol("bogus")
+	_, err = bashEx.offset("bogus")
 	if err == nil {
 		t.Fatal("find symbol: expected error")
 	}
@@ -142,19 +143,19 @@ func TestUprobeCreatePMU(t *testing.T) {
 
 	c := qt.New(t)
 
-	// Fetch the elf.Symbol from the /bin/bash Executable already defined.
-	sym, err := bashEx.symbol(bashSym)
+	// Fetch the offset from the /bin/bash Executable already defined.
+	off, err := bashEx.offset(bashSym)
 	c.Assert(err, qt.IsNil)
 
 	// uprobe PMU
-	pu, err := pmuUprobe(sym.Name, bashEx.path, sym.Value, perfAllThreads, false)
+	pu, err := pmuUprobe(bashSym, bashEx.path, off, perfAllThreads, false)
 	c.Assert(err, qt.IsNil)
 	defer pu.Close()
 
 	c.Assert(pu.typ, qt.Equals, uprobeEvent)
 
 	// uretprobe PMU
-	pr, err := pmuUprobe(sym.Name, bashEx.path, sym.Value, perfAllThreads, true)
+	pr, err := pmuUprobe(bashSym, bashEx.path, off, perfAllThreads, true)
 	c.Assert(err, qt.IsNil)
 	defer pr.Close()
 
@@ -165,11 +166,11 @@ func TestUprobeCreatePMU(t *testing.T) {
 func TestUprobePMUUnavailable(t *testing.T) {
 	c := qt.New(t)
 
-	// Fetch the elf.Symbol from the /bin/bash Executable already defined.
-	sym, err := bashEx.symbol(bashSym)
+	// Fetch the offset from the /bin/bash Executable already defined.
+	off, err := bashEx.offset(bashSym)
 	c.Assert(err, qt.IsNil)
 
-	pk, err := pmuUprobe(sym.Name, bashEx.path, sym.Value, perfAllThreads, false)
+	pk, err := pmuUprobe(bashSym, bashEx.path, off, perfAllThreads, false)
 	if err == nil {
 		pk.Close()
 		t.Skipf("Kernel supports perf_uprobe PMU, not asserting error.")
@@ -183,31 +184,31 @@ func TestUprobePMUUnavailable(t *testing.T) {
 func TestUprobeTraceFS(t *testing.T) {
 	c := qt.New(t)
 
-	// Fetch the elf.Symbol from the /bin/bash Executable already defined.
-	sym, err := bashEx.symbol(bashSym)
+	// Fetch the offset from the /bin/bash Executable already defined.
+	off, err := bashEx.offset(bashSym)
 	c.Assert(err, qt.IsNil)
 
 	// Sanitize the symbol in order to be used in tracefs API.
-	ssym := uprobeSanitizedSymbol(sym.Name)
+	ssym := uprobeSanitizedSymbol(bashSym)
 
 	// Open and close tracefs u(ret)probes, checking all errors.
-	up, err := tracefsUprobe(ssym, bashEx.path, sym.Value, perfAllThreads, false)
+	up, err := tracefsUprobe(ssym, bashEx.path, off, perfAllThreads, false)
 	c.Assert(err, qt.IsNil)
 	c.Assert(up.Close(), qt.IsNil)
 	c.Assert(up.typ, qt.Equals, uprobeEvent)
 
-	up, err = tracefsUprobe(ssym, bashEx.path, sym.Value, perfAllThreads, true)
+	up, err = tracefsUprobe(ssym, bashEx.path, off, perfAllThreads, true)
 	c.Assert(err, qt.IsNil)
 	c.Assert(up.Close(), qt.IsNil)
 	c.Assert(up.typ, qt.Equals, uretprobeEvent)
 
 	// Create two identical trace events, ensure their IDs differ.
-	u1, err := tracefsUprobe(ssym, bashEx.path, sym.Value, perfAllThreads, false)
+	u1, err := tracefsUprobe(ssym, bashEx.path, off, perfAllThreads, false)
 	c.Assert(err, qt.IsNil)
 	defer u1.Close()
 	c.Assert(u1.tracefsID, qt.Not(qt.Equals), 0)
 
-	u2, err := tracefsUprobe(ssym, bashEx.path, sym.Value, perfAllThreads, false)
+	u2, err := tracefsUprobe(ssym, bashEx.path, off, perfAllThreads, false)
 	c.Assert(err, qt.IsNil)
 	defer u2.Close()
 	c.Assert(u2.tracefsID, qt.Not(qt.Equals), 0)
@@ -225,12 +226,12 @@ func TestUprobeCreateTraceFS(t *testing.T) {
 
 	c := qt.New(t)
 
-	// Fetch the elf.Symbol from the /bin/bash Executable already defined.
-	sym, err := bashEx.symbol(bashSym)
+	// Fetch the offset from the /bin/bash Executable already defined.
+	off, err := bashEx.offset(bashSym)
 	c.Assert(err, qt.IsNil)
 
 	// Sanitize the symbol in order to be used in tracefs API.
-	ssym := uprobeSanitizedSymbol(sym.Name)
+	ssym := uprobeSanitizedSymbol(bashSym)
 
 	pg, _ := randomGroup("ebpftest")
 	rg, _ := randomGroup("ebpftest")
@@ -242,12 +243,12 @@ func TestUprobeCreateTraceFS(t *testing.T) {
 	}()
 
 	// Create a uprobe.
-	err = createTraceFSProbeEvent(uprobeType, pg, ssym, bashEx.path, sym.Value, false)
+	err = createTraceFSProbeEvent(uprobeType, pg, ssym, bashEx.path, off, false)
 	c.Assert(err, qt.IsNil)
 
 	// Attempt to create an identical uprobe using tracefs,
 	// expect it to fail with os.ErrExist.
-	err = createTraceFSProbeEvent(uprobeType, pg, ssym, bashEx.path, sym.Value, false)
+	err = createTraceFSProbeEvent(uprobeType, pg, ssym, bashEx.path, off, false)
 	c.Assert(errors.Is(err, os.ErrExist), qt.IsTrue,
 		qt.Commentf("expected consecutive uprobe creation to contain os.ErrExist, got: %v", err))
 
@@ -255,10 +256,10 @@ func TestUprobeCreateTraceFS(t *testing.T) {
 	c.Assert(closeTraceFSProbeEvent(uprobeType, pg, ssym), qt.IsNil)
 
 	// Same test for a kretprobe.
-	err = createTraceFSProbeEvent(uprobeType, rg, ssym, bashEx.path, sym.Value, true)
+	err = createTraceFSProbeEvent(uprobeType, rg, ssym, bashEx.path, off, true)
 	c.Assert(err, qt.IsNil)
 
-	err = createTraceFSProbeEvent(uprobeType, rg, ssym, bashEx.path, sym.Value, true)
+	err = createTraceFSProbeEvent(uprobeType, rg, ssym, bashEx.path, off, true)
 	c.Assert(os.IsExist(err), qt.IsFalse,
 		qt.Commentf("expected consecutive uretprobe creation to contain os.ErrExist, got: %v", err))
 
@@ -267,7 +268,7 @@ func TestUprobeCreateTraceFS(t *testing.T) {
 }
 
 func TestUprobeSanitizedSymbol(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		symbol   string
 		expected string
 	}{
@@ -288,7 +289,7 @@ func TestUprobeSanitizedSymbol(t *testing.T) {
 }
 
 func TestUprobePathOffset(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		path     string
 		offset   uint64
 		expected string
@@ -310,47 +311,71 @@ func TestUprobePathOffset(t *testing.T) {
 }
 
 func TestUprobeProgramCall(t *testing.T) {
-	m, p := newUpdaterMapProg(t, ebpf.Kprobe)
-
-	// Load the '/bin/bash' executable.
-	ex, err := OpenExecutable("/bin/bash")
-	if err != nil {
-		t.Fatal(err)
+	tests := []struct {
+		name string
+		elf  string
+		args []string
+		sym  string
+	}{
+		{
+			"bash",
+			"/bin/bash",
+			[]string{"--help"},
+			"main",
+		},
+		{
+			"go-binary",
+			path.Join(build.Default.GOROOT, "bin/go"),
+			[]string{"version"},
+			"main.main",
+		},
 	}
 
-	// Open Uprobe on '/bin/bash' for the symbol 'main'
-	// and attach it to the ebpf program created above.
-	u, err := ex.Uprobe("main", p, nil)
-	if err != nil {
-		t.Fatal(err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m, p := newUpdaterMapProg(t, ebpf.Kprobe)
+
+			// Load the executable.
+			ex, err := OpenExecutable(tt.elf)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Open Uprobe on the executable for the given symbol
+			// and attach it to the ebpf program created above.
+			u, err := ex.Uprobe(tt.sym, p, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Trigger ebpf program call.
+			trigger := func(t *testing.T) {
+				if err := exec.Command(tt.elf, tt.args...).Run(); err != nil {
+					t.Fatal(err)
+				}
+			}
+			trigger(t)
+
+			// Assert that the value at index 0 has been updated to 1.
+			assertMapValue(t, m, 0, 1)
+
+			// Detach the Uprobe.
+			if err := u.Close(); err != nil {
+				t.Fatal(err)
+			}
+
+			// Reset map value to 0 at index 0.
+			if err := m.Update(uint32(0), uint32(0), ebpf.UpdateExist); err != nil {
+				t.Fatal(err)
+			}
+
+			// Retrigger the ebpf program call.
+			trigger(t)
+
+			// Assert that this time the value has not been updated.
+			assertMapValue(t, m, 0, 0)
+		})
 	}
-
-	// Trigger ebpf program call.
-	trigger := func(t *testing.T) {
-		if err := exec.Command("/bin/bash", "--help").Run(); err != nil {
-			t.Fatal(err)
-		}
-	}
-	trigger(t)
-
-	// Assert that the value at index 0 has been updated to 1.
-	assertMapValue(t, m, 0, 1)
-
-	// Detach the Uprobe.
-	if err := u.Close(); err != nil {
-		t.Fatal(err)
-	}
-
-	// Reset map value to 0 at index 0.
-	if err := m.Update(uint32(0), uint32(0), ebpf.UpdateExist); err != nil {
-		t.Fatal(err)
-	}
-
-	// Retrigger the ebpf program call.
-	trigger(t)
-
-	// Assert that this time the value has not been updated.
-	assertMapValue(t, m, 0, 0)
 }
 
 func TestUprobeProgramWrongPID(t *testing.T) {


### PR DESCRIPTION
Context: https://cilium.slack.com/archives/CKC55JL8L/p1629493947056900

I could reproduce the problem, after applying these changes (https://github.com/iovisor/bcc/blob/master/libbpf-tools/uprobe_helpers.c#L268, https://github.com/iovisor/bcc/pull/3519/commits/af3da2370e656e22383dc2f10aa6b1da7637d0ea), it works for me locally.
