### PR TITLE
update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,7 @@ The library is maintained by [Cloudflare](https://www.cloudflare.com) and
 [join](https://ebpf.io/slack) the
 [#ebpf-go](https://cilium.slack.com/messages/ebpf-go) channel on Slack.
 
-## Current status
-
-The package is production ready, but **the API is explicitly unstable right
-now**. Expect to update your code if you want to follow along.
+See [ebpf.io](https://ebpf.io) for other projects from the eBPF ecosystem.
 
 ## Getting Started
 
@@ -37,17 +34,7 @@ eBPF and the library, and help shape the future of the project.
 
 * A version of Go that is [supported by
   upstream](https://golang.org/doc/devel/release.html#policy)
-* Linux 4.9, 4.19 or 5.4 (versions in-between should work, but are not tested)
-
-## Useful resources
-
-* [eBPF.io](https://ebpf.io) (recommended)
-* [Cilium eBPF documentation](https://docs.cilium.io/en/latest/bpf/#bpf-guide)
-  (recommended)
-* [Linux documentation on
-  BPF](https://www.kernel.org/doc/html/latest/networking/filter.html)
-* [eBPF features by Linux
-  version](https://github.com/iovisor/bcc/blob/master/docs/kernel-versions.md)
+* Linux >= 4.9. CI is run against LTS releases.
 
 ## Regenerating Testdata
 


### PR DESCRIPTION
Remove the scary warning about API instability. In general we're conservative with changes and we're still on v0 anyways. Also cut down on related links, instead point users to ebpf.io.