### PR TITLE
examples: adapt uretprobe example to the new library version

### DIFF
--- a/examples/uretprobe/main.go
+++ b/examples/uretprobe/main.go
@@ -66,7 +66,7 @@ func main() {
 
 	// Open a Uretprobe at the exit point of the symbol and attach
 	// the pre-compiled eBPF program to it.
-	up, err := ex.Uretprobe(symbol, objs.UretprobeBashReadline)
+	up, err := ex.Uretprobe(symbol, objs.UretprobeBashReadline, nil)
 	if err != nil {
 		log.Fatalf("creating uretprobe: %s", err)
 	}


### PR DESCRIPTION
```
# github.com/cilium/ebpf/examples/uretprobe
uretprobe/main.go:69:25: not enough arguments in call to ex.Uretprobe
	have (string, *ebpf.Program)
	want (string, *ebpf.Program, *link.UprobeOptions)
```
