### PR TITLE
Utility function to remove memlock rlimit

### DIFF
--- a/internal/testutils/rlimit.go
+++ b/internal/testutils/rlimit.go
@@ -10,11 +10,7 @@ import (
 func init() {
 	// Increase the memlock for all tests unconditionally. It's a great source of
 	// weird bugs, since different distros have different default limits.
-	err := unix.Setrlimit(unix.RLIMIT_MEMLOCK, &unix.Rlimit{
-		Cur: unix.RLIM_INFINITY,
-		Max: unix.RLIM_INFINITY,
-	})
-	if err != nil {
+	if _, err := unix.RemoveMemlockRlimit(); err != nil {
 		fmt.Fprintln(os.Stderr, "WARNING: Failed to adjust rlimit, tests may fail")
 	}
 }

--- a/internal/unix/types_other.go
+++ b/internal/unix/types_other.go
@@ -88,11 +88,6 @@ type Rlimit struct {
 	Max uint64
 }
 
-// Setrlimit is a wrapper
-func Setrlimit(resource int, rlim *Rlimit) (err error) {
-	return errNonLinux
-}
-
 // Syscall is a wrapper
 func Syscall(trap, a1, a2, a3 uintptr) (r1, r2 uintptr, err syscall.Errno) {
 	return 0, 0, syscall.Errno(1)
@@ -262,4 +257,8 @@ func Renameat2(olddirfd int, oldpath string, newdirfd int, newpath string, flags
 
 func KernelRelease() (string, error) {
 	return "", errNonLinux
+}
+
+func RemoveMemlockRlimit() (func() error, error) {
+	return nil, errNonLinux
 }

--- a/map.go
+++ b/map.go
@@ -197,7 +197,7 @@ func NewMap(spec *MapSpec) (*Map, error) {
 //
 // The caller is responsible for ensuring the process' rlimit is set
 // sufficiently high for locking memory during map creation. This can be done
-// by calling unix.Setrlimit with unix.RLIMIT_MEMLOCK prior to calling NewMapWithOptions.
+// by calling ebpf.RemoveMemlockRlimit() prior to calling NewMapWithOptions.
 //
 // May return an error wrapping ErrMapIncompatible.
 func NewMapWithOptions(spec *MapSpec, opts MapOptions) (*Map, error) {

--- a/syscalls.go
+++ b/syscalls.go
@@ -17,6 +17,16 @@ import (
 // Deprecated: use os.ErrNotExist instead.
 var ErrNotExist = os.ErrNotExist
 
+// RemoveMemlockRlimit removes the limit on the amount of memory the current
+// process can lock into RAM. Returns a function that restores the limit to
+// its previous value.
+//
+// This is not required to load eBPF resources on kernel versions 5.11+
+// due to the introduction of cgroup-based memory accounting.
+func RemoveMemlockRlimit() (func() error, error) {
+	return unix.RemoveMemlockRlimit()
+}
+
 // invalidBPFObjNameChar returns true if char may not appear in
 // a BPF object name.
 func invalidBPFObjNameChar(char rune) bool {


### PR DESCRIPTION
This should implement the suggestion in https://github.com/cilium/ebpf/issues/290 if I understood it correctly.

Wasn't sure what package this would best live in, let me know if there's a better location/name.

Going to open another PR to update the examples once (if) this gets merged.