### PR TITLE
program: don't retrieve map ids by default

### DIFF
--- a/internal/testutils/feature.go
+++ b/internal/testutils/feature.go
@@ -7,7 +7,7 @@ import (
 	"github.com/cilium/ebpf/internal"
 )
 
-func mustKernelVersion() internal.Version {
+func MustKernelVersion() internal.Version {
 	v, err := internal.KernelVersion()
 	if err != nil {
 		panic(err)
@@ -47,7 +47,7 @@ func checkKernelVersion(tb testing.TB, ufe *internal.UnsupportedFeatureError) {
 		return
 	}
 
-	kernelVersion := mustKernelVersion()
+	kernelVersion := MustKernelVersion()
 	if ufe.MinimumVersion.Less(kernelVersion) {
 		tb.Helper()
 		tb.Fatalf("Feature '%s' isn't supported even though kernel %s is newer than %s",
@@ -63,7 +63,7 @@ func SkipOnOldKernel(tb testing.TB, minVersion, feature string) {
 		tb.Fatalf("Invalid version %s: %s", minVersion, err)
 	}
 
-	if mustKernelVersion().Less(minv) {
+	if MustKernelVersion().Less(minv) {
 		tb.Skipf("Test requires at least kernel %s (due to missing %s)", minv, feature)
 	}
 }

--- a/syscalls.go
+++ b/syscalls.go
@@ -84,7 +84,7 @@ type bpfProgInfo struct {
 	xlated_prog_insns        internal.Pointer
 	load_time                uint64 // since 4.15 cb4d2b3f03d8
 	created_by_uid           uint32
-	nr_map_ids               uint32
+	nr_map_ids               uint32 // since 4.15 cb4d2b3f03d8
 	map_ids                  internal.Pointer
 	name                     internal.BPFObjName // since 4.15 067cae47771c
 	ifindex                  uint32


### PR DESCRIPTION
nr_map_ids was added to struct bpf_prog_info in v4.15. If we
specify a non-zero value for the field in kernels < v4.15 we'll get
an EINVAL from the syscall. This isn't covered by our testsuite since
we don't test against such a kernel, so strictly speaking we don't
have to support this. As per Hyrum's law it's probably better to
go the extra mile however.