### PR TITLE
perf: deprecate IsClosed

### DIFF
--- a/perf/reader.go
+++ b/perf/reader.go
@@ -15,7 +15,7 @@ import (
 )
 
 var (
-	errClosed = errors.New("perf reader was closed")
+	ErrClosed = errors.New("perf reader was closed")
 	errEOR    = errors.New("end of ring")
 )
 
@@ -322,7 +322,7 @@ func (pr *Reader) Read() (Record, error) {
 	defer pr.mu.Unlock()
 
 	if pr.epollFd == -1 {
-		return Record{}, errClosed
+		return Record{}, fmt.Errorf("%w", ErrClosed)
 	}
 
 	for {
@@ -339,7 +339,7 @@ func (pr *Reader) Read() (Record, error) {
 
 			for _, event := range pr.epollEvents[:nEvents] {
 				if int(event.Fd) == pr.closeFd {
-					return Record{}, errClosed
+					return Record{}, fmt.Errorf("%w", ErrClosed)
 				}
 
 				ring := pr.rings[cpuForEvent(&event)]
@@ -378,7 +378,7 @@ func (pr *Reader) Pause() error {
 	defer pr.pauseMu.Unlock()
 
 	if pr.pauseFds == nil {
-		return errClosed
+		return fmt.Errorf("%w", ErrClosed)
 	}
 
 	for i := range pr.pauseFds {
@@ -398,7 +398,7 @@ func (pr *Reader) Resume() error {
 	defer pr.pauseMu.Unlock()
 
 	if pr.pauseFds == nil {
-		return errClosed
+		return fmt.Errorf("%w", ErrClosed)
 	}
 
 	for i, fd := range pr.pauseFds {
@@ -420,8 +420,10 @@ type temporaryError interface {
 
 // IsClosed returns true if the error occurred because
 // a Reader was closed.
+//
+// Deprecated: use errors.Is(err, ErrClosed) instead.
 func IsClosed(err error) bool {
-	return errors.Is(err, errClosed)
+	return errors.Is(err, ErrClosed)
 }
 
 type unknownEventError struct {

--- a/perf/reader_test.go
+++ b/perf/reader_test.go
@@ -3,6 +3,7 @@ package perf
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"os"
 	"syscall"
@@ -14,6 +15,8 @@ import (
 	"github.com/cilium/ebpf/internal"
 	"github.com/cilium/ebpf/internal/testutils"
 	"github.com/cilium/ebpf/internal/unix"
+
+	qt "github.com/frankban/quicktest"
 )
 
 var (
@@ -371,12 +374,13 @@ func TestPause(t *testing.T) {
 	}
 
 	// Pause/Resume after close should be no-op.
-	if err = rd.Pause(); err != errClosed {
-		t.Fatalf("Unexpected error: %s", err)
-	}
-	if err = rd.Resume(); err != errClosed {
-		t.Fatalf("Unexpected error: %s", err)
-	}
+	err = rd.Pause()
+	qt.Assert(t, err, qt.Not(qt.Equals), ErrClosed, qt.Commentf("returns unwrapped ErrClosed"))
+	qt.Assert(t, errors.Is(err, ErrClosed), qt.IsTrue, qt.Commentf("doesn't wrap ErrClosed"))
+
+	err = rd.Resume()
+	qt.Assert(t, err, qt.Not(qt.Equals), ErrClosed, qt.Commentf("returns unwrapped ErrClosed"))
+	qt.Assert(t, errors.Is(err, ErrClosed), qt.IsTrue, qt.Commentf("doesn't wrap ErrClosed"))
 }
 
 func BenchmarkReader(b *testing.B) {


### PR DESCRIPTION
Encourage the use of errors.Is instead.