### PR TITLE
Update Slack join and channel link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,8 +6,8 @@ are welcome. Please take a look at [the architecture](ARCHITECTURE.md) to get
 a better understanding for the high-level goals.
 
 New features must be accompanied by tests. Before starting work on any large
-feature, please [join](https://cilium.herokuapp.com/) the
-[#libbpf-go](https://cilium.slack.com/messages/libbpf-go) channel on Slack to
+feature, please [join](https://ebpf.io/slack) the
+[#ebpf-go](https://cilium.slack.com/messages/ebpf-go) channel on Slack to
 discuss the design first.
 
 When submitting pull requests, consider writing details about what problem you


### PR DESCRIPTION
Slack channel was renamed from `#libbpf-go` to `#ebpf-go` on August 18, 2021 and the [README.md](https://github.com/cilium/ebpf/blob/master/README.md) was updated in 633cfda797d5f40410e02f072fdf772b397bb68d.

[CONTRIBUTING.md](https://github.com/cilium/ebpf/blob/master/CONTRIBUTING.md) was left untouched, so this PR updates the links in the contributing guidelines too.