### PR TITLE
internal/unix: implement RemoveMemlockRlimit() using prlimit(2)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,5 @@ go 1.16
 require (
 	github.com/frankban/quicktest v1.11.3
 	github.com/google/go-cmp v0.5.4
-	golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c
+	golang.org/x/sys v0.0.0-20210906170528-6f6e22806c34
 )

--- a/go.sum
+++ b/go.sum
@@ -7,7 +7,7 @@ github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfn
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c h1:VwygUrnw9jn88c4u8GD3rZQbqrP/tgas88tPUbBxQrk=
-golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210906170528-6f6e22806c34 h1:GkvMjFtXUmahfDtashnc1mnrCtuBVcwse5QV2lUk/tI=
+golang.org/x/sys v0.0.0-20210906170528-6f6e22806c34/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/internal/unix/types_linux.go
+++ b/internal/unix/types_linux.go
@@ -202,21 +202,17 @@ func KernelRelease() (string, error) {
 }
 
 func RemoveMemlockRlimit() (func() error, error) {
-	oldLimit := new(Rlimit)
-	if err := linux.Getrlimit(RLIMIT_MEMLOCK, oldLimit); err != nil {
-		return nil, fmt.Errorf("failed to get memlock rlimit: %w", err)
-	}
+	var oldLimit Rlimit
+	newLimit := Rlimit{Cur: RLIM_INFINITY, Max: RLIM_INFINITY}
 
-	if err := linux.Setrlimit(RLIMIT_MEMLOCK, &Rlimit{
-		Cur: RLIM_INFINITY,
-		Max: RLIM_INFINITY,
-	}); err != nil {
+	// pid 0 affects the current process.
+	if err := linux.Prlimit(0, RLIMIT_MEMLOCK, &newLimit, &oldLimit); err != nil {
 		return nil, fmt.Errorf("failed to set memlock rlimit: %w", err)
 	}
 
 	return func() error {
-		if err := linux.Setrlimit(RLIMIT_MEMLOCK, oldLimit); err != nil {
-			return fmt.Errorf("failed to reset memlock rlimit: %w", err)
+		if err := linux.Setrlimit(RLIMIT_MEMLOCK, &oldLimit); err != nil {
+			return fmt.Errorf("failed to revert memlock rlimit: %w", err)
 		}
 		return nil
 	}, nil


### PR DESCRIPTION
Closes https://github.com/cilium/ebpf/issues/407

This returns the original rlimit values overwritten during the syscall, making it safer to call concurrently.