### PR TITLE
CI: turn off verbose tests

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -4,7 +4,7 @@ name: CI Build
 agent:
   machine:
     type: e1-standard-2
-    os_image: ubuntu1804
+    os_image: ubuntu2004
 
 global_job_config:
   secrets:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -26,8 +26,10 @@ blocks:
           - sudo pip3 install https://github.com/amluto/virtme/archive/beb85146cd91de37ae455eccb6ab67c393e6e290.zip
           - sudo apt-get update
           - sudo apt-get install -y --no-install-recommends qemu-system-x86 clang-9
+          - sudo dmesg -C
       epilogue:
         commands:
+          - sudo dmesg
           - cache store
       env_vars:
         - name: TMPDIR

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -42,9 +42,9 @@ blocks:
       - name: Build
         commands:
           - pushd ./examples; go build -v -o "$(mktemp -d)" ./...; popd
-          - GOOS=darwin go build ./... && for p in $(go list ./...) ; do GOOS=darwin go test -c $p ; done
-          - GOARCH=arm GOARM=6 go build ./... && for p in $(go list ./...) ; do GOARCH=arm GOARM=6 go test -c $p ; done
-          - GOARCH=arm64 go build ./... && for p in $(go list ./...) ; do GOARCH=arm64 go test -c $p ; done
+          - ( export GOOS=darwin; go build ./... && for p in $(go list ./...) ; do go test -c $p || exit ; done )
+          - ( export GOARCH=arm GOARM=6; go build ./... && for p in $(go list ./...) ; do go test -c $p || exit ; done )
+          - ( export GOARCH=arm64; go build ./... && for p in $(go list ./...) ; do go test -c $p || exit ; done )
       - name: Lint
         commands:
           - golangci-lint run

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -10,6 +10,10 @@ global_job_config:
   secrets:
     - name: Coveralls
 
+auto_cancel:
+  running:
+    when: "branch != 'master'"
+
 blocks:
   - name: Run tests
     task:

--- a/asm/instruction_test.go
+++ b/asm/instruction_test.go
@@ -29,7 +29,7 @@ func TestRead64bitImmediate(t *testing.T) {
 	}
 
 	if c := ins.Constant; c != math.MinInt32-1 {
-		t.Errorf("Expected immediate to be %v, got %v", math.MinInt32-1, c)
+		t.Errorf("Expected immediate to be %v, got %v", int64(math.MinInt32)-1, c)
 	}
 }
 

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -108,7 +108,7 @@ else
   echo "No selftests found, disabling"
 fi
 
-args=(-v -short -coverpkg=./... -coverprofile=coverage.out -count 1 ./...)
+args=(-short -coverpkg=./... -coverprofile=coverage.out -count 1 ./...)
 if (( $# > 0 )); then
   args=("$@")
 fi


### PR DESCRIPTION
We're at a stage where it's difficult to figure out what went wrong on CI,
since there are so many tests. Turn off verbose output for now.