### PR TITLE
map: detect map Name and PinPath separately

### DIFF
--- a/map.go
+++ b/map.go
@@ -226,8 +226,12 @@ func newMapWithOptions(spec *MapSpec, opts MapOptions, handles *handleCache) (_ 
 
 	switch spec.Pinning {
 	case PinByName:
-		if spec.Name == "" || opts.PinPath == "" {
-			return nil, fmt.Errorf("pin by name: missing Name or PinPath")
+		if spec.Name == "" {
+			return nil, fmt.Errorf("pin by name: missing Name")
+		}
+
+		if opts.PinPath == "" {
+			return nil, fmt.Errorf("pin by name: missing MapOptions.PinPath")
 		}
 
 		path := filepath.Join(opts.PinPath, spec.Name)


### PR DESCRIPTION
libbpf uses `/sys/fs/bpf` as the default pinpath if the user doesn't specify
one. We'd better keep consistent with it.

```
static int build_map_pin_path(struct bpf_map *map, const char *path)
{
...
	if (!path)
		path = "/sys/fs/bpf";
...
}
```

Signed-off-by: Hao Lee <haolee@didiglobal.com>