### PR TITLE
Avoid escaping of bytes.Reader in unmarshalBytes()

### DIFF
--- a/marshalers.go
+++ b/marshalers.go
@@ -81,6 +81,11 @@ func makeBuffer(dst interface{}, length int) (internal.Pointer, []byte) {
 	return internal.NewSlicePointer(buf), buf
 }
 
+func noescape(p unsafe.Pointer) unsafe.Pointer {
+	x := uintptr(p)
+	return unsafe.Pointer(x ^ 0) // nolint: staticcheck
+}
+
 // unmarshalBytes converts a byte buffer into an arbitrary value.
 //
 // Prefer using Map.unmarshalKey and Map.unmarshalValue if possible, since
@@ -114,7 +119,8 @@ func unmarshalBytes(data interface{}, buf []byte) error {
 	case []byte:
 		return errors.New("require pointer to []byte")
 	default:
-		rd := bytes.NewReader(buf)
+		// Without noescape(), rd escapes to the heap for no good reason.
+		rd := (*bytes.Reader)(noescape(unsafe.Pointer(bytes.NewReader(buf))))
 		if err := binary.Read(rd, internal.NativeEndian, value); err != nil {
 			return fmt.Errorf("decoding %T: %v", value, err)
 		}


### PR DESCRIPTION
This change reduced the share of allocations in an application from 22% to 7.6%.

## Before (22%)
```
Total: 36070845
ROUTINE ======================== github.com/cilium/ebpf.unmarshalBytes in /home/tim/go/pkg/mod/github.com/cilium/ebpf@v0.3.1-0.20210223102256-b3a4c97df850/marshalers.go
         0    7941062 (flat, cum) 22.02% of Total
         .          .    107:   case string:
         .          .    108:           return errors.New("require pointer to string")
         .          .    109:   case []byte:
         .          .    110:           return errors.New("require pointer to []byte")
         .          .    111:   default:
         .    5286813    112:           rd := bytes.NewReader(buf)
         .    2654249    113:           if err := binary.Read(rd, internal.NativeEndian, value); err != nil {
         .          .    114:                   return fmt.Errorf("decoding %T: %v", value, err)
         .          .    115:           }
         .          .    116:           return nil
         .          .    117:   }
         .          .    118:}
```

## After (7.6%)
```
Total: 23284313
ROUTINE ======================== github.com/cilium/ebpf.unmarshalBytes in /home/tim/src/ebpf/marshalers.go
         0    1769499 (flat, cum)  7.60% of Total
         .          .    119:   case []byte:
         .          .    120:           return errors.New("require pointer to []byte")
         .          .    121:   default:
         .          .    122:           // Without noescape(), rd escapes to the heap for no good reason.
         .          .    123:           rd := (*bytes.Reader)(noescape(unsafe.Pointer(bytes.NewReader(buf))))
         .    1769499    124:           if err := binary.Read(rd, internal.NativeEndian, value); err != nil {
         .          .    125:                   return fmt.Errorf("decoding %T: %v", value, err)
         .          .    126:           }
         .          .    127:           return nil
         .          .    128:   }
         .          .    129:}
```

The duration of the runs were different, so the total number of allocations is different. But the workload was pretty much the same, so comparing the % value is reasonable.

The `noescape()` function is ugly and it's use needs comments.
And possibly there is a more convenient way to convince the compiler to not escape rd !? Any suggestions ?
