### PR TITLE
CI: try to reduce flakiness

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -5,7 +5,7 @@
 #     Run all tests on a 5.4 kernel
 #     $ ./run-tests.sh 5.4
 #     Run a subset of tests:
-#     $ ./run-tests.sh 5.4 go test ./link
+#     $ ./run-tests.sh 5.4 ./link
 
 set -euo pipefail
 
@@ -48,15 +48,17 @@ if [[ "${1:-}" = "--exec-vm" ]]; then
     rm "${output}/fake-stdin"
   fi
 
-  $sudo virtme-run --kimg "${input}/bzImage" --memory 768M --pwd \
-  --rwdir="${testdir}=${testdir}" \
-  --rodir=/run/input="${input}" \
-  --rwdir=/run/output="${output}" \
-  --script-sh "PATH=\"$PATH\" \"$script\" --exec-test $cmd" \
-  --qemu-opts -smp 2 # need at least two CPUs for some tests
+  if ! $sudo virtme-run --kimg "${input}/bzImage" --memory 768M --pwd \
+    --rwdir="${testdir}=${testdir}" \
+    --rodir=/run/input="${input}" \
+    --rwdir=/run/output="${output}" \
+    --script-sh "PATH=\"$PATH\" \"$script\" --exec-test $cmd" \
+    --qemu-opts -smp 2; then # need at least two CPUs for some tests
+    exit 23
+  fi
 
   if [[ ! -e "${output}/success" ]]; then
-    exit 1
+    exit 42
   fi
 
   $sudo rm -r "$output"
@@ -74,7 +76,7 @@ elif [[ "${1:-}" = "--exec-test" ]]; then
   dmesg -C
   if ! "$@"; then
     dmesg
-    exit 1
+    exit 1 # this return code is "swallowed" by qemu
   fi
   touch "/run/output/success"
   exit 0

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -53,7 +53,7 @@ if [[ "${1:-}" = "--exec-vm" ]]; then
     --rodir=/run/input="${input}" \
     --rwdir=/run/output="${output}" \
     --script-sh "PATH=\"$PATH\" \"$script\" --exec-test $cmd" \
-    --qemu-opts -smp 2; then # need at least two CPUs for some tests
+    --kopt possible_cpus=2; then # need at least two CPUs for some tests
     exit 23
   fi
 


### PR DESCRIPTION
CI: run qemu with single CPU
    
    Investigating #422 it seems like the sporadic crashed we see might be
    related to giving qemu multiple CPUs. The only reason we have two vCPU
    is that TestPerCPUMarshaling needs /sys/devices/system/cpu/possible to
    have be at least two.
    
    Instead of adding vCPU we can use the possible_cpus command line argument.
    
    Updates #422

CI: use distinct exit codes
    
    Use distinct exit codes in run-tests.sh to make it easier to discern
    which command failed.

Switching to a single vCPU has also made the CI run faster!