### PR TITLE
Fix btf.FindType to avoid copy

### DIFF
--- a/elf_reader.go
+++ b/elf_reader.go
@@ -554,7 +554,7 @@ func (ec *elfCode) loadBTFMaps(maps map[string]*MapSpec) error {
 		}
 
 		// Each section must appear as a DataSec in the ELF's BTF blob.
-		var ds btf.Datasec
+		var ds *btf.Datasec
 		if err := ec.btf.FindType(sec.Name, &ds); err != nil {
 			return fmt.Errorf("cannot find section '%s' in BTF: %w", sec.Name, err)
 		}
@@ -926,7 +926,7 @@ func (ec *elfCode) loadDataSections(maps map[string]*MapSpec) error {
 			return errors.New("data sections require BTF, make sure all consts are marked as static")
 		}
 
-		var datasec btf.Datasec
+		var datasec *btf.Datasec
 		if err := ec.btf.FindType(sec.Name, &datasec); err != nil {
 			return fmt.Errorf("data section %s: can't get BTF: %w", sec.Name, err)
 		}
@@ -947,7 +947,7 @@ func (ec *elfCode) loadDataSections(maps map[string]*MapSpec) error {
 			ValueSize:  uint32(len(data)),
 			MaxEntries: 1,
 			Contents:   []MapKV{{uint32(0), data}},
-			BTF:        &btf.Map{Spec: ec.btf, Key: &btf.Void{}, Value: &datasec},
+			BTF:        &btf.Map{Spec: ec.btf, Key: &btf.Void{}, Value: datasec},
 		}
 
 		switch sec.Name {

--- a/internal/btf/btf.go
+++ b/internal/btf/btf.go
@@ -478,7 +478,7 @@ func (s *Spec) FindType(name string, typ interface{}) error {
 		return fmt.Errorf("%T is not a pointer", typ)
 	}
 
-	typPtr := reflect.Indirect(typValue)
+	typPtr := typValue.Elem()
 	if !typPtr.CanSet() {
 		return fmt.Errorf("%T cannot be set", typ)
 	}
@@ -510,7 +510,7 @@ func (s *Spec) FindType(name string, typ interface{}) error {
 		return fmt.Errorf("type %s: %w", name, ErrNotFound)
 	}
 
-	typPtr.Set(reflect.Indirect(reflect.ValueOf(candidate)).Addr())
+	typPtr.Set(reflect.ValueOf(candidate))
 
 	return nil
 }

--- a/internal/btf/btf_test.go
+++ b/internal/btf/btf_test.go
@@ -29,7 +29,7 @@ func TestParseVmlinux(t *testing.T) {
 		t.Fatal("Can't load BTF:", err)
 	}
 
-	var iphdr Struct
+	var iphdr *Struct
 	err = spec.FindType("iphdr", &iphdr)
 	if err != nil {
 		t.Fatalf("unable to find `iphdr` struct: %s", err)
@@ -100,17 +100,17 @@ func TestLoadSpecFromElf(t *testing.T) {
 			t.Error("Missing BTF for the socket section")
 		}
 
-		var bpfMapDef Struct
+		var bpfMapDef *Struct
 		if err := spec.FindType("bpf_map_def", &bpfMapDef); err != nil {
 			t.Error("Can't find bpf_map_def:", err)
 		}
 
-		var tmp Void
+		var tmp *Void
 		if err := spec.FindType("totally_bogus_type", &tmp); !errors.Is(err, ErrNotFound) {
 			t.Error("FindType doesn't return ErrNotFound:", err)
 		}
 
-		var fn Func
+		var fn *Func
 		if err := spec.FindType("global_fn", &fn); err != nil {
 			t.Error("Can't find global_fn():", err)
 		} else {
@@ -119,7 +119,7 @@ func TestLoadSpecFromElf(t *testing.T) {
 			}
 		}
 
-		var v Var
+		var v *Var
 		if err := spec.FindType("key3", &v); err != nil {
 			t.Error("Cant find key3:", err)
 		} else {
@@ -198,7 +198,7 @@ func ExampleSpec_FindType() {
 	spec := new(Spec)
 
 	// Declare a variable of the desired type
-	var foo Struct
+	var foo *Struct
 
 	if err := spec.FindType("foo", &foo); err != nil {
 		// There is no struct with name foo, or there

--- a/internal/btf/btf_test.go
+++ b/internal/btf/btf_test.go
@@ -31,12 +31,20 @@ func TestFindType(t *testing.T) {
 	}
 
 	// spec.FindType MUST fail if typ is not a non-nil **T, where T satisfies btf.Type.
+	i := 0
+	p := &i
 	for _, typ := range []interface{}{
 		nil,
 		Struct{},
 		&Struct{},
+		[]Struct{},
+		&[]Struct{},
+		map[int]Struct{},
+		&map[int]Struct{},
+		p,
+		&p,
 	} {
-		if err := spec.FindType("iphdr", nil); err == nil {
+		if err := spec.FindType("iphdr", typ); err == nil {
 			t.Fatalf("FindType does not fail with type %T", typ)
 		}
 	}

--- a/prog.go
+++ b/prog.go
@@ -720,24 +720,17 @@ func resolveBTFType(spec *btf.Spec, name string, progType ProgramType, attachTyp
 		a AttachType
 	}
 
-	var target btf.Type
 	var typeName, featureName string
 	switch (match{progType, attachType}) {
 	case match{LSM, AttachLSMMac}:
-		target = new(btf.Func)
 		typeName = "bpf_lsm_" + name
 		featureName = name + " LSM hook"
-
 	case match{Tracing, AttachTraceIter}:
-		target = new(btf.Func)
 		typeName = "bpf_iter_" + name
 		featureName = name + " iterator"
-
 	case match{Extension, AttachNone}:
-		target = new(btf.Func)
 		typeName = name
 		featureName = fmt.Sprintf("freplace %s", name)
-
 	default:
 		return nil, nil
 	}
@@ -750,7 +743,8 @@ func resolveBTFType(spec *btf.Spec, name string, progType ProgramType, attachTyp
 		}
 	}
 
-	err := spec.FindType(typeName, target)
+	var target *btf.Func
+	err := spec.FindType(typeName, &target)
 	if errors.Is(err, btf.ErrNotFound) {
 		return nil, &internal.UnsupportedFeatureError{
 			Name: featureName,


### PR DESCRIPTION
Fix `btf.FindType` to return a pointer to the matching BTF type.
This will allow to get exactly the same type (same address) for multiple calls requesting the same type name.

Fixes #416