### PR TITLE
link/uprobe: skip integration test when binaries are stripped

### DIFF
--- a/link/uprobe.go
+++ b/link/uprobe.go
@@ -25,6 +25,10 @@ var (
 		value uint64
 		err   error
 	}{}
+
+	// ErrNoSymbol indicates that the given symbol was not found
+	// in the ELF symbols table.
+	ErrNoSymbol = errors.New("not found")
 )
 
 // Executable defines an executable program on the filesystem.
@@ -144,7 +148,7 @@ func (ex *Executable) offset(symbol string) (uint64, error) {
 		}
 		return off, nil
 	}
-	return 0, fmt.Errorf("symbol %s not found", symbol)
+	return 0, fmt.Errorf("symbol %s: %w", symbol, ErrNoSymbol)
 }
 
 // Uprobe attaches the given eBPF program to a perf event that fires when the

--- a/link/uprobe_test.go
+++ b/link/uprobe_test.go
@@ -349,6 +349,12 @@ func TestUprobeProgramCall(t *testing.T) {
 			// Open Uprobe on the executable for the given symbol
 			// and attach it to the ebpf program created above.
 			u, err := ex.Uprobe(tt.sym, p, nil)
+			if errors.Is(err, ErrNoSymbol) {
+				// Assume bash::main and go::main.main always exists
+				// and skip the test if the symbol can't be found as
+				// certain OS (eg. Debian) strip binaries.
+				t.Skipf("executable %s appear to be stripped, skipping", tt.elf)
+			}
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
Context: https://cilium.slack.com/archives/C027KBX679U/p1631808389034700

The Go binary on Debian seems to be stripped:

```
SYMBOL TABLE:
no symbols
```

```
$ file /usr/lib/go-1.17/bin/go
/usr/lib/go-1.17/bin/go: ELF 64-bit LSB executable, ..., stripped
```

This PR is for skipping the test in such cases (assuming bash's `main` and Go's `main.main` always exists, it should be safe to do so)

cc @rockdaboot 