### PR TITLE
Fix missing close of fds from BPF{ProgLoad,MapCreate}

### DIFF
--- a/features/map.go
+++ b/features/map.go
@@ -139,7 +139,7 @@ func haveMapType(mt ebpf.MapType) error {
 		return err
 	}
 
-	_, err = internal.BPFMapCreate(createMapTypeAttr(mt))
+	fd, err := internal.BPFMapCreate(createMapTypeAttr(mt))
 
 	switch {
 	// For nested and storage map types we accept EBADF as indicator that these maps are supported
@@ -162,6 +162,9 @@ func haveMapType(mt ebpf.MapType) error {
 	// Wrap unexpected errors.
 	case err != nil:
 		err = fmt.Errorf("unexpected error during feature probe: %w", err)
+
+	default:
+		fd.Close()
 	}
 
 	mc.mapTypes[mt] = err

--- a/features/prog.go
+++ b/features/prog.go
@@ -123,7 +123,7 @@ func haveProgType(pt ebpf.ProgramType) error {
 		return fmt.Errorf("couldn't create the program load attribute: %w", err)
 	}
 
-	_, err = internal.BPFProgLoad(attr)
+	fd, err := internal.BPFProgLoad(attr)
 
 	switch {
 	// EINVAL occurs when attempting to create a program with an unknown type.
@@ -140,6 +140,9 @@ func haveProgType(pt ebpf.ProgramType) error {
 	// Wrap unexpected errors.
 	case err != nil:
 		err = fmt.Errorf("unexpected error during feature probe: %w", err)
+
+	default:
+		fd.Close()
 	}
 
 	pc.progTypes[pt] = err

--- a/prog.go
+++ b/prog.go
@@ -307,7 +307,10 @@ func newProgramWithOptions(spec *ProgramSpec, opts ProgramOptions, handles *hand
 		attr.LogSize = uint32(len(logBuf))
 		attr.LogBuf = internal.NewSlicePointer(logBuf)
 
-		_, logErr = internal.BPFProgLoad(attr)
+		fd, logErr = internal.BPFProgLoad(attr)
+		if logErr == nil {
+			fd.Close()
+		}
 	}
 
 	if errors.Is(logErr, unix.EPERM) && logBuf[0] == 0 {


### PR DESCRIPTION
Since it is possible to disable the GC, we cannot rely solely on the finalizers to close the file descriptors returned by BPFProgLoad or BPFMapCreate.
So, we always close them explicitly, if needed.

Fixes #373 