### PR TITLE
tree-wide: drop deprecated io/ioutil

### DIFF
--- a/asm/instruction_test.go
+++ b/asm/instruction_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math"
 	"testing"
 
@@ -55,7 +55,7 @@ func TestSignedJump(t *testing.T) {
 
 	insns[0].Offset = 1
 
-	err := insns.Marshal(ioutil.Discard, binary.LittleEndian)
+	err := insns.Marshal(io.Discard, binary.LittleEndian)
 	if err != nil {
 		t.Error("Can't marshal signed jump:", err)
 	}

--- a/cmd/bpf2go/compile_test.go
+++ b/cmd/bpf2go/compile_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -68,12 +67,12 @@ func TestReproducibleCompile(t *testing.T) {
 		t.Fatal("Can't compile:", err)
 	}
 
-	aBytes, err := ioutil.ReadFile(filepath.Join(dir, "a.o"))
+	aBytes, err := os.ReadFile(filepath.Join(dir, "a.o"))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	bBytes, err := ioutil.ReadFile(filepath.Join(dir, "b.o"))
+	bBytes, err := os.ReadFile(filepath.Join(dir, "b.o"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -151,14 +150,14 @@ nothing:
 func mustWriteTempFile(t *testing.T, name, contents string) string {
 	t.Helper()
 
-	tmp, err := ioutil.TempDir("", "bpf2go")
+	tmp, err := os.MkdirTemp("", "bpf2go")
 	if err != nil {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { os.RemoveAll(tmp) })
 
 	tmpFile := filepath.Join(tmp, name)
-	if err := ioutil.WriteFile(tmpFile, []byte(contents), 0660); err != nil {
+	if err := os.WriteFile(tmpFile, []byte(contents), 0660); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cmd/bpf2go/main.go
+++ b/cmd/bpf2go/main.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"go/token"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -289,7 +288,7 @@ func (b2g *bpf2go) convert(tgt target, arches []string) (err error) {
 	}
 
 	depFileName := goFileName + ".d"
-	if err := ioutil.WriteFile(depFileName, depFile, 0666); err != nil {
+	if err := os.WriteFile(depFileName, depFile, 0666); err != nil {
 		return fmt.Errorf("can't write dependency file: %s", err)
 	}
 

--- a/cmd/bpf2go/main_test.go
+++ b/cmd/bpf2go/main_test.go
@@ -3,7 +3,7 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -31,7 +31,7 @@ func TestRun(t *testing.T) {
 		t.Fatal("No go.mod file in", modRoot)
 	}
 
-	tmpDir, err := ioutil.TempDir("", "bpf2go-module-*")
+	tmpDir, err := os.MkdirTemp("", "bpf2go-module-*")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -60,7 +60,7 @@ func TestRun(t *testing.T) {
 		fmt.Sprintf("-replace=%s=%s", ebpfModule, modRoot),
 	)
 
-	err = run(ioutil.Discard, "foo", tmpDir, []string{
+	err = run(io.Discard, "foo", tmpDir, []string{
 		"-cc", "clang-9",
 		"bar",
 		filepath.Join(dir, "test.c"),
@@ -198,7 +198,7 @@ func TestConvertGOARCH(t *testing.T) {
 
 	b2g := bpf2go{
 		pkg:        "test",
-		stdout:     ioutil.Discard,
+		stdout:     io.Discard,
 		ident:      "test",
 		cc:         "clang-9",
 		sourceFile: tmp + "/test.c",

--- a/cmd/bpf2go/output.go
+++ b/cmd/bpf2go/output.go
@@ -8,7 +8,7 @@ import (
 	"go/scanner"
 	"go/token"
 	"io"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"text/template"
@@ -220,7 +220,7 @@ type writeArgs struct {
 }
 
 func writeCommon(args writeArgs) error {
-	obj, err := ioutil.ReadFile(args.obj)
+	obj, err := os.ReadFile(args.obj)
 	if err != nil {
 		return fmt.Errorf("read object file contents: %s", err)
 	}

--- a/elf_reader.go
+++ b/elf_reader.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"os"
 	"strings"
@@ -521,7 +520,7 @@ func (ec *elfCode) loadMaps(maps map[string]*MapSpec) error {
 				return fmt.Errorf("map %s: missing flags", mapName)
 			}
 
-			extra, err := ioutil.ReadAll(lr)
+			extra, err := io.ReadAll(lr)
 			if err != nil {
 				return fmt.Errorf("map %s: reading map tail: %w", mapName, err)
 			}
@@ -606,7 +605,7 @@ func (ec *elfCode) loadBTFMaps(maps map[string]*MapSpec) error {
 
 		// Drain the ELF section reader to make sure all bytes are accounted for
 		// with BTF metadata.
-		i, err := io.Copy(ioutil.Discard, rs)
+		i, err := io.Copy(io.Discard, rs)
 		if err != nil {
 			return fmt.Errorf("section %v: unexpected error reading remainder of ELF section: %w", sec.Name, err)
 		}

--- a/internal/btf/btf.go
+++ b/internal/btf/btf.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"os"
 	"reflect"
@@ -242,7 +241,7 @@ func loadKernelSpec() (*Spec, error) {
 }
 
 func parseBTF(btf io.Reader, bo binary.ByteOrder) ([]rawType, stringTable, error) {
-	rawBTF, err := ioutil.ReadAll(btf)
+	rawBTF, err := io.ReadAll(btf)
 	if err != nil {
 		return nil, nil, fmt.Errorf("can't read BTF: %v", err)
 	}

--- a/internal/btf/ext_info.go
+++ b/internal/btf/ext_info.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 
 	"github.com/cilium/ebpf/asm"
 	"github.com/cilium/ebpf/internal"
@@ -64,7 +63,7 @@ func parseExtInfos(r io.ReadSeeker, bo binary.ByteOrder, strings stringTable) (f
 
 	// Of course, the .BTF.ext header has different semantics than the
 	// .BTF ext header. We need to ignore non-null values.
-	_, err = io.CopyN(ioutil.Discard, r, remainder)
+	_, err = io.CopyN(io.Discard, r, remainder)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("header padding: %v", err)
 	}

--- a/internal/btf/strings.go
+++ b/internal/btf/strings.go
@@ -5,13 +5,12 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 )
 
 type stringTable []byte
 
 func readStringTable(r io.Reader) (stringTable, error) {
-	contents, err := ioutil.ReadAll(r)
+	contents, err := io.ReadAll(r)
 	if err != nil {
 		return nil, fmt.Errorf("can't read string table: %v", err)
 	}

--- a/internal/cpu.go
+++ b/internal/cpu.go
@@ -2,7 +2,7 @@ package internal
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"sync"
 )
@@ -24,7 +24,7 @@ func PossibleCPUs() (int, error) {
 }
 
 func parseCPUsFromFile(path string) (int, error) {
-	spec, err := ioutil.ReadFile(path)
+	spec, err := os.ReadFile(path)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/testutils/bpffs.go
+++ b/internal/testutils/bpffs.go
@@ -1,7 +1,6 @@
 package testutils
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 )
@@ -12,7 +11,7 @@ import (
 func TempBPFFS(tb testing.TB) string {
 	tb.Helper()
 
-	tmp, err := ioutil.TempDir("/sys/fs/bpf", "ebpf-test")
+	tmp, err := os.MkdirTemp("/sys/fs/bpf", "ebpf-test")
 	if err != nil {
 		tb.Fatal("Create temporary directory on BPFFS:", err)
 	}

--- a/internal/testutils/cgroup.go
+++ b/internal/testutils/cgroup.go
@@ -2,7 +2,6 @@ package testutils
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"strings"
 	"sync"
@@ -19,7 +18,7 @@ var cgroup2 = struct {
 
 func cgroup2Path() (string, error) {
 	cgroup2.once.Do(func() {
-		mounts, err := ioutil.ReadFile("/proc/mounts")
+		mounts, err := os.ReadFile("/proc/mounts")
 		if err != nil {
 			cgroup2.err = err
 			return
@@ -53,7 +52,7 @@ func CreateCgroup(tb testing.TB) *os.File {
 		tb.Fatal("Can't locate cgroup2 mount:", err)
 	}
 
-	cgdir, err := ioutil.TempDir(cg2, "ebpf-link")
+	cgdir, err := os.MkdirTemp(cg2, "ebpf-link")
 	if err != nil {
 		tb.Fatal("Can't create cgroupv2:", err)
 	}

--- a/internal/version.go
+++ b/internal/version.go
@@ -2,7 +2,7 @@ package internal
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"regexp"
 	"sync"
 
@@ -109,7 +109,7 @@ func detectKernelVersion() (Version, error) {
 	// Example format: Ubuntu 4.15.0-91.92-generic 4.15.18
 	// This method exists in the kernel itself, see d18acd15c
 	// ("perf tools: Fix kernel version error in ubuntu").
-	if pvs, err := ioutil.ReadFile("/proc/version_signature"); err == nil {
+	if pvs, err := os.ReadFile("/proc/version_signature"); err == nil {
 		// If /proc/version_signature exists, failing to parse it is an error.
 		// It only exists on Ubuntu, where the real patch level is not obtainable
 		// through any other method.

--- a/link/iter_test.go
+++ b/link/iter_test.go
@@ -1,7 +1,7 @@
 package link
 
 import (
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/cilium/ebpf"
@@ -39,7 +39,7 @@ func TestIter(t *testing.T) {
 	}
 	defer file.Close()
 
-	contents, err := ioutil.ReadAll(file)
+	contents, err := io.ReadAll(file)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -99,7 +99,7 @@ func TestIterMapElements(t *testing.T) {
 	}
 	defer file.Close()
 
-	contents, err := ioutil.ReadAll(file)
+	contents, err := io.ReadAll(file)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/link/kprobe.go
+++ b/link/kprobe.go
@@ -5,7 +5,6 @@ import (
 	"crypto/rand"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -420,7 +419,7 @@ func probePrefix(ret bool) string {
 func determineRetprobeBit(typ probeType) (uint64, error) {
 	p := filepath.Join("/sys/bus/event_source/devices/", typ.String(), "/format/retprobe")
 
-	data, err := ioutil.ReadFile(p)
+	data, err := os.ReadFile(p)
 	if err != nil {
 		return 0, err
 	}

--- a/link/link_test.go
+++ b/link/link_test.go
@@ -2,7 +2,6 @@ package link
 
 import (
 	"errors"
-	"io/ioutil"
 	"math"
 	"os"
 	"path/filepath"
@@ -124,7 +123,7 @@ type testLinkOptions struct {
 func testLink(t *testing.T, link Link, opts testLinkOptions) {
 	t.Helper()
 
-	tmp, err := ioutil.TempDir("/sys/fs/bpf", "ebpf-test")
+	tmp, err := os.MkdirTemp("/sys/fs/bpf", "ebpf-test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/link/perf_event.go
+++ b/link/perf_event.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -263,7 +262,7 @@ func uint64FromFile(base string, path ...string) (uint64, error) {
 		return 0, fmt.Errorf("path '%s' attempts to escape base path '%s': %w", l, base, errInvalidInput)
 	}
 
-	data, err := ioutil.ReadFile(p)
+	data, err := os.ReadFile(p)
 	if err != nil {
 		return 0, fmt.Errorf("reading file %s: %w", p, err)
 	}

--- a/map_test.go
+++ b/map_test.go
@@ -3,7 +3,6 @@ package ebpf
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"os"
 	"path/filepath"
@@ -344,7 +343,7 @@ func TestNestedMapPin(t *testing.T) {
 	}
 	defer m.Close()
 
-	tmp, err := ioutil.TempDir("/sys/fs/bpf", "ebpf-test")
+	tmp, err := os.MkdirTemp("/sys/fs/bpf", "ebpf-test")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Go 1.16 announced [1] the deprecation of io/ioutil with (almost)
drop in replacements in io and os packages. This change moves to
use those replacements.

Note: io/ioutil going away was NOT announced but dropping it is
trivial and allows to reduce imports.

[1] https://golang.org/doc/go1.16#ioutil

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>