### PR TITLE
examples - convert to new rlimit package for memlock removal

### DIFF
--- a/examples/go.mod
+++ b/examples/go.mod
@@ -3,6 +3,6 @@ module github.com/cilium/ebpf/examples
 go 1.16
 
 require (
-	github.com/cilium/ebpf v0.6.3-0.20210908112439-54eeaaca78c6
-	golang.org/x/sys v0.0.0-20210908143011-c212e7322662
+	github.com/cilium/ebpf v0.6.3-0.20211001093841-41f3f37fcc9c
+	golang.org/x/sys v0.0.0-20211001092434-39dca1131b70
 )

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -1,5 +1,7 @@
 github.com/cilium/ebpf v0.6.3-0.20210908112439-54eeaaca78c6 h1:m3v1ajcMru78X/KBQO3lwXiRL5ks6kKckeIrUxba+VE=
 github.com/cilium/ebpf v0.6.3-0.20210908112439-54eeaaca78c6/go.mod h1:/oI2+1shJiTGAMgl6/RgJr36Eo1jzrRcAWbcXO2usCA=
+github.com/cilium/ebpf v0.6.3-0.20211001093841-41f3f37fcc9c h1:LrVaoI3beWc60R6ylMrBc1qVuuQko+dKgGhe/IAK1p8=
+github.com/cilium/ebpf v0.6.3-0.20211001093841-41f3f37fcc9c/go.mod h1:/oI2+1shJiTGAMgl6/RgJr36Eo1jzrRcAWbcXO2usCA=
 github.com/frankban/quicktest v1.11.3 h1:8sXhOn0uLys67V8EsXLc6eszDs8VXWxL3iRvebPhedY=
 github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM0I9ntUbOk+k=
 github.com/google/go-cmp v0.5.4 h1:L8R9j+yAqZuZjsqh/z+F1NCffTKKLShY6zXTItVIZ8M=
@@ -12,5 +14,7 @@ github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 golang.org/x/sys v0.0.0-20210906170528-6f6e22806c34/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210908143011-c212e7322662 h1:2+M7sCYQcvlpag1ug05BCZa5B9jbazrHdgsOdwqlfE8=
 golang.org/x/sys v0.0.0-20210908143011-c212e7322662/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211001092434-39dca1131b70 h1:pGleJoyD1yA5HfvuaksHxD0404gsEkNDerKsQ0N0y1s=
+golang.org/x/sys v0.0.0-20211001092434-39dca1131b70/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/examples/kprobe/main.go
+++ b/examples/kprobe/main.go
@@ -14,8 +14,8 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/link"
+	"github.com/cilium/ebpf/rlimit"
 )
 
 //go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc clang-11 KProbeExample ./bpf/kprobe_example.c -- -nostdinc -I../headers
@@ -32,8 +32,7 @@ func main() {
 	signal.Notify(stopper, os.Interrupt, syscall.SIGTERM)
 
 	// Allow the current process to lock memory for eBPF resources.
-	rrl, err := ebpf.RemoveMemlockRlimit()
-	if err != nil {
+	if err := rlimit.RemoveMemlock(); err != nil {
 		log.Fatal(err)
 	}
 
@@ -43,11 +42,6 @@ func main() {
 		log.Fatalf("loading objects: %v", err)
 	}
 	defer objs.Close()
-
-	// Revert the process' rlimit after eBPF resources have been loaded.
-	if err := rrl(); err != nil {
-		log.Fatal(err)
-	}
 
 	// Open a Kprobe at the entry point of the kernel function and attach the
 	// pre-compiled program. Each time the kernel function enters, the program

--- a/examples/ringbuffer/main.go
+++ b/examples/ringbuffer/main.go
@@ -12,9 +12,9 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/link"
 	"github.com/cilium/ebpf/ringbuf"
+	"github.com/cilium/ebpf/rlimit"
 	"golang.org/x/sys/unix"
 )
 
@@ -37,8 +37,7 @@ func main() {
 	signal.Notify(stopper, os.Interrupt, syscall.SIGTERM)
 
 	// Allow the current process to lock memory for eBPF resources.
-	rrl, err := ebpf.RemoveMemlockRlimit()
-	if err != nil {
+	if err := rlimit.RemoveMemlock(); err != nil {
 		log.Fatal(err)
 	}
 
@@ -48,11 +47,6 @@ func main() {
 		log.Fatalf("loading objects: %v", err)
 	}
 	defer objs.Close()
-
-	// Revert the process' rlimit after eBPF resources have been loaded.
-	if err := rrl(); err != nil {
-		log.Fatal(err)
-	}
 
 	// Open a Kprobe at the entry point of the kernel function and attach the
 	// pre-compiled program. Each time the kernel function enters, the program

--- a/examples/tracepoint_in_c/main.go
+++ b/examples/tracepoint_in_c/main.go
@@ -14,8 +14,8 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/link"
+	"github.com/cilium/ebpf/rlimit"
 )
 
 //go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc clang-11 Handler ./bpf/handler.c -- -nostdinc -I../headers
@@ -29,10 +29,9 @@ func main() {
 	stopper := make(chan os.Signal, 1)
 	signal.Notify(stopper, os.Interrupt, syscall.SIGTERM)
 
-	// Increase the rlimit of the current process to provide sufficient space
-	// for locking memory for the eBPF map.
-	if _, err := ebpf.RemoveMemlockRlimit(); err != nil {
-		log.Fatalf("failed to set temporary rlimit: %v", err)
+	// Allow the current process to lock memory for eBPF resources.
+	if err := rlimit.RemoveMemlock(); err != nil {
+		log.Fatal(err)
 	}
 
 	// Load pre-compiled programs and maps into the kernel.

--- a/examples/tracepoint_in_go/main.go
+++ b/examples/tracepoint_in_go/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cilium/ebpf/asm"
 	"github.com/cilium/ebpf/link"
 	"github.com/cilium/ebpf/perf"
+	"github.com/cilium/ebpf/rlimit"
 )
 
 // Metadata for the eBPF program used in this example.
@@ -33,8 +34,7 @@ func main() {
 	signal.Notify(stopper, os.Interrupt, syscall.SIGTERM)
 
 	// Allow the current process to lock memory for eBPF resources.
-	rrl, err := ebpf.RemoveMemlockRlimit()
-	if err != nil {
+	if err := rlimit.RemoveMemlock(); err != nil {
 		log.Fatal(err)
 	}
 
@@ -94,11 +94,6 @@ func main() {
 		log.Fatalf("creating ebpf program: %s", err)
 	}
 	defer prog.Close()
-
-	// Revert the process' rlimit after eBPF resources have been loaded.
-	if err := rrl(); err != nil {
-		log.Fatal(err)
-	}
 
 	// Open a trace event based on a pre-existing kernel hook (tracepoint).
 	// Each time a userspace program uses the 'openat()' syscall, the eBPF


### PR DESCRIPTION
Following #438, switch to the new rlimit package for conditionally bumping the memlock rlimit.

@folbricht 