### PR TITLE
README.md: changes for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,20 +8,9 @@ eBPF is a pure Go library that provides utilities for loading, compiling, and
 debugging eBPF programs. It has minimal external dependencies and is intended to
 be used in long running processes.
 
-
-* [asm](https://pkg.go.dev/github.com/cilium/ebpf/asm) contains a basic
-  assembler
-* [link](https://pkg.go.dev/github.com/cilium/ebpf/link) allows attaching eBPF
-  to various hooks
-* [perf](https://pkg.go.dev/github.com/cilium/ebpf/perf) allows reading from a
-  `PERF_EVENT_ARRAY`
-* [ringbuf](https://pkg.go.dev/github.com/cilium/ebpf/ringbuf) allows reading from a
-  `BPF_MAP_TYPE_RINGBUF` map
-* [cmd/bpf2go](https://pkg.go.dev/github.com/cilium/ebpf/cmd/bpf2go) allows
-  compiling and embedding eBPF programs in Go code
-
 The library is maintained by [Cloudflare](https://www.cloudflare.com) and
 [Cilium](https://www.cilium.io).
+
 See [ebpf.io](https://ebpf.io) for other projects from the eBPF ecosystem.
 
 ## Getting Started
@@ -38,6 +27,25 @@ Please
 [join](https://ebpf.io/slack) the
 [#ebpf-go](https://cilium.slack.com/messages/ebpf-go) channel on Slack if you
 have questions regarding the library.
+
+## Packages
+
+This library includes the following packages: 
+
+* [asm](https://pkg.go.dev/github.com/cilium/ebpf/asm) contains a basic
+  assembler, allowing you to write eBPF assembly instructions directly
+  within your Go code. (You don't need to use this if you prefer to write your eBPF program in C.)
+* [cmd/bpf2go](https://pkg.go.dev/github.com/cilium/ebpf/cmd/bpf2go) allows
+  compiling and embedding eBPF programs written in C within Go code. As well as
+  compiling the C code, it auto-generates Go code for loading and manipulating
+  the eBPF program and map objects. 
+* [link](https://pkg.go.dev/github.com/cilium/ebpf/link) allows attaching eBPF
+  to various hooks
+* [perf](https://pkg.go.dev/github.com/cilium/ebpf/perf) allows reading from a
+  `PERF_EVENT_ARRAY`
+* [ringbuf](https://pkg.go.dev/github.com/cilium/ebpf/ringbuf) allows reading from a
+  `BPF_MAP_TYPE_RINGBUF` map
+
 
 ## Requirements
 


### PR DESCRIPTION
* A bit of re-ordering so that newcomers are more likely to start with the examples
* Small clarifications about `asm` & `cmd/bpf2go` 

Signed-off-by: Liz Rice <liz@lizrice.com>