### PR TITLE
WIP : [CI] add kernel 4.4.131 support

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -61,7 +61,7 @@ blocks:
       - name: Run unit tests
         matrix:
           - env_var: KERNEL_VERSION
-            values: ["5.10", "5.4", "4.19", "4.9"]
+            values: ["5.10", "5.4", "4.19", "4.9", "4.4.131"]
         commands:
           - timeout -s KILL 600s ./run-tests.sh $KERNEL_VERSION
           - goveralls -coverprofile="coverage.out" -service=semaphore -repotoken "$COVERALLS_TOKEN" || echo Submission to coveralls failed

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -38,6 +38,8 @@ blocks:
       env_vars:
         - name: TMPDIR
           value: /tmp
+        - name: BRANCH
+          value: nplanel/add-kernel-44
       jobs:
       - name: Build
         commands:

--- a/info.go
+++ b/info.go
@@ -15,6 +15,32 @@ import (
 	"github.com/cilium/ebpf/internal/btf"
 )
 
+var haveFdInfoMaps = internal.FeatureTest("proc/pid/fdinfo maps", "4.9?", func() error {
+	// This checks we can scan /proc/pid/fdinfo, which appeared in 4.9?.
+	m, err := internal.BPFMapCreate(&internal.BPFMapCreateAttr{
+		MapType:    uint32(Array),
+		KeySize:    4,
+		ValueSize:  4,
+		MaxEntries: 1,
+	})
+	if err != nil {
+		return internal.ErrNotSupported
+	}
+	var mi MapInfo
+	err = scanFdInfo(m, map[string]interface{}{
+		"map_type":    &mi.Type,
+		"key_size":    &mi.KeySize,
+		"value_size":  &mi.ValueSize,
+		"max_entries": &mi.MaxEntries,
+		"map_flags":   &mi.Flags,
+	})
+	if err != nil {
+		return internal.ErrNotSupported
+	}
+	_ = m.Close()
+	return nil
+})
+
 // MapInfo describes a map.
 type MapInfo struct {
 	Type       MapType
@@ -49,6 +75,10 @@ func newMapInfoFromFd(fd *internal.FD) (*MapInfo, error) {
 }
 
 func newMapInfoFromProc(fd *internal.FD) (*MapInfo, error) {
+	if err := haveFdInfoMaps(); err != nil {
+		return nil, err
+	}
+
 	var mi MapInfo
 	err := scanFdInfo(fd, map[string]interface{}{
 		"map_type":    &mi.Type,

--- a/info_test.go
+++ b/info_test.go
@@ -14,20 +14,25 @@ import (
 )
 
 func TestMapInfoFromProc(t *testing.T) {
-	hash, err := NewMap(&MapSpec{
+	mapSpec := &MapSpec{
 		Name:       "testing",
 		Type:       Hash,
 		KeySize:    4,
 		ValueSize:  5,
 		MaxEntries: 2,
-		Flags:      unix.BPF_F_NO_PREALLOC,
-	})
+	}
+	if err := haveNoPreallocMaps(); err == nil {
+		mapSpec.Flags = unix.BPF_F_NO_PREALLOC
+	}
+
+	hash, err := NewMap(mapSpec)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer hash.Close()
 
 	info, err := newMapInfoFromProc(hash.fd)
+	testutils.SkipIfNotSupported(t, err)
 	if err != nil {
 		t.Fatal("Can't get map info:", err)
 	}
@@ -48,7 +53,7 @@ func TestMapInfoFromProc(t *testing.T) {
 		t.Error("Expected MaxEntries of 2, got", info.MaxEntries)
 	}
 
-	if info.Flags != unix.BPF_F_NO_PREALLOC {
+	if mapSpec.Flags&unix.BPF_F_NO_PREALLOC > 0 && info.Flags&unix.BPF_F_NO_PREALLOC > 0 {
 		t.Errorf("Expected Flags to be %d, got %d", unix.BPF_F_NO_PREALLOC, info.Flags)
 	}
 

--- a/internal/unix/types_linux.go
+++ b/internal/unix/types_linux.go
@@ -24,6 +24,7 @@ const (
 	ENODEV  = linux.ENODEV
 	EBADF   = linux.EBADF
 	E2BIG   = linux.E2BIG
+	EFAULT  = linux.EFAULT
 	// ENOTSUPP is not the same as ENOTSUP or EOPNOTSUP
 	ENOTSUPP = syscall.Errno(0x20c)
 

--- a/internal/unix/types_other.go
+++ b/internal/unix/types_other.go
@@ -23,6 +23,7 @@ const (
 	ENODEV = syscall.ENODEV
 	EBADF  = syscall.Errno(0)
 	E2BIG  = syscall.Errno(0)
+	EFAULT = syscall.EFAULT
 	// ENOTSUPP is not the same as ENOTSUP or EOPNOTSUP
 	ENOTSUPP = syscall.Errno(0x20c)
 

--- a/link/perf_event_test.go
+++ b/link/perf_event_test.go
@@ -27,7 +27,7 @@ func TestTraceEventTypePMU(t *testing.T) {
 func TestTraceEventID(t *testing.T) {
 	c := qt.New(t)
 
-	eid, err := getTraceEventID("syscalls", "sys_enter_execve")
+	eid, err := getTraceEventID("syscalls", "sys_enter_mkdir")
 	c.Assert(err, qt.IsNil)
 	c.Assert(eid, qt.Not(qt.Equals), 0)
 }

--- a/link/tracepoint_test.go
+++ b/link/tracepoint_test.go
@@ -49,6 +49,9 @@ func TestTracepoint(t *testing.T) {
 }
 
 func TestTracepointMissing(t *testing.T) {
+	// Requires at least 4.7 (98b5c2c65c29 "perf, bpf: allow bpf programs attach to tracepoints")
+	testutils.SkipOnOldKernel(t, "4.7", "tracepoint support")
+
 	prog, err := ebpf.NewProgram(&tracepointSpec)
 	if err != nil {
 		t.Fatal(err)

--- a/map.go
+++ b/map.go
@@ -360,6 +360,11 @@ func (spec *MapSpec) createMap(inner *internal.FD, opts MapOptions, handles *han
 			return nil, fmt.Errorf("map create: %w", err)
 		}
 	}
+	if spec.Flags&unix.BPF_F_NO_PREALLOC > 0 {
+		if err := haveNoPreallocMaps(); err != nil {
+			return nil, fmt.Errorf("map create: %w", err)
+		}
+	}
 
 	attr := internal.BPFMapCreateAttr{
 		MapType:    uint32(spec.Type),

--- a/map.go
+++ b/map.go
@@ -203,7 +203,7 @@ func newMapFromFD(fd *internal.FD) (*Map, error) {
 	info, err := newMapInfoFromFd(fd)
 	if err != nil {
 		fd.Close()
-		return nil, fmt.Errorf("get map info: %s", err)
+		return nil, fmt.Errorf("get map info: %w", err)
 	}
 
 	return newMap(fd, info.Name, info.Type, info.KeySize, info.ValueSize, info.MaxEntries, info.Flags)
@@ -314,7 +314,7 @@ func newMapWithOptions(spec *MapSpec, opts MapOptions, handles *handleCache) (_ 
 	if spec.Pinning == PinByName {
 		path := filepath.Join(opts.PinPath, spec.Name)
 		if err := m.Pin(path); err != nil {
-			return nil, fmt.Errorf("pin map: %s", err)
+			return nil, fmt.Errorf("pin map: %w", err)
 		}
 	}
 
@@ -955,6 +955,9 @@ func (m *Map) Clone() (*Map, error) {
 //
 // This requires bpffs to be mounted above fileName. See https://docs.cilium.io/en/k8s-doc/admin/#admin-mount-bpffs
 func (m *Map) Pin(fileName string) error {
+	if err := haveFdInfoMaps(); errors.Is(err, ErrNotSupported) {
+		return err
+	}
 	if err := internal.Pin(m.pinnedPath, fileName, m.fd); err != nil {
 		return err
 	}
@@ -968,6 +971,9 @@ func (m *Map) Pin(fileName string) error {
 //
 // Unpinning an unpinned Map returns nil.
 func (m *Map) Unpin() error {
+	if err := haveFdInfoMaps(); errors.Is(err, ErrNotSupported) {
+		return err
+	}
 	if err := internal.Unpin(m.pinnedPath); err != nil {
 		return err
 	}

--- a/map_test.go
+++ b/map_test.go
@@ -301,6 +301,7 @@ func TestMapPin(t *testing.T) {
 	path := filepath.Join(tmp, "map")
 
 	if err := m.Pin(path); err != nil {
+		testutils.SkipIfNotSupported(t, err)
 		t.Fatal(err)
 	}
 
@@ -310,6 +311,7 @@ func TestMapPin(t *testing.T) {
 	m.Close()
 
 	m, err := LoadPinnedMap(path, nil)
+	testutils.SkipIfNotSupported(t, err) // TODO: add support for old kernel for load pinned from MapSpec
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -388,6 +390,7 @@ func TestMapPinMultiple(t *testing.T) {
 	spec := spec1.Copy()
 
 	m1, err := NewMapWithOptions(spec, MapOptions{PinPath: tmp})
+	testutils.SkipIfNotSupported(t, err)
 	if err != nil {
 		t.Fatal("Can't create map:", err)
 	}
@@ -425,6 +428,7 @@ func TestMapPinFailReplace(t *testing.T) {
 	spec2.Name = spec1.Name + "bar"
 
 	m, err := NewMapWithOptions(spec, MapOptions{PinPath: tmp})
+	testutils.SkipIfNotSupported(t, err)
 	if err != nil {
 		t.Fatal("Failed to create map:", err)
 	}
@@ -447,6 +451,7 @@ func TestMapUnpin(t *testing.T) {
 	spec := spec1.Copy()
 
 	m, err := NewMapWithOptions(spec, MapOptions{PinPath: tmp})
+	testutils.SkipIfNotSupported(t, err)
 	if err != nil {
 		t.Fatal("Failed to create map:", err)
 	}
@@ -474,6 +479,7 @@ func TestMapLoadPinned(t *testing.T) {
 	spec := spec1.Copy()
 
 	m1, err := NewMapWithOptions(spec, MapOptions{PinPath: tmp})
+	testutils.SkipIfNotSupported(t, err)
 	c.Assert(err, qt.IsNil)
 	defer m1.Close()
 	pinned := m1.IsPinned()
@@ -494,6 +500,7 @@ func TestMapLoadPinnedUnpin(t *testing.T) {
 	spec := spec1.Copy()
 
 	m1, err := NewMapWithOptions(spec, MapOptions{PinPath: tmp})
+	testutils.SkipIfNotSupported(t, err)
 	c.Assert(err, qt.IsNil)
 	defer m1.Close()
 	pinned := m1.IsPinned()
@@ -574,6 +581,7 @@ func TestMapPinFlags(t *testing.T) {
 	m, err := NewMapWithOptions(spec, MapOptions{
 		PinPath: tmp,
 	})
+	testutils.SkipIfNotSupported(t, err)
 	qt.Assert(t, err, qt.IsNil)
 	m.Close()
 
@@ -997,6 +1005,9 @@ func TestPerCPUMarshaling(t *testing.T) {
 			if numCPU < 2 {
 				t.Skip("Test requires at least two CPUs")
 			}
+			if typ == PerCPUHash || typ == PerCPUArray {
+				testutils.SkipOnOldKernel(t, "4.6", "per-CPU hash and array")
+			}
 			if typ == LRUCPUHash {
 				testutils.SkipOnOldKernel(t, "4.10", "LRU per-CPU hash")
 			}
@@ -1220,6 +1231,7 @@ func TestMapFromFD(t *testing.T) {
 	// If you're thinking about copying this, don't. Use
 	// Clone() instead.
 	m2, err := NewMapFromFD(m.FD())
+	testutils.SkipIfNotSupported(t, err)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1367,6 +1379,7 @@ func TestMapPinning(t *testing.T) {
 	}
 
 	m1, err := NewMapWithOptions(spec, MapOptions{PinPath: tmp})
+	testutils.SkipIfNotSupported(t, err)
 	if err != nil {
 		t.Fatal("Can't create map:", err)
 	}

--- a/map_test.go
+++ b/map_test.go
@@ -928,11 +928,16 @@ func TestNotExist(t *testing.T) {
 	}
 
 	if err := hash.Delete("hello"); !errors.Is(err, ErrKeyNotExist) {
-		t.Error("Deleting unknown key doesn't return ErrKeyNotExist")
+		t.Error("Deleting unknown key doesn't return ErrKeyNotExist", err)
+	}
+
+	var k = []byte{1, 2, 3, 4, 5}
+	if err := hash.NextKey(&k, &tmp); !errors.Is(err, ErrKeyNotExist) {
+		t.Error("Looking up next key in empty map doesn't return a non-existing error", err)
 	}
 
 	if err := hash.NextKey(nil, &tmp); !errors.Is(err, ErrKeyNotExist) {
-		t.Error("Looking up next key in empty map doesn't return a non-existing error")
+		t.Error("Looking up next key in empty map doesn't return a non-existing error", err)
 	}
 }
 

--- a/perf/reader_test.go
+++ b/perf/reader_test.go
@@ -120,6 +120,9 @@ func outputSamplesProg(sampleSizes ...int) (*ebpf.Program, *ebpf.Map, error) {
 func mustOutputSamplesProg(tb testing.TB, sampleSizes ...int) (*ebpf.Program, *ebpf.Map) {
 	tb.Helper()
 
+	// Requires at least 4.9 (0515e5999a46 "bpf: introduce BPF_PROG_TYPE_PERF_EVENT program type")
+	testutils.SkipOnOldKernel(tb, "4.9", "perf events support")
+
 	prog, events, err := outputSamplesProg(sampleSizes...)
 	if err != nil {
 		tb.Fatal(err)

--- a/prog_test.go
+++ b/prog_test.go
@@ -23,6 +23,8 @@ import (
 )
 
 func TestProgramRun(t *testing.T) {
+	testutils.SkipOnOldKernel(t, "4.8", "XDP program")
+
 	pat := []byte{0xDE, 0xAD, 0xBE, 0xEF}
 	buf := make([]byte, 14)
 

--- a/syscalls.go
+++ b/syscalls.go
@@ -214,6 +214,22 @@ var haveInnerMaps = internal.FeatureTest("inner maps", "5.10", func() error {
 	return nil
 })
 
+var haveNoPreallocMaps = internal.FeatureTest("prealloc maps", "4.6", func() error {
+	// This checks BPF_F_NO_PREALLOC, which appeared in 4.6.
+	m, err := internal.BPFMapCreate(&internal.BPFMapCreateAttr{
+		MapType:    uint32(Array),
+		KeySize:    4,
+		ValueSize:  4,
+		MaxEntries: 1,
+		Flags:      unix.BPF_F_NO_PREALLOC,
+	})
+	if err != nil {
+		return internal.ErrNotSupported
+	}
+	_ = m.Close()
+	return nil
+})
+
 func bpfMapLookupElem(m *internal.FD, key, valueOut internal.Pointer) error {
 	fd, err := m.Value()
 	if err != nil {


### PR DESCRIPTION
I push this here for a first pass review

I disabled (ErrNotSupported) map.Pin() and map.UnPin() when the kernel can't read map info (keysize, ...) back from /proc/pid/fdinfo
Technically for these old kernel is possible to Pin (If I'm correct) but the caller need to give the map Spec, if it's need to be supported we need to have a persistent way to save map spec, may via shmget() ?
