### PR TITLE
program: add program type syscall

### DIFF
--- a/features/prog_test.go
+++ b/features/prog_test.go
@@ -41,6 +41,7 @@ var progTypeMinVersion = map[ebpf.ProgramType]string{
 	ebpf.Extension:             "5.6",
 	ebpf.LSM:                   "5.7",
 	ebpf.SkLookup:              "5.9",
+	ebpf.Syscall:               "5.14",
 }
 
 func TestHaveProgType(t *testing.T) {

--- a/types.go
+++ b/types.go
@@ -167,6 +167,7 @@ const (
 	Extension
 	LSM
 	SkLookup
+	Syscall
 	maxProgramType
 )
 

--- a/types_string.go
+++ b/types_string.go
@@ -86,12 +86,13 @@ func _() {
 	_ = x[Extension-28]
 	_ = x[LSM-29]
 	_ = x[SkLookup-30]
-	_ = x[maxProgramType-31]
+	_ = x[Syscall-31]
+	_ = x[maxProgramType-32]
 }
 
-const _ProgramType_name = "UnspecifiedProgramSocketFilterKprobeSchedCLSSchedACTTracePointXDPPerfEventCGroupSKBCGroupSockLWTInLWTOutLWTXmitSockOpsSkSKBCGroupDeviceSkMsgRawTracepointCGroupSockAddrLWTSeg6LocalLircMode2SkReuseportFlowDissectorCGroupSysctlRawTracepointWritableCGroupSockoptTracingStructOpsExtensionLSMSkLookupmaxProgramType"
+const _ProgramType_name = "UnspecifiedProgramSocketFilterKprobeSchedCLSSchedACTTracePointXDPPerfEventCGroupSKBCGroupSockLWTInLWTOutLWTXmitSockOpsSkSKBCGroupDeviceSkMsgRawTracepointCGroupSockAddrLWTSeg6LocalLircMode2SkReuseportFlowDissectorCGroupSysctlRawTracepointWritableCGroupSockoptTracingStructOpsExtensionLSMSkLookupSyscallmaxProgramType"
 
-var _ProgramType_index = [...]uint16{0, 18, 30, 36, 44, 52, 62, 65, 74, 83, 93, 98, 104, 111, 118, 123, 135, 140, 153, 167, 179, 188, 199, 212, 224, 245, 258, 265, 274, 283, 286, 294, 308}
+var _ProgramType_index = [...]uint16{0, 18, 30, 36, 44, 52, 62, 65, 74, 83, 93, 98, 104, 111, 118, 123, 135, 140, 153, 167, 179, 188, 199, 212, 224, 245, 258, 265, 274, 283, 286, 294, 301, 315}
 
 func (i ProgramType) String() string {
 	if i >= ProgramType(len(_ProgramType_index)-1) {


### PR DESCRIPTION
Signed-off-by: Florian Lehner <dev@der-flo.net>

Add the program type `BPF_PROG_TYPE_SYSCALL` that was introduced with https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/include/uapi/linux/bpf.h?id=79a7f8bdb159d9914b58740f3d31d602a6e4aca8