### PR TITLE
link/uprobe: support ref_ctr_offset

### DIFF
--- a/link/kprobe.go
+++ b/link/kprobe.go
@@ -28,6 +28,13 @@ var (
 
 type probeType uint8
 
+type probeArgs struct {
+	symbol, group, path  string
+	offset, refCtrOffset uint64
+	pid                  int
+	ret                  bool
+}
+
 const (
 	kprobeType probeType = iota
 	uprobeType
@@ -131,10 +138,17 @@ func kprobe(symbol string, prog *ebpf.Program, ret bool) (*perfEvent, error) {
 		return nil, fmt.Errorf("eBPF program type %s is not a Kprobe: %w", prog.Type(), errInvalidInput)
 	}
 
+	args := probeArgs{
+		pid:    perfAllThreads,
+		symbol: platformPrefix(symbol),
+		ret:    ret,
+	}
+
 	// Use kprobe PMU if the kernel has it available.
-	tp, err := pmuKprobe(platformPrefix(symbol), ret)
+	tp, err := pmuKprobe(args)
 	if errors.Is(err, os.ErrNotExist) {
-		tp, err = pmuKprobe(symbol, ret)
+		args.symbol = symbol
+		tp, err = pmuKprobe(args)
 	}
 	if err == nil {
 		return tp, nil
@@ -144,9 +158,11 @@ func kprobe(symbol string, prog *ebpf.Program, ret bool) (*perfEvent, error) {
 	}
 
 	// Use tracefs if kprobe PMU is missing.
-	tp, err = tracefsKprobe(platformPrefix(symbol), ret)
+	args.symbol = platformPrefix(symbol)
+	tp, err = tracefsKprobe(args)
 	if errors.Is(err, os.ErrNotExist) {
-		tp, err = tracefsKprobe(symbol, ret)
+		args.symbol = symbol
+		tp, err = tracefsKprobe(args)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("creating trace event '%s' in tracefs: %w", symbol, err)
@@ -157,8 +173,8 @@ func kprobe(symbol string, prog *ebpf.Program, ret bool) (*perfEvent, error) {
 
 // pmuKprobe opens a perf event based on the kprobe PMU.
 // Returns os.ErrNotExist if the given symbol does not exist in the kernel.
-func pmuKprobe(symbol string, ret bool) (*perfEvent, error) {
-	return pmuProbe(kprobeType, symbol, "", 0, perfAllThreads, 0, ret)
+func pmuKprobe(args probeArgs) (*perfEvent, error) {
+	return pmuProbe(kprobeType, args)
 }
 
 // pmuProbe opens a perf event based on a Performance Monitoring Unit.
@@ -168,7 +184,7 @@ func pmuKprobe(symbol string, ret bool) (*perfEvent, error) {
 // 33ea4b24277b "perf/core: Implement the 'perf_uprobe' PMU"
 //
 // Returns ErrNotSupported if the kernel doesn't support perf_[k,u]probe PMU
-func pmuProbe(typ probeType, symbol, path string, offset uint64, pid int, refCtrOffset uint64, ret bool) (*perfEvent, error) {
+func pmuProbe(typ probeType, args probeArgs) (*perfEvent, error) {
 	// Getting the PMU type will fail if the kernel doesn't support
 	// the perf_[k,u]probe PMU.
 	et, err := getPMUEventType(typ)
@@ -177,7 +193,7 @@ func pmuProbe(typ probeType, symbol, path string, offset uint64, pid int, refCtr
 	}
 
 	var config uint64
-	if ret {
+	if args.ret {
 		bit, err := typ.RetprobeBit()
 		if err != nil {
 			return nil, err
@@ -192,7 +208,7 @@ func pmuProbe(typ probeType, symbol, path string, offset uint64, pid int, refCtr
 	switch typ {
 	case kprobeType:
 		// Create a pointer to a NUL-terminated string for the kernel.
-		sp, err = unsafeStringPtr(symbol)
+		sp, err = unsafeStringPtr(args.symbol)
 		if err != nil {
 			return nil, err
 		}
@@ -203,13 +219,13 @@ func pmuProbe(typ probeType, symbol, path string, offset uint64, pid int, refCtr
 			Config: config,              // Retprobe flag
 		}
 	case uprobeType:
-		sp, err = unsafeStringPtr(path)
+		sp, err = unsafeStringPtr(args.path)
 		if err != nil {
 			return nil, err
 		}
 
-		if refCtrOffset != 0 {
-			config |= refCtrOffset << uprobeRefCtrOffsetShift
+		if args.refCtrOffset != 0 {
+			config |= args.refCtrOffset << uprobeRefCtrOffsetShift
 		}
 
 		attr = unix.PerfEventAttr{
@@ -220,23 +236,23 @@ func pmuProbe(typ probeType, symbol, path string, offset uint64, pid int, refCtr
 			Size:   unix.PERF_ATTR_SIZE_VER1,
 			Type:   uint32(et),          // PMU event type read from sysfs
 			Ext1:   uint64(uintptr(sp)), // Uprobe path
-			Ext2:   offset,              // Uprobe offset
+			Ext2:   args.offset,         // Uprobe offset
 			Config: config,              // RefCtrOffset, Retprobe flag
 		}
 	}
 
-	rawFd, err := unix.PerfEventOpen(&attr, pid, 0, -1, unix.PERF_FLAG_FD_CLOEXEC)
+	rawFd, err := unix.PerfEventOpen(&attr, args.pid, 0, -1, unix.PERF_FLAG_FD_CLOEXEC)
 
 	// Since commit 97c753e62e6c, ENOENT is correctly returned instead of EINVAL
 	// when trying to create a kretprobe for a missing symbol. Make sure ENOENT
 	// is returned to the caller.
 	if errors.Is(err, os.ErrNotExist) || errors.Is(err, unix.EINVAL) {
-		return nil, fmt.Errorf("symbol '%s' not found: %w", symbol, os.ErrNotExist)
+		return nil, fmt.Errorf("symbol '%s' not found: %w", args.symbol, os.ErrNotExist)
 	}
 	// Since at least commit cb9a19fe4aa51, ENOTSUPP is returned
 	// when attempting to set a uprobe on a trap instruction.
 	if errors.Is(err, unix.ENOTSUPP) {
-		return nil, fmt.Errorf("failed setting uprobe on offset %#x (possible trap insn): %w", offset, err)
+		return nil, fmt.Errorf("failed setting uprobe on offset %#x (possible trap insn): %w", args.offset, err)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("opening perf event: %w", err)
@@ -254,14 +270,14 @@ func pmuProbe(typ probeType, symbol, path string, offset uint64, pid int, refCtr
 	return &perfEvent{
 		fd:    fd,
 		pmuID: et,
-		name:  symbol,
-		typ:   typ.PerfEventType(ret),
+		name:  args.symbol,
+		typ:   typ.PerfEventType(args.ret),
 	}, nil
 }
 
 // tracefsKprobe creates a Kprobe tracefs entry.
-func tracefsKprobe(symbol string, ret bool) (*perfEvent, error) {
-	return tracefsProbe(kprobeType, symbol, "", 0, perfAllThreads, 0, ret)
+func tracefsKprobe(args probeArgs) (*perfEvent, error) {
+	return tracefsProbe(kprobeType, args)
 }
 
 // tracefsProbe creates a trace event by writing an entry to <tracefs>/[k,u]probe_events.
@@ -270,7 +286,7 @@ func tracefsKprobe(symbol string, ret bool) (*perfEvent, error) {
 // Path and offset are only set in the case of uprobe(s) and are used to set
 // the executable/library path on the filesystem and the offset where the probe is inserted.
 // A perf event is then opened on the newly-created trace event and returned to the caller.
-func tracefsProbe(typ probeType, symbol, path string, offset uint64, pid int, refCtrOffset uint64, ret bool) (*perfEvent, error) {
+func tracefsProbe(typ probeType, args probeArgs) (*perfEvent, error) {
 	// Generate a random string for each trace event we attempt to create.
 	// This value is used as the 'group' token in tracefs to allow creating
 	// multiple kprobe trace events with the same name.
@@ -278,32 +294,33 @@ func tracefsProbe(typ probeType, symbol, path string, offset uint64, pid int, re
 	if err != nil {
 		return nil, fmt.Errorf("randomizing group name: %w", err)
 	}
+	args.group = group
 
 	// Before attempting to create a trace event through tracefs,
 	// check if an event with the same group and name already exists.
 	// Kernels 4.x and earlier don't return os.ErrExist on writing a duplicate
 	// entry, so we need to rely on reads for detecting uniqueness.
-	_, err = getTraceEventID(group, symbol)
+	_, err = getTraceEventID(group, args.symbol)
 	if err == nil {
-		return nil, fmt.Errorf("trace event already exists: %s/%s", group, symbol)
+		return nil, fmt.Errorf("trace event already exists: %s/%s", group, args.symbol)
 	}
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
-		return nil, fmt.Errorf("checking trace event %s/%s: %w", group, symbol, err)
+		return nil, fmt.Errorf("checking trace event %s/%s: %w", group, args.symbol, err)
 	}
 
 	// Create the [k,u]probe trace event using tracefs.
-	if err := createTraceFSProbeEvent(typ, group, symbol, path, offset, refCtrOffset, ret); err != nil {
+	if err := createTraceFSProbeEvent(typ, args); err != nil {
 		return nil, fmt.Errorf("creating probe entry on tracefs: %w", err)
 	}
 
 	// Get the newly-created trace event's id.
-	tid, err := getTraceEventID(group, symbol)
+	tid, err := getTraceEventID(group, args.symbol)
 	if err != nil {
 		return nil, fmt.Errorf("getting trace event id: %w", err)
 	}
 
 	// Kprobes are ephemeral tracepoints and share the same perf event type.
-	fd, err := openTracepointPerfEvent(tid, pid)
+	fd, err := openTracepointPerfEvent(tid, args.pid)
 	if err != nil {
 		return nil, err
 	}
@@ -311,9 +328,9 @@ func tracefsProbe(typ probeType, symbol, path string, offset uint64, pid int, re
 	return &perfEvent{
 		fd:        fd,
 		group:     group,
-		name:      symbol,
+		name:      args.symbol,
 		tracefsID: tid,
-		typ:       typ.PerfEventType(ret),
+		typ:       typ.PerfEventType(args.ret),
 	}, nil
 }
 
@@ -321,7 +338,7 @@ func tracefsProbe(typ probeType, symbol, path string, offset uint64, pid int, re
 // <tracefs>/[k,u]probe_events. Returns os.ErrNotExist if symbol is not a valid
 // kernel symbol, or if it is not traceable with kprobes. Returns os.ErrExist
 // if a probe with the same group and symbol already exists.
-func createTraceFSProbeEvent(typ probeType, group, symbol, path string, offset, refCtrOffset uint64, ret bool) error {
+func createTraceFSProbeEvent(typ probeType, args probeArgs) error {
 	// Open the kprobe_events file in tracefs.
 	f, err := os.OpenFile(typ.EventsPath(), os.O_APPEND|os.O_WRONLY, 0666)
 	if err != nil {
@@ -346,7 +363,7 @@ func createTraceFSProbeEvent(typ probeType, group, symbol, path string, offset, 
 		// subsampling or rate limiting logic can be more accurately implemented in
 		// the eBPF program itself.
 		// See Documentation/kprobes.txt for more details.
-		pe = fmt.Sprintf("%s:%s/%s %s", probePrefix(ret), group, symbol, symbol)
+		pe = fmt.Sprintf("%s:%s/%s %s", probePrefix(args.ret), args.group, args.symbol, args.symbol)
 	case uprobeType:
 		// The uprobe_events syntax is as follows:
 		// p[:[GRP/]EVENT] PATH:OFFSET [FETCHARGS] : Set a probe
@@ -358,15 +375,14 @@ func createTraceFSProbeEvent(typ probeType, group, symbol, path string, offset, 
 		// p:ebpf_5678/main_mySymbol /bin/mybin:0x12345(0x123)
 		//
 		// See Documentation/trace/uprobetracer.txt for more details.
-		pathOffset := uprobePathOffset(path, offset, refCtrOffset)
-		pe = fmt.Sprintf("%s:%s/%s %s", probePrefix(ret), group, symbol, pathOffset)
+		pe = fmt.Sprintf("%s:%s/%s %s", probePrefix(args.ret), args.group, args.symbol, uprobeToken(args))
 	}
 	_, err = f.WriteString(pe)
 	// Since commit 97c753e62e6c, ENOENT is correctly returned instead of EINVAL
 	// when trying to create a kretprobe for a missing symbol. Make sure ENOENT
 	// is returned to the caller.
 	if errors.Is(err, os.ErrNotExist) || errors.Is(err, unix.EINVAL) {
-		return fmt.Errorf("symbol %s not found: %w", symbol, os.ErrNotExist)
+		return fmt.Errorf("symbol %s not found: %w", args.symbol, os.ErrNotExist)
 	}
 	if err != nil {
 		return fmt.Errorf("writing '%s' to '%s': %w", pe, typ.EventsPath(), err)

--- a/link/kprobe_test.go
+++ b/link/kprobe_test.go
@@ -97,14 +97,14 @@ func TestKprobeCreatePMU(t *testing.T) {
 	c := qt.New(t)
 
 	// kprobe happy path. printk is always present.
-	pk, err := pmuKprobe("printk", false)
+	pk, err := pmuKprobe(probeArgs{symbol: "printk"})
 	c.Assert(err, qt.IsNil)
 	defer pk.Close()
 
 	c.Assert(pk.typ, qt.Equals, kprobeEvent)
 
 	// kretprobe happy path.
-	pr, err := pmuKprobe("printk", true)
+	pr, err := pmuKprobe(probeArgs{symbol: "printk", ret: true})
 	c.Assert(err, qt.IsNil)
 	defer pr.Close()
 
@@ -112,12 +112,12 @@ func TestKprobeCreatePMU(t *testing.T) {
 
 	// Expect os.ErrNotExist when specifying a non-existent kernel symbol
 	// on kernels 4.17 and up.
-	_, err = pmuKprobe("bogus", false)
+	_, err = pmuKprobe(probeArgs{symbol: "bogus"})
 	c.Assert(errors.Is(err, os.ErrNotExist), qt.IsTrue, qt.Commentf("got error: %s", err))
 
 	// A kernel bug was fixed in 97c753e62e6c where EINVAL was returned instead
 	// of ENOENT, but only for kretprobes.
-	_, err = pmuKprobe("bogus", true)
+	_, err = pmuKprobe(probeArgs{symbol: "bogus", ret: true})
 	c.Assert(errors.Is(err, os.ErrNotExist), qt.IsTrue, qt.Commentf("got error: %s", err))
 }
 
@@ -125,7 +125,7 @@ func TestKprobeCreatePMU(t *testing.T) {
 func TestKprobePMUUnavailable(t *testing.T) {
 	c := qt.New(t)
 
-	pk, err := pmuKprobe("printk", false)
+	pk, err := pmuKprobe(probeArgs{symbol: "printk"})
 	if err == nil {
 		pk.Close()
 		t.Skipf("Kernel supports perf_kprobe PMU, not asserting error.")
@@ -137,7 +137,7 @@ func TestKprobePMUUnavailable(t *testing.T) {
 
 func BenchmarkKprobeCreatePMU(b *testing.B) {
 	for n := 0; n < b.N; n++ {
-		pr, err := pmuKprobe("printk", false)
+		pr, err := pmuKprobe(probeArgs{symbol: "printk"})
 		if err != nil {
 			b.Error("error creating perf_kprobe PMU:", err)
 		}
@@ -155,23 +155,23 @@ func TestKprobeTraceFS(t *testing.T) {
 	symbol := "printk"
 
 	// Open and close tracefs k(ret)probes, checking all errors.
-	kp, err := tracefsKprobe(symbol, false)
+	kp, err := tracefsKprobe(probeArgs{symbol: symbol})
 	c.Assert(err, qt.IsNil)
 	c.Assert(kp.Close(), qt.IsNil)
 	c.Assert(kp.typ, qt.Equals, kprobeEvent)
 
-	kp, err = tracefsKprobe(symbol, true)
+	kp, err = tracefsKprobe(probeArgs{symbol: symbol, ret: true})
 	c.Assert(err, qt.IsNil)
 	c.Assert(kp.Close(), qt.IsNil)
 	c.Assert(kp.typ, qt.Equals, kretprobeEvent)
 
 	// Create two identical trace events, ensure their IDs differ.
-	k1, err := tracefsKprobe(symbol, false)
+	k1, err := tracefsKprobe(probeArgs{symbol: symbol})
 	c.Assert(err, qt.IsNil)
 	defer k1.Close()
 	c.Assert(k1.tracefsID, qt.Not(qt.Equals), 0)
 
-	k2, err := tracefsKprobe(symbol, false)
+	k2, err := tracefsKprobe(probeArgs{symbol: symbol})
 	c.Assert(err, qt.IsNil)
 	defer k2.Close()
 	c.Assert(k2.tracefsID, qt.Not(qt.Equals), 0)
@@ -179,13 +179,17 @@ func TestKprobeTraceFS(t *testing.T) {
 	// Compare the kprobes' tracefs IDs.
 	c.Assert(k1.tracefsID, qt.Not(qt.CmpEquals()), k2.tracefsID)
 
+	// Prepare probe args.
+	args := probeArgs{group: "testgroup", symbol: "symbol"}
+
 	// Write a k(ret)probe event for a non-existing symbol.
-	err = createTraceFSProbeEvent(kprobeType, "testgroup", "bogus", "", 0, 0, false)
+	err = createTraceFSProbeEvent(kprobeType, args)
 	c.Assert(errors.Is(err, os.ErrNotExist), qt.IsTrue, qt.Commentf("got error: %s", err))
 
 	// A kernel bug was fixed in 97c753e62e6c where EINVAL was returned instead
 	// of ENOENT, but only for kretprobes.
-	err = createTraceFSProbeEvent(kprobeType, "testgroup", "bogus", "", 0, 0, true)
+	args.ret = true
+	err = createTraceFSProbeEvent(kprobeType, args)
 	c.Assert(errors.Is(err, os.ErrNotExist), qt.IsTrue, qt.Commentf("got error: %s", err))
 }
 
@@ -193,7 +197,7 @@ func BenchmarkKprobeCreateTraceFS(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		// Include <tracefs>/kprobe_events operations in the benchmark loop
 		// because we create one per perf event.
-		pr, err := tracefsKprobe("printk", false)
+		pr, err := tracefsKprobe(probeArgs{symbol: "printk"})
 		if err != nil {
 			b.Error("error creating tracefs perf event:", err)
 		}
@@ -223,24 +227,30 @@ func TestKprobeCreateTraceFS(t *testing.T) {
 		_ = closeTraceFSProbeEvent(kprobeType, rg, symbol)
 	}()
 
+	// Prepare probe args.
+	args := probeArgs{group: pg, symbol: symbol}
+
 	// Create a kprobe.
-	err := createTraceFSProbeEvent(kprobeType, pg, symbol, "", 0, 0, false)
+	err := createTraceFSProbeEvent(kprobeType, args)
 	c.Assert(err, qt.IsNil)
 
 	// Attempt to create an identical kprobe using tracefs,
 	// expect it to fail with os.ErrExist.
-	err = createTraceFSProbeEvent(kprobeType, pg, symbol, "", 0, 0, false)
+	err = createTraceFSProbeEvent(kprobeType, args)
 	c.Assert(errors.Is(err, os.ErrExist), qt.IsTrue,
 		qt.Commentf("expected consecutive kprobe creation to contain os.ErrExist, got: %v", err))
 
 	// Expect a successful close of the kprobe.
 	c.Assert(closeTraceFSProbeEvent(kprobeType, pg, symbol), qt.IsNil)
 
+	args.group = rg
+	args.ret = true
+
 	// Same test for a kretprobe.
-	err = createTraceFSProbeEvent(kprobeType, rg, symbol, "", 0, 0, true)
+	err = createTraceFSProbeEvent(kprobeType, args)
 	c.Assert(err, qt.IsNil)
 
-	err = createTraceFSProbeEvent(kprobeType, rg, symbol, "", 0, 0, true)
+	err = createTraceFSProbeEvent(kprobeType, args)
 	c.Assert(os.IsExist(err), qt.IsFalse,
 		qt.Commentf("expected consecutive kretprobe creation to contain os.ErrExist, got: %v", err))
 

--- a/link/kprobe_test.go
+++ b/link/kprobe_test.go
@@ -13,17 +13,15 @@ import (
 	"github.com/cilium/ebpf/internal/unix"
 )
 
-var (
-	kprobeSpec = ebpf.ProgramSpec{
-		Type:    ebpf.Kprobe,
-		License: "MIT",
-		Instructions: asm.Instructions{
-			// set exit code to 0
-			asm.Mov.Imm(asm.R0, 0),
-			asm.Return(),
-		},
-	}
-)
+var kprobeSpec = ebpf.ProgramSpec{
+	Type:    ebpf.Kprobe,
+	License: "MIT",
+	Instructions: asm.Instructions{
+		// set exit code to 0
+		asm.Mov.Imm(asm.R0, 0),
+		asm.Return(),
+	},
+}
 
 func TestKprobe(t *testing.T) {
 	c := qt.New(t)
@@ -93,7 +91,6 @@ func TestKprobeErrors(t *testing.T) {
 
 // Test k(ret)probe creation using perf_kprobe PMU.
 func TestKprobeCreatePMU(t *testing.T) {
-
 	// Requires at least 4.17 (e12f03d7031a "perf/core: Implement the 'perf_kprobe' PMU")
 	testutils.SkipOnOldKernel(t, "4.17", "perf_kprobe PMU")
 
@@ -183,12 +180,12 @@ func TestKprobeTraceFS(t *testing.T) {
 	c.Assert(k1.tracefsID, qt.Not(qt.CmpEquals()), k2.tracefsID)
 
 	// Write a k(ret)probe event for a non-existing symbol.
-	err = createTraceFSProbeEvent(kprobeType, "testgroup", "bogus", "", 0, false)
+	err = createTraceFSProbeEvent(kprobeType, "testgroup", "bogus", "", 0, 0, false)
 	c.Assert(errors.Is(err, os.ErrNotExist), qt.IsTrue, qt.Commentf("got error: %s", err))
 
 	// A kernel bug was fixed in 97c753e62e6c where EINVAL was returned instead
 	// of ENOENT, but only for kretprobes.
-	err = createTraceFSProbeEvent(kprobeType, "testgroup", "bogus", "", 0, true)
+	err = createTraceFSProbeEvent(kprobeType, "testgroup", "bogus", "", 0, 0, true)
 	c.Assert(errors.Is(err, os.ErrNotExist), qt.IsTrue, qt.Commentf("got error: %s", err))
 }
 
@@ -227,12 +224,12 @@ func TestKprobeCreateTraceFS(t *testing.T) {
 	}()
 
 	// Create a kprobe.
-	err := createTraceFSProbeEvent(kprobeType, pg, symbol, "", 0, false)
+	err := createTraceFSProbeEvent(kprobeType, pg, symbol, "", 0, 0, false)
 	c.Assert(err, qt.IsNil)
 
 	// Attempt to create an identical kprobe using tracefs,
 	// expect it to fail with os.ErrExist.
-	err = createTraceFSProbeEvent(kprobeType, pg, symbol, "", 0, false)
+	err = createTraceFSProbeEvent(kprobeType, pg, symbol, "", 0, 0, false)
 	c.Assert(errors.Is(err, os.ErrExist), qt.IsTrue,
 		qt.Commentf("expected consecutive kprobe creation to contain os.ErrExist, got: %v", err))
 
@@ -240,10 +237,10 @@ func TestKprobeCreateTraceFS(t *testing.T) {
 	c.Assert(closeTraceFSProbeEvent(kprobeType, pg, symbol), qt.IsNil)
 
 	// Same test for a kretprobe.
-	err = createTraceFSProbeEvent(kprobeType, rg, symbol, "", 0, true)
+	err = createTraceFSProbeEvent(kprobeType, rg, symbol, "", 0, 0, true)
 	c.Assert(err, qt.IsNil)
 
-	err = createTraceFSProbeEvent(kprobeType, rg, symbol, "", 0, true)
+	err = createTraceFSProbeEvent(kprobeType, rg, symbol, "", 0, 0, true)
 	c.Assert(os.IsExist(err), qt.IsFalse,
 		qt.Commentf("expected consecutive kretprobe creation to contain os.ErrExist, got: %v", err))
 

--- a/link/uprobe.go
+++ b/link/uprobe.go
@@ -27,12 +27,15 @@ var (
 	}{}
 
 	uprobeRefCtrOffsetPMUPath = "/sys/bus/event_source/devices/uprobe/format/ref_ctr_offset"
-	uprobeRefCtrOffsetPMU     = struct {
-		once sync.Once
-		err  error
-	}{}
 	// elixir.bootlin.com/linux/v5.15-rc7/source/kernel/events/core.c#L9799
 	uprobeRefCtrOffsetShift = 32
+	haveRefCtrOffsetPMU     = internal.FeatureTest("RefCtrOffsetPMU", "4.20", func() error {
+		_, err := os.Stat(uprobeRefCtrOffsetPMUPath)
+		if err != nil {
+			return internal.ErrNotSupported
+		}
+		return nil
+	})
 
 	// ErrNoSymbol indicates that the given symbol was not found
 	// in the ELF symbols table.
@@ -58,7 +61,12 @@ type UprobeOptions struct {
 	PID int
 	// Automatically manage SDT reference counts (semaphores).
 	//
+	// If this field is set, the Kernel will increment/decrement the
+	// semaphore located in the process memory at the provided address on
+	// probe attach/detach.
+	//
 	// See also:
+	// sourceware.org/systemtap/wiki/UserSpaceProbeImplementation (Semaphore Handling)
 	// github.com/torvalds/linux/commit/1cc33161a83d
 	// github.com/torvalds/linux/commit/a6ca88b241d5
 	RefCtrOffset uint64
@@ -239,11 +247,12 @@ func (ex *Executable) uprobe(symbol string, prog *ebpf.Program, opts *UprobeOpti
 	if prog.Type() != ebpf.Kprobe {
 		return nil, fmt.Errorf("eBPF program type %s is not Kprobe: %w", prog.Type(), errInvalidInput)
 	}
+	if opts == nil {
+		opts = &UprobeOptions{}
+	}
 
-	var offset uint64
-	if opts != nil && opts.Offset != 0 {
-		offset = opts.Offset
-	} else {
+	offset := opts.Offset
+	if offset == 0 {
 		off, err := ex.offset(symbol)
 		if err != nil {
 			return nil, err
@@ -251,21 +260,28 @@ func (ex *Executable) uprobe(symbol string, prog *ebpf.Program, opts *UprobeOpti
 		offset = off
 	}
 
-	pid := perfAllThreads
-	if opts != nil && opts.PID != 0 {
-		pid = opts.PID
+	pid := opts.PID
+	if pid == 0 {
+		pid = perfAllThreads
 	}
 
-	var refCtrOffset uint64
-	if opts != nil && opts.RefCtrOffset != 0 {
-		if err := readUprobeRefCtrOffsetPMU(); err != nil {
-			return nil, fmt.Errorf("ref_ctr_offset not supported: %w", err)
+	if opts.RefCtrOffset != 0 {
+		if err := haveRefCtrOffsetPMU(); err != nil {
+			return nil, fmt.Errorf("uprobe ref_ctr_offset: %w", err)
 		}
-		refCtrOffset = opts.RefCtrOffset
+	}
+
+	args := probeArgs{
+		symbol:       symbol,
+		path:         ex.path,
+		offset:       offset,
+		pid:          pid,
+		refCtrOffset: opts.RefCtrOffset,
+		ret:          ret,
 	}
 
 	// Use uprobe PMU if the kernel has it available.
-	tp, err := pmuUprobe(symbol, ex.path, offset, pid, refCtrOffset, ret)
+	tp, err := pmuUprobe(args)
 	if err == nil {
 		return tp, nil
 	}
@@ -274,7 +290,8 @@ func (ex *Executable) uprobe(symbol string, prog *ebpf.Program, opts *UprobeOpti
 	}
 
 	// Use tracefs if uprobe PMU is missing.
-	tp, err = tracefsUprobe(uprobeSanitizedSymbol(symbol), ex.path, offset, pid, refCtrOffset, ret)
+	args.symbol = uprobeSanitizedSymbol(symbol)
+	tp, err = tracefsUprobe(args)
 	if err != nil {
 		return nil, fmt.Errorf("creating trace event '%s:%s' in tracefs: %w", ex.path, symbol, err)
 	}
@@ -283,13 +300,13 @@ func (ex *Executable) uprobe(symbol string, prog *ebpf.Program, opts *UprobeOpti
 }
 
 // pmuUprobe opens a perf event based on the uprobe PMU.
-func pmuUprobe(symbol, path string, offset uint64, pid int, refCtrOffset uint64, ret bool) (*perfEvent, error) {
-	return pmuProbe(uprobeType, symbol, path, offset, pid, refCtrOffset, ret)
+func pmuUprobe(args probeArgs) (*perfEvent, error) {
+	return pmuProbe(uprobeType, args)
 }
 
 // tracefsUprobe creates a Uprobe tracefs entry.
-func tracefsUprobe(symbol, path string, offset uint64, pid int, refCtrOffset uint64, ret bool) (*perfEvent, error) {
-	return tracefsProbe(uprobeType, symbol, path, offset, pid, refCtrOffset, ret)
+func tracefsUprobe(args probeArgs) (*perfEvent, error) {
+	return tracefsProbe(uprobeType, args)
 }
 
 // uprobeSanitizedSymbol replaces every invalid characted for the tracefs api with an underscore.
@@ -297,14 +314,14 @@ func uprobeSanitizedSymbol(symbol string) string {
 	return rgxUprobeSymbol.ReplaceAllString(symbol, "_")
 }
 
-// uprobePathOffset creates the PATH:OFFSET(REF_CTR_OFFSET) token for the tracefs api.
-func uprobePathOffset(path string, offset, refCtrOffset uint64) string {
-	po := fmt.Sprintf("%s:%#x", path, offset)
+// uprobeToken creates the PATH:OFFSET(REF_CTR_OFFSET) token for the tracefs api.
+func uprobeToken(args probeArgs) string {
+	po := fmt.Sprintf("%s:%#x", args.path, args.offset)
 
-	if refCtrOffset != 0 {
+	if args.refCtrOffset != 0 {
 		// This is not documented in Documentation/trace/uprobetracer.txt.
-		// https://elixir.bootlin.com/linux/v5.15-rc7/source/kernel/trace/trace.c#L5564
-		po += fmt.Sprintf("(%#x)", refCtrOffset)
+		// elixir.bootlin.com/linux/v5.15-rc7/source/kernel/trace/trace.c#L5564
+		po += fmt.Sprintf("(%#x)", args.refCtrOffset)
 	}
 
 	return po
@@ -315,15 +332,4 @@ func uretprobeBit() (uint64, error) {
 		uprobeRetprobeBit.value, uprobeRetprobeBit.err = determineRetprobeBit(uprobeType)
 	})
 	return uprobeRetprobeBit.value, uprobeRetprobeBit.err
-}
-
-// readUprobeRefCtrOffsetPMU asserts uprobeRefCtrOffsetPMUPath exists.
-func readUprobeRefCtrOffsetPMU() error {
-	uprobeRefCtrOffsetPMU.once.Do(func() {
-		_, err := os.Stat(uprobeRefCtrOffsetPMUPath)
-		if err != nil {
-			uprobeRefCtrOffsetPMU.err = internal.ErrNotSupported
-		}
-	})
-	return uprobeRefCtrOffsetPMU.err
 }

--- a/link/uprobe_test.go
+++ b/link/uprobe_test.go
@@ -148,14 +148,14 @@ func TestUprobeCreatePMU(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 
 	// uprobe PMU
-	pu, err := pmuUprobe(bashSym, bashEx.path, off, perfAllThreads, false)
+	pu, err := pmuUprobe(bashSym, bashEx.path, off, perfAllThreads, 0, false)
 	c.Assert(err, qt.IsNil)
 	defer pu.Close()
 
 	c.Assert(pu.typ, qt.Equals, uprobeEvent)
 
 	// uretprobe PMU
-	pr, err := pmuUprobe(bashSym, bashEx.path, off, perfAllThreads, true)
+	pr, err := pmuUprobe(bashSym, bashEx.path, off, perfAllThreads, 0, true)
 	c.Assert(err, qt.IsNil)
 	defer pr.Close()
 
@@ -170,7 +170,7 @@ func TestUprobePMUUnavailable(t *testing.T) {
 	off, err := bashEx.offset(bashSym)
 	c.Assert(err, qt.IsNil)
 
-	pk, err := pmuUprobe(bashSym, bashEx.path, off, perfAllThreads, false)
+	pk, err := pmuUprobe(bashSym, bashEx.path, off, perfAllThreads, 0, false)
 	if err == nil {
 		pk.Close()
 		t.Skipf("Kernel supports perf_uprobe PMU, not asserting error.")
@@ -192,23 +192,23 @@ func TestUprobeTraceFS(t *testing.T) {
 	ssym := uprobeSanitizedSymbol(bashSym)
 
 	// Open and close tracefs u(ret)probes, checking all errors.
-	up, err := tracefsUprobe(ssym, bashEx.path, off, perfAllThreads, false)
+	up, err := tracefsUprobe(ssym, bashEx.path, off, perfAllThreads, 0, false)
 	c.Assert(err, qt.IsNil)
 	c.Assert(up.Close(), qt.IsNil)
 	c.Assert(up.typ, qt.Equals, uprobeEvent)
 
-	up, err = tracefsUprobe(ssym, bashEx.path, off, perfAllThreads, true)
+	up, err = tracefsUprobe(ssym, bashEx.path, off, perfAllThreads, 0, true)
 	c.Assert(err, qt.IsNil)
 	c.Assert(up.Close(), qt.IsNil)
 	c.Assert(up.typ, qt.Equals, uretprobeEvent)
 
 	// Create two identical trace events, ensure their IDs differ.
-	u1, err := tracefsUprobe(ssym, bashEx.path, off, perfAllThreads, false)
+	u1, err := tracefsUprobe(ssym, bashEx.path, off, perfAllThreads, 0, false)
 	c.Assert(err, qt.IsNil)
 	defer u1.Close()
 	c.Assert(u1.tracefsID, qt.Not(qt.Equals), 0)
 
-	u2, err := tracefsUprobe(ssym, bashEx.path, off, perfAllThreads, false)
+	u2, err := tracefsUprobe(ssym, bashEx.path, off, perfAllThreads, 0, false)
 	c.Assert(err, qt.IsNil)
 	defer u2.Close()
 	c.Assert(u2.tracefsID, qt.Not(qt.Equals), 0)
@@ -243,12 +243,12 @@ func TestUprobeCreateTraceFS(t *testing.T) {
 	}()
 
 	// Create a uprobe.
-	err = createTraceFSProbeEvent(uprobeType, pg, ssym, bashEx.path, off, false)
+	err = createTraceFSProbeEvent(uprobeType, pg, ssym, bashEx.path, off, 0, false)
 	c.Assert(err, qt.IsNil)
 
 	// Attempt to create an identical uprobe using tracefs,
 	// expect it to fail with os.ErrExist.
-	err = createTraceFSProbeEvent(uprobeType, pg, ssym, bashEx.path, off, false)
+	err = createTraceFSProbeEvent(uprobeType, pg, ssym, bashEx.path, off, 0, false)
 	c.Assert(errors.Is(err, os.ErrExist), qt.IsTrue,
 		qt.Commentf("expected consecutive uprobe creation to contain os.ErrExist, got: %v", err))
 
@@ -256,10 +256,10 @@ func TestUprobeCreateTraceFS(t *testing.T) {
 	c.Assert(closeTraceFSProbeEvent(uprobeType, pg, ssym), qt.IsNil)
 
 	// Same test for a kretprobe.
-	err = createTraceFSProbeEvent(uprobeType, rg, ssym, bashEx.path, off, true)
+	err = createTraceFSProbeEvent(uprobeType, rg, ssym, bashEx.path, off, 0, true)
 	c.Assert(err, qt.IsNil)
 
-	err = createTraceFSProbeEvent(uprobeType, rg, ssym, bashEx.path, off, true)
+	err = createTraceFSProbeEvent(uprobeType, rg, ssym, bashEx.path, off, 0, true)
 	c.Assert(os.IsExist(err), qt.IsFalse,
 		qt.Commentf("expected consecutive uretprobe creation to contain os.ErrExist, got: %v", err))
 
@@ -290,19 +290,21 @@ func TestUprobeSanitizedSymbol(t *testing.T) {
 
 func TestUprobePathOffset(t *testing.T) {
 	tests := []struct {
-		path     string
-		offset   uint64
-		expected string
+		path                 string
+		offset, refCtrOffset uint64
+		expected             string
 	}{
-		{"/bin/bash", 0, "/bin/bash:0x0"},
-		{"/bin/bash", 1, "/bin/bash:0x1"},
-		{"/bin/bash", 65535, "/bin/bash:0xffff"},
-		{"/bin/bash", 65536, "/bin/bash:0x10000"},
+		{"/bin/bash", 0, 0, "/bin/bash:0x0"},
+		{"/bin/bash", 1, 0, "/bin/bash:0x1"},
+		{"/bin/bash", 65535, 0, "/bin/bash:0xffff"},
+		{"/bin/bash", 65536, 0, "/bin/bash:0x10000"},
+		{"/bin/bash", 1, 1, "/bin/bash:0x1(0x1)"},
+		{"/bin/bash", 1, 65535, "/bin/bash:0x1(0xffff)"},
 	}
 
 	for i, tt := range tests {
 		t.Run(fmt.Sprint(i), func(t *testing.T) {
-			po := uprobePathOffset(tt.path, tt.offset)
+			po := uprobePathOffset(tt.path, tt.offset, tt.refCtrOffset)
 			if tt.expected != po {
 				t.Errorf("Expected path:offset to be '%s', got '%s'", tt.expected, po)
 			}
@@ -416,4 +418,13 @@ func TestUprobeProgramWrongPID(t *testing.T) {
 
 	// Assert that the value at index 0 is still 0.
 	assertMapValue(t, m, 0, 0)
+}
+
+func TestReadUprobeRefCtrOffsetPMU(t *testing.T) {
+	testutils.SkipOnOldKernel(t, "4.20", "ref_ctr_offset PMU")
+
+	err := readUprobeRefCtrOffsetPMU()
+	if err != nil {
+		t.Fatal(err)
+	}
 }

--- a/link/uprobe_test.go
+++ b/link/uprobe_test.go
@@ -147,15 +147,24 @@ func TestUprobeCreatePMU(t *testing.T) {
 	off, err := bashEx.offset(bashSym)
 	c.Assert(err, qt.IsNil)
 
+	// Prepare probe args.
+	args := probeArgs{
+		symbol: bashSym,
+		path:   bashEx.path,
+		offset: off,
+		pid:    perfAllThreads,
+	}
+
 	// uprobe PMU
-	pu, err := pmuUprobe(bashSym, bashEx.path, off, perfAllThreads, 0, false)
+	pu, err := pmuUprobe(args)
 	c.Assert(err, qt.IsNil)
 	defer pu.Close()
 
 	c.Assert(pu.typ, qt.Equals, uprobeEvent)
 
 	// uretprobe PMU
-	pr, err := pmuUprobe(bashSym, bashEx.path, off, perfAllThreads, 0, true)
+	args.ret = true
+	pr, err := pmuUprobe(args)
 	c.Assert(err, qt.IsNil)
 	defer pr.Close()
 
@@ -170,7 +179,15 @@ func TestUprobePMUUnavailable(t *testing.T) {
 	off, err := bashEx.offset(bashSym)
 	c.Assert(err, qt.IsNil)
 
-	pk, err := pmuUprobe(bashSym, bashEx.path, off, perfAllThreads, 0, false)
+	// Prepare probe args.
+	args := probeArgs{
+		symbol: bashSym,
+		path:   bashEx.path,
+		offset: off,
+		pid:    perfAllThreads,
+	}
+
+	pk, err := pmuUprobe(args)
 	if err == nil {
 		pk.Close()
 		t.Skipf("Kernel supports perf_uprobe PMU, not asserting error.")
@@ -188,27 +205,34 @@ func TestUprobeTraceFS(t *testing.T) {
 	off, err := bashEx.offset(bashSym)
 	c.Assert(err, qt.IsNil)
 
-	// Sanitize the symbol in order to be used in tracefs API.
-	ssym := uprobeSanitizedSymbol(bashSym)
+	// Prepare probe args.
+	args := probeArgs{
+		symbol: uprobeSanitizedSymbol(bashSym),
+		path:   bashEx.path,
+		offset: off,
+		pid:    perfAllThreads,
+	}
 
 	// Open and close tracefs u(ret)probes, checking all errors.
-	up, err := tracefsUprobe(ssym, bashEx.path, off, perfAllThreads, 0, false)
+	up, err := tracefsUprobe(args)
 	c.Assert(err, qt.IsNil)
 	c.Assert(up.Close(), qt.IsNil)
 	c.Assert(up.typ, qt.Equals, uprobeEvent)
 
-	up, err = tracefsUprobe(ssym, bashEx.path, off, perfAllThreads, 0, true)
+	args.ret = true
+	up, err = tracefsUprobe(args)
 	c.Assert(err, qt.IsNil)
 	c.Assert(up.Close(), qt.IsNil)
 	c.Assert(up.typ, qt.Equals, uretprobeEvent)
 
 	// Create two identical trace events, ensure their IDs differ.
-	u1, err := tracefsUprobe(ssym, bashEx.path, off, perfAllThreads, 0, false)
+	args.ret = false
+	u1, err := tracefsUprobe(args)
 	c.Assert(err, qt.IsNil)
 	defer u1.Close()
 	c.Assert(u1.tracefsID, qt.Not(qt.Equals), 0)
 
-	u2, err := tracefsUprobe(ssym, bashEx.path, off, perfAllThreads, 0, false)
+	u2, err := tracefsUprobe(args)
 	c.Assert(err, qt.IsNil)
 	defer u2.Close()
 	c.Assert(u2.tracefsID, qt.Not(qt.Equals), 0)
@@ -242,24 +266,35 @@ func TestUprobeCreateTraceFS(t *testing.T) {
 		_ = closeTraceFSProbeEvent(uprobeType, rg, ssym)
 	}()
 
+	// Prepare probe args.
+	args := probeArgs{
+		group:  pg,
+		symbol: ssym,
+		path:   bashEx.path,
+		offset: off,
+	}
+
 	// Create a uprobe.
-	err = createTraceFSProbeEvent(uprobeType, pg, ssym, bashEx.path, off, 0, false)
+	err = createTraceFSProbeEvent(uprobeType, args)
 	c.Assert(err, qt.IsNil)
 
 	// Attempt to create an identical uprobe using tracefs,
 	// expect it to fail with os.ErrExist.
-	err = createTraceFSProbeEvent(uprobeType, pg, ssym, bashEx.path, off, 0, false)
+	err = createTraceFSProbeEvent(uprobeType, args)
 	c.Assert(errors.Is(err, os.ErrExist), qt.IsTrue,
 		qt.Commentf("expected consecutive uprobe creation to contain os.ErrExist, got: %v", err))
 
 	// Expect a successful close of the kprobe.
 	c.Assert(closeTraceFSProbeEvent(uprobeType, pg, ssym), qt.IsNil)
 
+	args.group = rg
+	args.ret = true
+
 	// Same test for a kretprobe.
-	err = createTraceFSProbeEvent(uprobeType, rg, ssym, bashEx.path, off, 0, true)
+	err = createTraceFSProbeEvent(uprobeType, args)
 	c.Assert(err, qt.IsNil)
 
-	err = createTraceFSProbeEvent(uprobeType, rg, ssym, bashEx.path, off, 0, true)
+	err = createTraceFSProbeEvent(uprobeType, args)
 	c.Assert(os.IsExist(err), qt.IsFalse,
 		qt.Commentf("expected consecutive uretprobe creation to contain os.ErrExist, got: %v", err))
 
@@ -288,23 +323,22 @@ func TestUprobeSanitizedSymbol(t *testing.T) {
 	}
 }
 
-func TestUprobePathOffset(t *testing.T) {
+func TestUprobeToken(t *testing.T) {
 	tests := []struct {
-		path                 string
-		offset, refCtrOffset uint64
-		expected             string
+		args     probeArgs
+		expected string
 	}{
-		{"/bin/bash", 0, 0, "/bin/bash:0x0"},
-		{"/bin/bash", 1, 0, "/bin/bash:0x1"},
-		{"/bin/bash", 65535, 0, "/bin/bash:0xffff"},
-		{"/bin/bash", 65536, 0, "/bin/bash:0x10000"},
-		{"/bin/bash", 1, 1, "/bin/bash:0x1(0x1)"},
-		{"/bin/bash", 1, 65535, "/bin/bash:0x1(0xffff)"},
+		{probeArgs{path: "/bin/bash"}, "/bin/bash:0x0"},
+		{probeArgs{path: "/bin/bash", offset: 1}, "/bin/bash:0x1"},
+		{probeArgs{path: "/bin/bash", offset: 65535}, "/bin/bash:0xffff"},
+		{probeArgs{path: "/bin/bash", offset: 65536}, "/bin/bash:0x10000"},
+		{probeArgs{path: "/bin/bash", offset: 1, refCtrOffset: 1}, "/bin/bash:0x1(0x1)"},
+		{probeArgs{path: "/bin/bash", offset: 1, refCtrOffset: 65535}, "/bin/bash:0x1(0xffff)"},
 	}
 
 	for i, tt := range tests {
 		t.Run(fmt.Sprint(i), func(t *testing.T) {
-			po := uprobePathOffset(tt.path, tt.offset, tt.refCtrOffset)
+			po := uprobeToken(tt.args)
 			if tt.expected != po {
 				t.Errorf("Expected path:offset to be '%s', got '%s'", tt.expected, po)
 			}
@@ -420,11 +454,6 @@ func TestUprobeProgramWrongPID(t *testing.T) {
 	assertMapValue(t, m, 0, 0)
 }
 
-func TestReadUprobeRefCtrOffsetPMU(t *testing.T) {
-	testutils.SkipOnOldKernel(t, "4.20", "ref_ctr_offset PMU")
-
-	err := readUprobeRefCtrOffsetPMU()
-	if err != nil {
-		t.Fatal(err)
-	}
+func TestHaveRefCtrOffsetPMU(t *testing.T) {
+	testutils.CheckFeatureTest(t, haveRefCtrOffsetPMU)
 }


### PR DESCRIPTION
This option should simplify implementing `USDT` probes on top of `link.Uprobe`