### PR TITLE
features: fix HaveProgType(ebpf.Syscall)

### DIFF
--- a/features/prog.go
+++ b/features/prog.go
@@ -29,6 +29,7 @@ type progCache struct {
 
 func createProgLoadAttr(pt ebpf.ProgramType) (*sys.ProgLoadAttr, error) {
 	var expectedAttachType ebpf.AttachType
+	var progFlags uint32
 
 	insns := asm.Instructions{
 		asm.LoadImm(asm.R0, 0, asm.DWord),
@@ -52,6 +53,8 @@ func createProgLoadAttr(pt ebpf.ProgramType) (*sys.ProgLoadAttr, error) {
 		expectedAttachType = ebpf.AttachCGroupGetsockopt
 	case ebpf.SkLookup:
 		expectedAttachType = ebpf.AttachSkLookup
+	case ebpf.Syscall:
+		progFlags = unix.BPF_F_SLEEPABLE
 	default:
 		expectedAttachType = ebpf.AttachNone
 	}
@@ -69,6 +72,7 @@ func createProgLoadAttr(pt ebpf.ProgramType) (*sys.ProgLoadAttr, error) {
 		ProgType:           sys.ProgType(pt),
 		Insns:              instructions,
 		InsnCnt:            uint32(len(bytecode) / asm.InstructionSize),
+		ProgFlags:          progFlags,
 		ExpectedAttachType: sys.AttachType(expectedAttachType),
 		License:            sys.NewStringPointer("GPL"),
 		KernVersion:        kv,

--- a/features/prog_test.go
+++ b/features/prog_test.go
@@ -66,10 +66,6 @@ func TestHaveProgType(t *testing.T) {
 			}
 			testutils.SkipOnOldKernel(t, minVersion, feature)
 
-			if pt == ebpf.Syscall {
-				t.Skip("HaveProgType(Syscall) is broken on 5.14")
-			}
-
 			if err := HaveProgType(pt); err != nil {
 				if pt == ebpf.LircMode2 {
 					// CI kernels are built with CONFIG_BPF_LIRC_MODE2, but some


### PR DESCRIPTION
BPF Syscall programs need to be sleepable which is enforced by the
verifier. So we need to set the correct program flags before executing
the feature probe.

Fixes #464.

Signed-off-by: Robin Gögge <r.goegge@gmail.com>