### PR TITLE
various CI fixes

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -104,6 +104,7 @@ fetch "${kernel}"
 cp "${tmp_dir}/${kernel}" "${input}/bzImage"
 
 if fetch "${selftests}"; then
+  echo "Decompressing selftests"
   mkdir "${input}/bpf"
   tar --strip-components=4 -xjf "${tmp_dir}/${selftests}" -C "${input}/bpf"
 else

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -90,7 +90,7 @@ fi
 shift
 
 readonly kernel="linux-${kernel_version}.bz"
-readonly selftests="linux-${kernel_version}-selftests-bpf.bz"
+readonly selftests="linux-${kernel_version}-selftests-bpf.tgz"
 readonly input="$(mktemp -d)"
 readonly tmp_dir="${TMPDIR:-/tmp}"
 readonly branch="${BRANCH:-master}"
@@ -110,7 +110,7 @@ cp "${tmp_dir}/${kernel}" "${input}/bzImage"
 if fetch "${selftests}"; then
   echo "Decompressing selftests"
   mkdir "${input}/bpf"
-  tar --strip-components=4 -xjf "${tmp_dir}/${selftests}" -C "${input}/bpf"
+  tar --strip-components=4 -xf "${tmp_dir}/${selftests}" -C "${input}/bpf"
 else
   echo "No selftests found, disabling"
 fi

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -97,7 +97,11 @@ readonly branch="${BRANCH:-master}"
 
 fetch() {
     echo Fetching "${1}"
-    wget -nv -N -P "${tmp_dir}" "https://github.com/cilium/ci-kernels/raw/${branch}/${1}"
+    pushd "${tmp_dir}" > /dev/null
+    curl -s -L -O --fail --etag-compare "${1}.etag" --etag-save "${1}.etag" "https://github.com/cilium/ci-kernels/raw/${branch}/${1}"
+    local ret=$?
+    popd > /dev/null
+    return $ret
 }
 
 fetch "${kernel}"


### PR DESCRIPTION
I went down a rabbit hole of trying to squeeze out faster builds, TL;DR: not much success. I originally thought that we waste time on bzip2 decompression, but that turned out to be a red herring. It's just that semaphore UI gives dodgy timestamps in the log.

Using tgz vs. bz2 still makes sense and using curl with etags also avoids unnecessary downloads, so there is no harm in merging these.