### PR TITLE
examples: minor tracepoint formatting

### DIFF
--- a/examples/tracepoint_in_c/bpf/handler.c
+++ b/examples/tracepoint_in_c/bpf/handler.c
@@ -11,7 +11,7 @@ struct bpf_map_def SEC("maps") counting_map = {
 	.max_entries = 1,
 };
 
-// This struct is defined according to the following format file.
+// This struct is defined according to the following format file:
 // /sys/kernel/debug/tracing/events/kmem/mm_page_alloc/format
 struct alloc_info {
 	/* The first 8 bytes is not allowed to read */
@@ -23,7 +23,7 @@ struct alloc_info {
 	int migratetype;
 };
 
-// This tracepoint is define in mm/page_alloc.c:__alloc_pages_nodemask()
+// This tracepoint is defined in mm/page_alloc.c:__alloc_pages_nodemask()
 // Userspace pathname: /sys/kernel/debug/tracing/events/kmem/mm_page_alloc
 SEC("tracepoint/kmem/mm_page_alloc")
 int mm_page_alloc(struct alloc_info *info) {

--- a/examples/tracepoint_in_c/main.go
+++ b/examples/tracepoint_in_c/main.go
@@ -25,7 +25,6 @@ const mapKey uint32 = 0
 
 func main() {
 
-	// Name of the kernel function to trace.
 	// Subscribe to signals for terminating the program.
 	stopper := make(chan os.Signal, 1)
 	signal.Notify(stopper, os.Interrupt, syscall.SIGTERM)
@@ -65,7 +64,7 @@ func main() {
 			if err := objs.CountingMap.Lookup(mapKey, &value); err != nil {
 				log.Fatalf("reading map: %v", err)
 			}
-			log.Printf("%v times\n", value)
+			log.Printf("%v times", value)
 		case <-stopper:
 			return
 		}


### PR DESCRIPTION
After working through the awesome tracepoint examples, I fixed a couple of formatting nits.