### PR TITLE
Makefile: prefer podman for container engine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ UIDGID := $(shell stat -c '%u:%g' ${REPODIR})
 # Prefer podman if installed, otherwise use docker.
 # Note: Setting the var at runtime will always override.
 CONTAINER_ENGINE ?= $(if $(shell command -v podman), podman, docker)
-CONTAINER_RUN_ARGS ?= --user "${UIDGID}"
+CONTAINER_RUN_ARGS ?= $(if $(filter ${CONTAINER_ENGINE}, podman),, --user "${UIDGID}")
 
 IMAGE := $(shell cat ${REPODIR}/testdata/docker/IMAGE)
 VERSION := $(shell cat ${REPODIR}/testdata/docker/VERSION)

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,9 @@ CFLAGS := -O2 -g -Wall -Werror $(CFLAGS)
 REPODIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 UIDGID := $(shell stat -c '%u:%g' ${REPODIR})
 
-CONTAINER_ENGINE ?= docker
+# Prefer podman if installed, otherwise use docker.
+# Note: Setting the var at runtime will always override.
+CONTAINER_ENGINE ?= $(if $(shell command -v podman), podman, docker)
 CONTAINER_RUN_ARGS ?= --user "${UIDGID}"
 
 IMAGE := $(shell cat ${REPODIR}/testdata/docker/IMAGE)


### PR DESCRIPTION
Ref: https://github.com/cilium/ebpf/issues/479

Usage:
```
# If podman is found on the system, then it is preferred. Otherwise fall back to using docker.
# Passing the variable at runtime will always take precedence:
$ command -v podman
/bin/podman
$ CONTAINER_ENGINE=docker make container-all
docker run --rm --user "1000:985" \
...
$ make container-all
podman run --rm  \
...
# Override container run args
$ CONTAINER_RUN_ARGS='--user "1000:985"' make container-all
podman run --rm --user "1000:985" \
...
# Override both
$ CONTAINER_ENGINE=docker CONTAINER_RUN_ARGS='--name=cilium-ebpf' make container-all
docker run --rm --name=cilium-ebpf \
...
```