### PR TITLE
implement BPF_PROG_BIND_MAP

### DIFF
--- a/internal/cmd/gentypes/.gitignore
+++ b/internal/cmd/gentypes/.gitignore
@@ -1,0 +1,1 @@
+gentypes

--- a/internal/cmd/gentypes/main.go
+++ b/internal/cmd/gentypes/main.go
@@ -266,6 +266,10 @@ import (
 			},
 		},
 		{
+			"ProgBindMap", retError, "prog_bind_map", "BPF_PROG_BIND_MAP",
+			nil,
+		},
+		{
 			"ObjPin", retError, "obj_pin", "BPF_OBJ_PIN",
 			[]patch{replace(pointer, "pathname")},
 		},

--- a/internal/sys/types.go
+++ b/internal/sys/types.go
@@ -810,6 +810,17 @@ func ProgAttach(attr *ProgAttachAttr) error {
 	return err
 }
 
+type ProgBindMapAttr struct {
+	ProgFd uint32
+	MapFd  uint32
+	Flags  uint32
+}
+
+func ProgBindMap(attr *ProgBindMapAttr) error {
+	_, err := BPF(BPF_PROG_BIND_MAP, unsafe.Pointer(attr), unsafe.Sizeof(*attr))
+	return err
+}
+
 type ProgDetachAttr struct {
 	TargetFd    uint32
 	AttachBpfFd uint32

--- a/prog.go
+++ b/prog.go
@@ -697,6 +697,19 @@ func (p *Program) ID() (ProgramID, error) {
 	return ProgramID(info.Id), nil
 }
 
+// BindMap binds map to the program and is only released once program is released.
+//
+// This may be used in cases where metadata should be associated with the program
+// which otherwise does not contain any references to the map.
+func (p *Program) BindMap(m *Map) error {
+	attr := &sys.ProgBindMapAttr{
+		ProgFd: uint32(p.FD()),
+		MapFd:  uint32(m.FD()),
+	}
+
+	return sys.ProgBindMap(attr)
+}
+
 func resolveBTFType(spec *btf.Spec, name string, progType ProgramType, attachType AttachType) (btf.Type, error) {
 	type match struct {
 		p ProgramType

--- a/prog_test.go
+++ b/prog_test.go
@@ -677,6 +677,34 @@ func TestProgramTargetBTF(t *testing.T) {
 	}
 }
 
+func TestProgramBindMap(t *testing.T) {
+	testutils.SkipOnOldKernel(t, "5.10", "BPF_PROG_BIND_MAP")
+
+	arr, err := NewMap(&MapSpec{
+		Type:       Array,
+		KeySize:    4,
+		ValueSize:  4,
+		MaxEntries: 1,
+	})
+	if err != nil {
+		t.Errorf("Failed to load map: %v", err)
+	}
+	defer arr.Close()
+
+	prog, err := NewProgram(socketFilterSpec)
+	if err != nil {
+		t.Errorf("Failed to load program: %v", err)
+	}
+	defer prog.Close()
+
+	// The attached map does not contain BTF information. So
+	// the metadata part of the program will be empty. This
+	// test just makes sure that we can bind a map to a program.
+	if err := prog.BindMap(arr); err != nil {
+		t.Errorf("Failed to bind map to program: %v", err)
+	}
+}
+
 type testReaderAt struct {
 	file *os.File
 	read bool


### PR DESCRIPTION
This PR implements the BPF_PROG_BIND_MAP functionality. While in general every map can be bind to a program, `bpftool` will only output and interpret data as metadata if the map meets some criteria:
https://github.com/torvalds/linux/blob/66f4beaa6c1d28161f534471484b2daa2de1dce0/tools/bpf/bpftool/prog.c#L212-L219

 