### PR TITLE
Fix LINUX_VERSION_CODE handling of 4.14.252+

### DIFF
--- a/internal/version.go
+++ b/internal/version.go
@@ -76,14 +76,20 @@ func (v Version) Kernel() uint32 {
 	// Kernels 4.4 and 4.9 have their SUBLEVEL clamped to 255 to avoid
 	// overflowing into PATCHLEVEL.
 	// See kernel commit 9b82f13e7ef3 ("kbuild: clamp SUBLEVEL to 255").
-	s := v[2]
-	if s > 255 {
-		s = 255
+	maj, min, sub := v[0], v[1], v[2]
+	if sub > 255 {
+		sub = 255
+	}
+
+	// clamp SUBLEVEL to 255 EARLY in 4.14.252 because they merged this too early:
+	// https://github.com/torvalds/linux/commit/e131e0e880f942f138c4b5e6af944c7ddcd7ec96
+	if maj == 4 && min == 14 && sub >= 252 {
+		sub = 255
 	}
 
 	// Truncate members to uint8 to prevent them from spilling over into
 	// each other when overflowing 8 bits.
-	return uint32(uint8(v[0]))<<16 | uint32(uint8(v[1]))<<8 | uint32(uint8(s))
+	return uint32(uint8(maj))<<16 | uint32(uint8(min))<<8 | uint32(uint8(sub))
 }
 
 // KernelVersion returns the version of the currently running kernel.

--- a/internal/version_test.go
+++ b/internal/version_test.go
@@ -40,6 +40,11 @@ func TestKernelVersion(t *testing.T) {
 		t.Errorf("256.256.256 should result in a kernel version of %d, got: %d", want, v.Kernel())
 	}
 
+	// kernel tree 4.14 clamps SUBLEVEL to 255 early at 252
+	if v, want := (Version{4, 14, 252}), uint32(265983); v.Kernel() != want {
+		t.Errorf("4.14.252+ should result in a kernel version of %d, got: %d", want, v.Kernel())
+	}
+
 	// Known good version.
 	if v, want := (Version{4, 9, 128}), uint32(264576); v.Kernel() != want {
 		t.Errorf("4.9.1 should result in a kernel version of %d, got: %d", want, v.Kernel())


### PR DESCRIPTION
Because the mainline kernel tree for 4.14 started forcing the sublevel to `255` early at version `252`, we need a special case to correctly match the `LINUX_VERSION_CODE` expected when loading kprobes.