### PR TITLE
link: use sys types and simplify feature test

### DIFF
--- a/internal/cmd/gentypes/main.go
+++ b/internal/cmd/gentypes/main.go
@@ -70,6 +70,7 @@ func run(args []string) error {
 
 func generateTypes(spec *btf.Spec) ([]byte, error) {
 	objName := &btf.Array{Nelems: 16, Type: &btf.Int{Encoding: btf.Char, Size: 1}}
+	linkID := &btf.Int{Size: 4}
 	pointer := &btf.Int{Size: 8}
 
 	// Pre-declare handwritten types sys.ObjName and sys.Pointer so that
@@ -77,11 +78,13 @@ func generateTypes(spec *btf.Spec) ([]byte, error) {
 	var (
 		_ sys.Pointer
 		_ sys.ObjName
+		_ sys.LinkID
 	)
 
 	gf := &btf.GoFormatter{
 		Names: map[btf.Type]string{
 			objName: "ObjName",
+			linkID:  "LinkID",
 			pointer: "Pointer",
 		},
 		Identifier: internal.Identifier,
@@ -173,6 +176,7 @@ import (
 			"LinkInfo", "bpf_link_info",
 			[]patch{
 				replace(enumTypes["LinkType"], "type"),
+				replace(linkID, "id"),
 				truncateAfter("prog_id"),
 			},
 		},

--- a/internal/sys/syscall.go
+++ b/internal/sys/syscall.go
@@ -90,6 +90,9 @@ func NewObjName(name string) ObjName {
 	return result
 }
 
+// LinkID uniquely identifies a bpf_link.
+type LinkID uint32
+
 // wrappedErrno wraps syscall.Errno to prevent direct comparisons with
 // syscall.E* or unix.E* constants.
 //

--- a/internal/sys/types.go
+++ b/internal/sys/types.go
@@ -425,7 +425,7 @@ type LineInfo struct {
 
 type LinkInfo struct {
 	Type   LinkType
-	Id     uint32
+	Id     LinkID
 	ProgId uint32
 }
 

--- a/link/link.go
+++ b/link/link.go
@@ -40,7 +40,7 @@ type Link interface {
 }
 
 // ID uniquely identifies a BPF link.
-type ID uint32
+type ID = sys.LinkID
 
 // RawLinkOptions control the creation of a raw link.
 type RawLinkOptions struct {
@@ -212,8 +212,8 @@ func (l *RawLink) Info() (*RawLinkInfo, error) {
 	}
 
 	return &RawLinkInfo{
-		Type(info.Type),
-		ID(info.Id),
+		info.Type,
+		info.Id,
 		ebpf.ProgramID(info.ProgId),
 	}, nil
 }

--- a/link/syscalls.go
+++ b/link/syscalls.go
@@ -86,27 +86,13 @@ var haveProgAttachReplace = internal.FeatureTest("BPF_PROG_ATTACH atomic replace
 })
 
 var haveBPFLink = internal.FeatureTest("bpf_link", "5.7", func() error {
-	prog, err := ebpf.NewProgram(&ebpf.ProgramSpec{
-		Type:       ebpf.CGroupSKB,
-		AttachType: ebpf.AttachCGroupInetIngress,
-		License:    "MIT",
-		Instructions: asm.Instructions{
-			asm.Mov.Imm(asm.R0, 0),
-			asm.Return(),
-		},
-	})
-	if err != nil {
-		return internal.ErrNotSupported
-	}
-	defer prog.Close()
-
 	attr := sys.LinkCreateAttr{
 		// This is a hopefully invalid file descriptor, which triggers EBADF.
 		TargetFd:   ^uint32(0),
-		ProgFd:     uint32(prog.FD()),
+		ProgFd:     ^uint32(0),
 		AttachType: sys.AttachType(ebpf.AttachCGroupInetIngress),
 	}
-	_, err = sys.LinkCreate(&attr)
+	_, err := sys.LinkCreate(&attr)
 	if errors.Is(err, unix.EINVAL) {
 		return internal.ErrNotSupported
 	}

--- a/link/syscalls.go
+++ b/link/syscalls.go
@@ -11,19 +11,17 @@ import (
 )
 
 // Type is the kind of link.
-type Type uint32
+type Type = sys.LinkType
 
 // Valid link types.
-//
-// Equivalent to enum bpf_link_type.
 const (
-	UnspecifiedType Type = iota
-	RawTracepointType
-	TracingType
-	CgroupType
-	IterType
-	NetNsType
-	XDPType
+	UnspecifiedType   = sys.BPF_LINK_TYPE_UNSPEC
+	RawTracepointType = sys.BPF_LINK_TYPE_RAW_TRACEPOINT
+	TracingType       = sys.BPF_LINK_TYPE_TRACING
+	CgroupType        = sys.BPF_LINK_TYPE_CGROUP
+	IterType          = sys.BPF_LINK_TYPE_ITER
+	NetNsType         = sys.BPF_LINK_TYPE_NETNS
+	XDPType           = sys.BPF_LINK_TYPE_XDP
 )
 
 var haveProgAttach = internal.FeatureTest("BPF_PROG_ATTACH", "4.10", func() error {


### PR DESCRIPTION
link: simplify link feature test
    
    Don't load a program to check for the presence of bpf_link, we can
    just call BPF_LINK_CREATE with an invalid fd instead.

link: use sys constants