### PR TITLE
link: add LoadPinnedLink

### DIFF
--- a/link/cgroup.go
+++ b/link/cgroup.go
@@ -57,6 +57,8 @@ func AttachCgroup(opts CgroupOptions) (Link, error) {
 }
 
 // LoadPinnedCgroup loads a pinned cgroup from a bpffs.
+//
+// Deprecated: use LoadPinnedLink instead.
 func LoadPinnedCgroup(fileName string, opts *ebpf.LoadPinOptions) (Link, error) {
 	link, err := LoadPinnedRawLink(fileName, CgroupType, opts)
 	if err != nil {

--- a/link/cgroup_test.go
+++ b/link/cgroup_test.go
@@ -39,9 +39,7 @@ func TestProgAttachCgroup(t *testing.T) {
 		t.Fatal("Can't create link:", err)
 	}
 
-	testLink(t, link, testLinkOptions{
-		prog: prog,
-	})
+	testLink(t, link, prog)
 }
 
 func TestProgAttachCgroupAllowMulti(t *testing.T) {
@@ -56,9 +54,7 @@ func TestProgAttachCgroupAllowMulti(t *testing.T) {
 	// It's currently not possible for a program to replace
 	// itself.
 	prog2 := mustCgroupEgressProgram(t)
-	testLink(t, link, testLinkOptions{
-		prog: prog2,
-	})
+	testLink(t, link, prog2)
 }
 
 func TestLinkCgroup(t *testing.T) {
@@ -70,8 +66,5 @@ func TestLinkCgroup(t *testing.T) {
 		t.Fatal("Can't create link:", err)
 	}
 
-	testLink(t, link, testLinkOptions{
-		prog:       prog,
-		loadPinned: LoadPinnedCgroup,
-	})
+	testLink(t, link, prog)
 }

--- a/link/iter.go
+++ b/link/iter.go
@@ -59,6 +59,8 @@ func AttachIter(opts IterOptions) (*Iter, error) {
 }
 
 // LoadPinnedIter loads a pinned iterator from a bpffs.
+//
+// Deprecated: use LoadPinnedLink instead.
 func LoadPinnedIter(fileName string, opts *ebpf.LoadPinOptions) (*Iter, error) {
 	link, err := LoadPinnedRawLink(fileName, IterType, opts)
 	if err != nil {

--- a/link/iter_test.go
+++ b/link/iter_test.go
@@ -48,12 +48,7 @@ func TestIter(t *testing.T) {
 		t.Error("Non-empty output from no-op iterator:", string(contents))
 	}
 
-	testLink(t, it, testLinkOptions{
-		prog: prog,
-		loadPinned: func(s string, opts *ebpf.LoadPinOptions) (Link, error) {
-			return LoadPinnedIter(s, opts)
-		},
-	})
+	testLink(t, it, prog)
 }
 
 func TestIterMapElements(t *testing.T) {

--- a/link/kprobe_test.go
+++ b/link/kprobe_test.go
@@ -36,9 +36,7 @@ func TestKprobe(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	defer k.Close()
 
-	testLink(t, k, testLinkOptions{
-		prog: prog,
-	})
+	testLink(t, k, prog)
 
 	k, err = Kprobe("bogus", prog)
 	c.Assert(errors.Is(err, os.ErrNotExist), qt.IsTrue, qt.Commentf("got error: %s", err))
@@ -60,9 +58,7 @@ func TestKretprobe(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	defer k.Close()
 
-	testLink(t, k, testLinkOptions{
-		prog: prog,
-	})
+	testLink(t, k, prog)
 
 	k, err = Kretprobe("bogus", prog)
 	c.Assert(errors.Is(err, os.ErrNotExist), qt.IsTrue, qt.Commentf("got error: %s", err))

--- a/link/link.go
+++ b/link/link.go
@@ -39,6 +39,42 @@ type Link interface {
 	isLink()
 }
 
+// LoadPinnedLink loads a link that was persisted into a bpffs.
+func LoadPinnedLink(fileName string, opts *ebpf.LoadPinOptions) (Link, error) {
+	raw, err := loadPinnedRawLink(fileName, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return wrapRawLink(raw)
+}
+
+// wrap a RawLink in a more specific type if possible.
+//
+// The function takes ownership of raw and closes it on error.
+func wrapRawLink(raw *RawLink) (Link, error) {
+	info, err := raw.Info()
+	if err != nil {
+		raw.Close()
+		return nil, err
+	}
+
+	switch info.Type {
+	case RawTracepointType:
+		return &rawTracepoint{*raw}, nil
+	case TracingType:
+		return &tracing{*raw}, nil
+	case CgroupType:
+		return &linkCgroup{*raw}, nil
+	case IterType:
+		return &Iter{*raw}, nil
+	case NetNsType:
+		return &NetNsLink{*raw}, nil
+	default:
+		return raw, nil
+	}
+}
+
 // ID uniquely identifies a BPF link.
 type ID uint32
 
@@ -106,16 +142,14 @@ func AttachRawLink(opts RawLinkOptions) (*RawLink, error) {
 //
 // Returns an error if the pinned link type doesn't match linkType. Pass
 // UnspecifiedType to disable this behaviour.
+//
+// Deprecated: use LoadPinnedLink instead.
 func LoadPinnedRawLink(fileName string, linkType Type, opts *ebpf.LoadPinOptions) (*RawLink, error) {
-	fd, err := sys.ObjGet(&sys.ObjGetAttr{
-		Pathname:  sys.NewStringPointer(fileName),
-		FileFlags: opts.Marshal(),
-	})
+	link, err := loadPinnedRawLink(fileName, opts)
 	if err != nil {
-		return nil, fmt.Errorf("load pinned link: %w", err)
+		return nil, err
 	}
 
-	link := &RawLink{fd, fileName}
 	if linkType == UnspecifiedType {
 		return link, nil
 	}
@@ -123,7 +157,7 @@ func LoadPinnedRawLink(fileName string, linkType Type, opts *ebpf.LoadPinOptions
 	info, err := link.Info()
 	if err != nil {
 		link.Close()
-		return nil, fmt.Errorf("get pinned link info: %s", err)
+		return nil, fmt.Errorf("get pinned link info: %w", err)
 	}
 
 	if info.Type != linkType {
@@ -132,6 +166,18 @@ func LoadPinnedRawLink(fileName string, linkType Type, opts *ebpf.LoadPinOptions
 	}
 
 	return link, nil
+}
+
+func loadPinnedRawLink(fileName string, opts *ebpf.LoadPinOptions) (*RawLink, error) {
+	fd, err := sys.ObjGet(&sys.ObjGetAttr{
+		Pathname:  sys.NewStringPointer(fileName),
+		FileFlags: opts.Marshal(),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("load pinned link: %w", err)
+	}
+
+	return &RawLink{fd, fileName}, nil
 }
 
 func (l *RawLink) isLink() {}

--- a/link/link_test.go
+++ b/link/link_test.go
@@ -46,12 +46,7 @@ func TestRawLink(t *testing.T) {
 		t.Error("Link program ID doesn't match program ID")
 	}
 
-	testLink(t, link, testLinkOptions{
-		prog: prog,
-		loadPinned: func(f string, opts *ebpf.LoadPinOptions) (Link, error) {
-			return LoadPinnedRawLink(f, UnspecifiedType, opts)
-		},
-	})
+	testLink(t, &linkCgroup{*link}, prog)
 }
 
 func TestRawLinkLoadPinnedWithOptions(t *testing.T) {
@@ -76,7 +71,7 @@ func TestRawLinkLoadPinnedWithOptions(t *testing.T) {
 
 	// It seems like the kernel ignores BPF_F_RDONLY when updating a link,
 	// so we can't test this.
-	_, err = LoadPinnedRawLink(path, UnspecifiedType, &ebpf.LoadPinOptions{
+	_, err = loadPinnedRawLink(path, &ebpf.LoadPinOptions{
 		Flags: math.MaxUint32,
 	})
 	if !errors.Is(err, unix.EINVAL) {
@@ -115,12 +110,7 @@ func mustCgroupEgressProgram(t *testing.T) *ebpf.Program {
 	return prog
 }
 
-type testLinkOptions struct {
-	prog       *ebpf.Program
-	loadPinned func(string, *ebpf.LoadPinOptions) (Link, error)
-}
-
-func testLink(t *testing.T, link Link, opts testLinkOptions) {
+func testLink(t *testing.T, link Link, prog *ebpf.Program) {
 	t.Helper()
 
 	tmp, err := os.MkdirTemp("/sys/fs/bpf", "ebpf-test")
@@ -137,7 +127,7 @@ func testLink(t *testing.T, link Link, opts testLinkOptions) {
 			t.Fatalf("Can't pin %T: %s", link, err)
 		}
 
-		link2, err := opts.loadPinned(path, nil)
+		link2, err := LoadPinnedLink(path, nil)
 		if err != nil {
 			t.Fatalf("Can't load pinned %T: %s", link, err)
 		}
@@ -147,7 +137,7 @@ func testLink(t *testing.T, link Link, opts testLinkOptions) {
 			t.Errorf("Loading a pinned %T returns a %T", link, link2)
 		}
 
-		_, err = opts.loadPinned(path, &ebpf.LoadPinOptions{
+		_, err = LoadPinnedLink(path, &ebpf.LoadPinOptions{
 			Flags: math.MaxUint32,
 		})
 		if !errors.Is(err, unix.EINVAL) {
@@ -156,7 +146,7 @@ func testLink(t *testing.T, link Link, opts testLinkOptions) {
 	})
 
 	t.Run("update", func(t *testing.T) {
-		err := link.Update(opts.prog)
+		err := link.Update(prog)
 		testutils.SkipIfNotSupported(t, err)
 		if err != nil {
 			t.Fatal("Update returns an error:", err)

--- a/link/netns.go
+++ b/link/netns.go
@@ -13,7 +13,7 @@ type NetNsInfo struct {
 
 // NetNsLink is a program attached to a network namespace.
 type NetNsLink struct {
-	*RawLink
+	RawLink
 }
 
 // AttachNetNs attaches a program to a network namespace.
@@ -37,17 +37,19 @@ func AttachNetNs(ns int, prog *ebpf.Program) (*NetNsLink, error) {
 		return nil, err
 	}
 
-	return &NetNsLink{link}, nil
+	return &NetNsLink{*link}, nil
 }
 
 // LoadPinnedNetNs loads a network namespace link from bpffs.
+//
+// Deprecated: use LoadPinnedLink instead.
 func LoadPinnedNetNs(fileName string, opts *ebpf.LoadPinOptions) (*NetNsLink, error) {
 	link, err := LoadPinnedRawLink(fileName, NetNsType, opts)
 	if err != nil {
 		return nil, err
 	}
 
-	return &NetNsLink{link}, nil
+	return &NetNsLink{*link}, nil
 }
 
 // Info returns information about the link.

--- a/link/netns_test.go
+++ b/link/netns_test.go
@@ -30,12 +30,7 @@ func TestSkLookup(t *testing.T) {
 		t.Fatal("Info returns an error:", err)
 	}
 
-	testLink(t, link, testLinkOptions{
-		prog: prog,
-		loadPinned: func(fileName string, opts *ebpf.LoadPinOptions) (Link, error) {
-			return LoadPinnedNetNs(fileName, opts)
-		},
-	})
+	testLink(t, link, prog)
 }
 
 func mustCreateSkLookupProgram(tb testing.TB) *ebpf.Program {

--- a/link/raw_tracepoint.go
+++ b/link/raw_tracepoint.go
@@ -48,16 +48,6 @@ func AttachRawTracepoint(opts RawTracepointOptions) (Link, error) {
 	return &rawTracepoint{RawLink{fd: fd}}, nil
 }
 
-// LoadPinnedRawTracepoint loads a raw_tracepoint link from a bpffs.
-func LoadPinnedRawTracepoint(fileName string, opts *ebpf.LoadPinOptions) (Link, error) {
-	link, err := LoadPinnedRawLink(fileName, RawTracepointType, opts)
-	if err != nil {
-		return nil, err
-	}
-
-	return &rawTracepoint{*link}, err
-}
-
 type simpleRawTracepoint struct {
 	fd *sys.FD
 }

--- a/link/raw_tracepoint_test.go
+++ b/link/raw_tracepoint_test.go
@@ -33,12 +33,7 @@ func TestRawTracepoint(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	testLink(t, link, testLinkOptions{
-		prog: prog,
-		loadPinned: func(s string, opts *ebpf.LoadPinOptions) (Link, error) {
-			return LoadPinnedRawTracepoint(s, opts)
-		},
-	})
+	testLink(t, link, prog)
 }
 
 func TestRawTracepoint_writable(t *testing.T) {
@@ -66,10 +61,5 @@ func TestRawTracepoint_writable(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	testLink(t, link, testLinkOptions{
-		prog: prog,
-		loadPinned: func(s string, opts *ebpf.LoadPinOptions) (Link, error) {
-			return LoadPinnedRawTracepoint(s, opts)
-		},
-	})
+	testLink(t, link, prog)
 }

--- a/link/tracing.go
+++ b/link/tracing.go
@@ -78,6 +78,8 @@ func AttachFreplace(targetProg *ebpf.Program, name string, prog *ebpf.Program) (
 }
 
 // LoadPinnedFreplace loads a pinned iterator from a bpffs.
+//
+// Deprecated: use LoadPinnedLink instead.
 func LoadPinnedFreplace(fileName string, opts *ebpf.LoadPinOptions) (Link, error) {
 	link, err := LoadPinnedRawLink(fileName, TracingType, opts)
 	if err != nil {
@@ -148,14 +150,4 @@ func AttachLSM(opts LSMOptions) (Link, error) {
 	}
 
 	return attachBTFID(opts.Program)
-}
-
-// LoadPinnedTrace loads a tracing/LSM link from a bpffs.
-func LoadPinnedTrace(fileName string, opts *ebpf.LoadPinOptions) (Link, error) {
-	link, err := LoadPinnedRawLink(fileName, TracingType, opts)
-	if err != nil {
-		return nil, err
-	}
-
-	return &tracing{*link}, err
 }

--- a/link/tracing_test.go
+++ b/link/tracing_test.go
@@ -43,12 +43,7 @@ func TestFreplace(t *testing.T) {
 			t.Fatal("Can't create freplace:", err)
 		}
 
-		testLink(t, freplace, testLinkOptions{
-			prog: replacement,
-			loadPinned: func(s string, opts *ebpf.LoadPinOptions) (Link, error) {
-				return LoadPinnedFreplace(s, opts)
-			},
-		})
+		testLink(t, freplace, replacement)
 	})
 }
 
@@ -108,15 +103,7 @@ func TestTracing(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			testLink(t, link, testLinkOptions{
-				prog: prog,
-				loadPinned: func(s string, opts *ebpf.LoadPinOptions) (Link, error) {
-					if tt.attachType != ebpf.AttachTraceRawTp {
-						return LoadPinnedTrace(s, opts)
-					}
-					return LoadPinnedRawTracepoint(s, opts)
-				},
-			})
+			testLink(t, link, prog)
 		})
 	}
 }
@@ -144,10 +131,5 @@ func TestLSM(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	testLink(t, link, testLinkOptions{
-		prog: prog,
-		loadPinned: func(s string, opts *ebpf.LoadPinOptions) (Link, error) {
-			return LoadPinnedTrace(s, opts)
-		},
-	})
+	testLink(t, link, prog)
 }

--- a/link/uprobe_test.go
+++ b/link/uprobe_test.go
@@ -55,9 +55,7 @@ func TestUprobe(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	defer up.Close()
 
-	testLink(t, up, testLinkOptions{
-		prog: prog,
-	})
+	testLink(t, up, prog)
 }
 
 func TestUprobeExtNotFound(t *testing.T) {
@@ -131,9 +129,7 @@ func TestUretprobe(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	defer up.Close()
 
-	testLink(t, up, testLinkOptions{
-		prog: prog,
-	})
+	testLink(t, up, prog)
 }
 
 // Test u(ret)probe creation using perf_uprobe PMU.

--- a/link/xdp_test.go
+++ b/link/xdp_test.go
@@ -33,10 +33,5 @@ func TestAttachXDP(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	testLink(t, l, testLinkOptions{
-		prog: prog,
-		loadPinned: func(s string, opts *ebpf.LoadPinOptions) (Link, error) {
-			return LoadPinnedRawLink(s, XDPType, opts)
-		},
-	})
+	testLink(t, l, prog)
 }


### PR DESCRIPTION
Add a function that allows loading any pinned link. This allows us to
deprecate all of the separate LoadPinned* functions. In the future we
can use LoadPinnedLink to build APIs that work with any kind of link.