### PR TITLE
asm: add Instructions.SizeBytes() for convenience and readability

### DIFF
--- a/asm/instruction.go
+++ b/asm/instruction.go
@@ -275,11 +275,25 @@ ref:
 	}
 }
 
+// Size returns the amount of bytes ins would occupy in binary form.
+func (ins Instruction) Size() uint64 {
+	return uint64(InstructionSize * ins.OpCode.rawInstructions())
+}
+
 // Instructions is an eBPF program.
 type Instructions []Instruction
 
 func (insns Instructions) String() string {
 	return fmt.Sprint(insns)
+}
+
+// Size returns the amount of bytes insns would occupy in binary form.
+func (insns Instructions) Size() uint64 {
+	var sum uint64
+	for _, ins := range insns {
+		sum += ins.Size()
+	}
+	return sum
 }
 
 // RewriteMapPtr rewrites all loads of a specific map pointer to a new fd.

--- a/features/prog.go
+++ b/features/prog.go
@@ -36,7 +36,7 @@ func createProgLoadAttr(pt ebpf.ProgramType) (*sys.ProgLoadAttr, error) {
 		asm.Return(),
 	}
 
-	buf := bytes.NewBuffer(make([]byte, 0, len(insns)*asm.InstructionSize))
+	buf := bytes.NewBuffer(make([]byte, 0, insns.Size()))
 	if err := insns.Marshal(buf, internal.NativeEndian); err != nil {
 		return nil, err
 	}

--- a/prog.go
+++ b/prog.go
@@ -237,7 +237,7 @@ func newProgramWithOptions(spec *ProgramSpec, opts ProgramOptions, handles *hand
 		return nil, err
 	}
 
-	buf := bytes.NewBuffer(make([]byte, 0, len(spec.Instructions)*asm.InstructionSize))
+	buf := bytes.NewBuffer(make([]byte, 0, insns.Size()))
 	err = insns.Marshal(buf, internal.NativeEndian)
 	if err != nil {
 		return nil, err

--- a/syscalls.go
+++ b/syscalls.go
@@ -226,7 +226,7 @@ var haveProbeReadKernel = internal.FeatureTest("bpf_probe_read_kernel", "5.5", f
 		asm.FnProbeReadKernel.Call(),
 		asm.Return(),
 	}
-	buf := bytes.NewBuffer(make([]byte, 0, len(insns)*asm.InstructionSize))
+	buf := bytes.NewBuffer(make([]byte, 0, insns.Size()))
 	if err := insns.Marshal(buf, internal.NativeEndian); err != nil {
 		return err
 	}


### PR DESCRIPTION
This fixes a subtle bug where buf would always be reallocated if the program contains dword loads.
