### PR TITLE
btf: buffered SectionReader, document BTF parsing, vmlinux benchmark

### DIFF
--- a/internal/io.go
+++ b/internal/io.go
@@ -1,6 +1,34 @@
 package internal
 
-import "errors"
+import (
+	"bufio"
+	"errors"
+	"io"
+	"os"
+)
+
+// NewBufferedSectionReader wraps an io.ReaderAt in an appropriately-sized
+// buffered reader. It is a convenience function for reading subsections of
+// ELF sections while minimizing the amount of read() syscalls made.
+//
+// Syscall overhead is non-negligible in continuous integration context
+// where ELFs might be accessed over virtual filesystems with poor random
+// access performance. Buffering reads makes sense because (sub)sections
+// end up being read completely anyway.
+//
+// Use instead of the r.Seek() + io.LimitReader() pattern.
+func NewBufferedSectionReader(ra io.ReaderAt, off, n int64) io.Reader {
+	// Clamp the size of the buffer to one page to avoid slurping large parts
+	// of a file into memory. bufio.NewReader uses a hardcoded default buffer
+	// of 4096. Allow arches with larger pages to allocate more, but don't
+	// allocate a fixed 4k buffer if we only need to read a small segment.
+	buf := n
+	if ps := int64(os.Getpagesize()); n > ps {
+		buf = ps
+	}
+
+	return bufio.NewReaderSize(io.NewSectionReader(ra, off, n), int(buf))
+}
 
 // DiscardZeroes makes sure that all written bytes are zero
 // before discarding them.


### PR DESCRIPTION
This PR aims to improve the readability of the logic and obviates the need to call `r.Seek()` and `io.LimitReader()`. It is part of a larger effort to support multiple progs per ELF section, which also requires some changes to lineinfo/funcinfo/corerelo handling. Moving things around this way makes those patches a bit easier to digest. :)

Convenience methods were added to determine the absolute starting offsets of type info, string table, funcInfos, lineInfos and coreRelos within their respective ELF sections.

Documented all functions in ext_info.go.

---

Also added a benchmark over `ParseVmLinux` because I'd like to make this more efficient in the future. (:scream_cat: :scream_cat:)

```
λ  ebpf tb/buffered-section-reader ✓ go test -exec sudo ./internal/btf  -bench=. -benchmem -memprofile memprofile.out -cpuprofile profile.out
goos: linux
goarch: amd64
pkg: github.com/cilium/ebpf/internal/btf
cpu: AMD Ryzen 7 3700X 8-Core Processor
BenchmarkParseVmlinux-16    	      10	 111009555 ns/op	75976636 B/op	  511036 allocs/op
PASS
ok  	github.com/cilium/ebpf/internal/btf	3.042s
```