### PR TITLE
unix: remove KernelRelease function

### DIFF
--- a/internal/unix/types_linux.go
+++ b/internal/unix/types_linux.go
@@ -4,7 +4,6 @@
 package unix
 
 import (
-	"bytes"
 	"syscall"
 
 	linux "golang.org/x/sys/unix"
@@ -192,18 +191,6 @@ func ByteSliceToString(s []byte) string {
 // Renameat2 is a wrapper
 func Renameat2(olddirfd int, oldpath string, newdirfd int, newpath string, flags uint) error {
 	return linux.Renameat2(olddirfd, oldpath, newdirfd, newpath, flags)
-}
-
-func KernelRelease() (string, error) {
-	var uname Utsname
-	err := Uname(&uname)
-	if err != nil {
-		return "", err
-	}
-
-	end := bytes.IndexByte(uname.Release[:], 0)
-	release := string(uname.Release[:end])
-	return release, nil
 }
 
 func Prlimit(pid, resource int, new, old *Rlimit) error {

--- a/internal/unix/types_other.go
+++ b/internal/unix/types_other.go
@@ -261,10 +261,6 @@ func Renameat2(olddirfd int, oldpath string, newdirfd int, newpath string, flags
 	return errNonLinux
 }
 
-func KernelRelease() (string, error) {
-	return "", errNonLinux
-}
-
 func Prlimit(pid, resource int, new, old *Rlimit) error {
 	return errNonLinux
 }


### PR DESCRIPTION
The function isn't just a wrapper for a function in `unix`. Move the code
to the single caller instead.