### PR TITLE
examples/fentry: fix call to link.AttachTracing

### DIFF
--- a/examples/fentry/main.go
+++ b/examples/fentry/main.go
@@ -80,7 +80,7 @@ func main() {
 	}
 	defer objs.Close()
 
-	link, err := link.AttachTrace(link.TraceOptions{
+	link, err := link.AttachTracing(link.TracingOptions{
 		Program: objs.bpfPrograms.TcpConnect,
 	})
 	if err != nil {


### PR DESCRIPTION
I renamed link.AttachTrace to link.AttachTracing recently, fix up the
example to call the correct function.