### PR TITLE
reduce test boilerplate

### DIFF
--- a/info_test.go
+++ b/info_test.go
@@ -87,8 +87,7 @@ func TestMapInfoFromProc(t *testing.T) {
 }
 
 func TestProgramInfo(t *testing.T) {
-	prog := createSocketFilter(t)
-	defer prog.Close()
+	prog := mustSocketFilter(t)
 
 	for name, fn := range map[string]func(*sys.FD) (*ProgramInfo, error){
 		"generic": newProgramInfoFromFd,
@@ -195,20 +194,7 @@ func TestScanFdInfoReader(t *testing.T) {
 func TestStats(t *testing.T) {
 	testutils.SkipOnOldKernel(t, "5.8", "BPF_ENABLE_STATS")
 
-	spec := &ProgramSpec{
-		Type: SocketFilter,
-		Instructions: asm.Instructions{
-			asm.LoadImm(asm.R0, 42, asm.DWord),
-			asm.Return(),
-		},
-		License: "MIT",
-	}
-
-	prog, err := NewProgram(spec)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer prog.Close()
+	prog := mustSocketFilter(t)
 
 	pi, err := prog.Info()
 	if err != nil {
@@ -240,21 +226,7 @@ func TestStats(t *testing.T) {
 func BenchmarkStats(b *testing.B) {
 	testutils.SkipOnOldKernel(b, "5.8", "BPF_ENABLE_STATS")
 
-	spec := &ProgramSpec{
-		Type: SocketFilter,
-		Instructions: asm.Instructions{
-			asm.LoadImm(asm.R0, 42, asm.DWord),
-			asm.Return(),
-		},
-		License: "MIT",
-	}
-
-	// Don't insert the program in a loop as it causes a flood of kaudit messages.
-	prog, err := NewProgram(spec)
-	if err != nil {
-		b.Fatal(err)
-	}
-	defer prog.Close()
+	prog := mustSocketFilter(b)
 
 	for n := 0; n < b.N; n++ {
 		if err := testStats(prog); err != nil {

--- a/link/cgroup_test.go
+++ b/link/cgroup_test.go
@@ -53,7 +53,7 @@ func TestProgAttachCgroupAllowMulti(t *testing.T) {
 
 	// It's currently not possible for a program to replace
 	// itself.
-	prog2 := mustCgroupEgressProgram(t)
+	prog2 := mustLoadProgram(t, ebpf.CGroupSKB, ebpf.AttachCGroupInetEgress, "")
 	testLink(t, link, prog2)
 }
 

--- a/link/iter_test.go
+++ b/link/iter_test.go
@@ -5,26 +5,13 @@ import (
 	"testing"
 
 	"github.com/cilium/ebpf"
-	"github.com/cilium/ebpf/asm"
 	"github.com/cilium/ebpf/internal/testutils"
 )
 
 func TestIter(t *testing.T) {
-	prog, err := ebpf.NewProgram(&ebpf.ProgramSpec{
-		Type:       ebpf.Tracing,
-		AttachType: ebpf.AttachTraceIter,
-		AttachTo:   "bpf_map",
-		Instructions: asm.Instructions{
-			asm.Mov.Imm(asm.R0, 0),
-			asm.Return(),
-		},
-		License: "MIT",
-	})
-	testutils.SkipIfNotSupported(t, err)
-	if err != nil {
-		t.Fatal("Can't load program:", err)
-	}
-	defer prog.Close()
+	testutils.SkipOnOldKernel(t, "5.9", "bpf_map iter")
+
+	prog := mustLoadProgram(t, ebpf.Tracing, ebpf.AttachTraceIter, "bpf_map")
 
 	it, err := AttachIter(IterOptions{
 		Program: prog,
@@ -52,21 +39,9 @@ func TestIter(t *testing.T) {
 }
 
 func TestIterMapElements(t *testing.T) {
-	prog, err := ebpf.NewProgram(&ebpf.ProgramSpec{
-		Type:       ebpf.Tracing,
-		AttachType: ebpf.AttachTraceIter,
-		AttachTo:   "bpf_map_elem",
-		Instructions: asm.Instructions{
-			asm.Mov.Imm(asm.R0, 0),
-			asm.Return(),
-		},
-		License: "MIT",
-	})
-	testutils.SkipIfNotSupported(t, err)
-	if err != nil {
-		t.Fatal("Can't load program:", err)
-	}
-	defer prog.Close()
+	testutils.SkipOnOldKernel(t, "5.9", "bpf_map_elem iter")
+
+	prog := mustLoadProgram(t, ebpf.Tracing, ebpf.AttachTraceIter, "bpf_map_elem")
 
 	arr, err := ebpf.NewMap(&ebpf.MapSpec{
 		Type:       ebpf.Array,

--- a/link/kprobe_test.go
+++ b/link/kprobe_test.go
@@ -13,24 +13,10 @@ import (
 	"github.com/cilium/ebpf/internal/unix"
 )
 
-var kprobeSpec = ebpf.ProgramSpec{
-	Type:    ebpf.Kprobe,
-	License: "MIT",
-	Instructions: asm.Instructions{
-		// set exit code to 0
-		asm.Mov.Imm(asm.R0, 0),
-		asm.Return(),
-	},
-}
-
 func TestKprobe(t *testing.T) {
 	c := qt.New(t)
 
-	prog, err := ebpf.NewProgram(&kprobeSpec)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer prog.Close()
+	prog := mustLoadProgram(t, ebpf.Kprobe, 0, "")
 
 	k, err := Kprobe("printk", prog)
 	c.Assert(err, qt.IsNil)
@@ -48,11 +34,7 @@ func TestKprobe(t *testing.T) {
 func TestKretprobe(t *testing.T) {
 	c := qt.New(t)
 
-	prog, err := ebpf.NewProgram(&kprobeSpec)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer prog.Close()
+	prog := mustLoadProgram(t, ebpf.Kprobe, 0, "")
 
 	k, err := Kretprobe("printk", prog)
 	c.Assert(err, qt.IsNil)

--- a/link/netns_test.go
+++ b/link/netns_test.go
@@ -12,7 +12,7 @@ import (
 func TestSkLookup(t *testing.T) {
 	testutils.SkipOnOldKernel(t, "5.8", "sk_lookup program")
 
-	prog := mustCreateSkLookupProgram(t)
+	prog := mustLoadProgram(t, ebpf.SkLookup, ebpf.AttachSkLookup, "")
 
 	netns, err := os.Open("/proc/self/ns/net")
 	if err != nil {
@@ -31,18 +31,6 @@ func TestSkLookup(t *testing.T) {
 	}
 
 	testLink(t, link, prog)
-}
-
-func mustCreateSkLookupProgram(tb testing.TB) *ebpf.Program {
-	tb.Helper()
-
-	prog, err := createSkLookupProgram()
-	if err != nil {
-		tb.Fatal(err)
-	}
-	tb.Cleanup(func() { prog.Close() })
-
-	return prog
 }
 
 func createSkLookupProgram() (*ebpf.Program, error) {

--- a/link/program_test.go
+++ b/link/program_test.go
@@ -4,30 +4,16 @@ import (
 	"testing"
 
 	"github.com/cilium/ebpf"
-	"github.com/cilium/ebpf/asm"
 	"github.com/cilium/ebpf/internal/testutils"
 )
 
 func TestProgramAlter(t *testing.T) {
 	testutils.SkipOnOldKernel(t, "4.13", "SkSKB type")
 
-	var err error
-	var prog *ebpf.Program
-	prog, err = ebpf.NewProgram(&ebpf.ProgramSpec{
-		Type: ebpf.SkSKB,
-		Instructions: asm.Instructions{
-			asm.LoadImm(asm.R0, 0, asm.DWord),
-			asm.Return(),
-		},
-		License: "MIT",
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer prog.Close()
+	prog := mustLoadProgram(t, ebpf.SkSKB, 0, "")
 
 	var sockMap *ebpf.Map
-	sockMap, err = ebpf.NewMap(&ebpf.MapSpec{
+	sockMap, err := ebpf.NewMap(&ebpf.MapSpec{
 		Type:       ebpf.MapType(15), // BPF_MAP_TYPE_SOCKMAP
 		KeySize:    4,
 		ValueSize:  4,

--- a/link/raw_tracepoint_test.go
+++ b/link/raw_tracepoint_test.go
@@ -4,26 +4,13 @@ import (
 	"testing"
 
 	"github.com/cilium/ebpf"
-	"github.com/cilium/ebpf/asm"
 	"github.com/cilium/ebpf/internal/testutils"
 )
 
 func TestRawTracepoint(t *testing.T) {
 	testutils.SkipOnOldKernel(t, "4.17", "BPF_RAW_TRACEPOINT API")
 
-	prog, err := ebpf.NewProgram(&ebpf.ProgramSpec{
-		Type:       ebpf.RawTracepoint,
-		AttachType: ebpf.AttachNone,
-		Instructions: asm.Instructions{
-			asm.LoadImm(asm.R0, 0, asm.DWord),
-			asm.Return(),
-		},
-		License: "GPL",
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer prog.Close()
+	prog := mustLoadProgram(t, ebpf.RawTracepoint, 0, "")
 
 	link, err := AttachRawTracepoint(RawTracepointOptions{
 		Name:    "cgroup_mkdir",
@@ -39,18 +26,8 @@ func TestRawTracepoint(t *testing.T) {
 func TestRawTracepoint_writable(t *testing.T) {
 	testutils.SkipOnOldKernel(t, "5.2", "BPF_RAW_TRACEPOINT_WRITABLE API")
 
-	prog, err := ebpf.NewProgram(&ebpf.ProgramSpec{
-		Type:       ebpf.RawTracepointWritable,
-		AttachType: ebpf.AttachNone,
-		Instructions: asm.Instructions{
-			asm.LoadImm(asm.R0, 0, asm.DWord),
-			asm.Return(),
-		},
-		License: "GPL",
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	prog := mustLoadProgram(t, ebpf.RawTracepoint, 0, "")
+
 	defer prog.Close()
 
 	link, err := AttachRawTracepoint(RawTracepointOptions{

--- a/link/tracepoint_test.go
+++ b/link/tracepoint_test.go
@@ -6,35 +6,17 @@ import (
 	"testing"
 
 	"github.com/cilium/ebpf"
-	"github.com/cilium/ebpf/asm"
 	"github.com/cilium/ebpf/internal/testutils"
 	"github.com/cilium/ebpf/internal/unix"
 
 	qt "github.com/frankban/quicktest"
 )
 
-var (
-	tracepointSpec = ebpf.ProgramSpec{
-		Type:    ebpf.TracePoint,
-		License: "MIT",
-		Instructions: asm.Instructions{
-			// set exit code to 0
-			asm.Mov.Imm(asm.R0, 0),
-			asm.Return(),
-		},
-	}
-)
-
 func TestTracepoint(t *testing.T) {
-
 	// Requires at least 4.7 (98b5c2c65c29 "perf, bpf: allow bpf programs attach to tracepoints")
 	testutils.SkipOnOldKernel(t, "4.7", "tracepoint support")
 
-	prog, err := ebpf.NewProgram(&tracepointSpec)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer prog.Close()
+	prog := mustLoadProgram(t, ebpf.TracePoint, 0, "")
 
 	// printk is guaranteed to be present.
 	// Kernels before 4.14 don't support attaching to syscall tracepoints.
@@ -52,13 +34,9 @@ func TestTracepointMissing(t *testing.T) {
 	// Requires at least 4.7 (98b5c2c65c29 "perf, bpf: allow bpf programs attach to tracepoints")
 	testutils.SkipOnOldKernel(t, "4.7", "tracepoint support")
 
-	prog, err := ebpf.NewProgram(&tracepointSpec)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer prog.Close()
+	prog := mustLoadProgram(t, ebpf.TracePoint, 0, "")
 
-	_, err = Tracepoint("missing", "foobazbar", prog)
+	_, err := Tracepoint("missing", "foobazbar", prog)
 	if !errors.Is(err, os.ErrNotExist) {
 		t.Error("Expected os.ErrNotExist, got", err)
 	}

--- a/link/uprobe_test.go
+++ b/link/uprobe_test.go
@@ -45,11 +45,7 @@ func TestExecutable(t *testing.T) {
 func TestUprobe(t *testing.T) {
 	c := qt.New(t)
 
-	prog, err := ebpf.NewProgram(&kprobeSpec)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer prog.Close()
+	prog := mustLoadProgram(t, ebpf.Kprobe, 0, "")
 
 	up, err := bashEx.Uprobe(bashSym, prog, nil)
 	c.Assert(err, qt.IsNil)
@@ -59,25 +55,17 @@ func TestUprobe(t *testing.T) {
 }
 
 func TestUprobeExtNotFound(t *testing.T) {
-	prog, err := ebpf.NewProgram(&kprobeSpec)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer prog.Close()
+	prog := mustLoadProgram(t, ebpf.Kprobe, 0, "")
 
 	// This symbol will not be present in Executable (elf.SHN_UNDEF).
-	_, err = bashEx.Uprobe("open", prog, nil)
+	_, err := bashEx.Uprobe("open", prog, nil)
 	if err == nil {
 		t.Fatal("expected error")
 	}
 }
 
 func TestUprobeExtWithOpts(t *testing.T) {
-	prog, err := ebpf.NewProgram(&kprobeSpec)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer prog.Close()
+	prog := mustLoadProgram(t, ebpf.Kprobe, 0, "")
 
 	// This Uprobe is broken and will not work because the offset is not
 	// correct. This is expected since the offset is provided by the user.
@@ -89,11 +77,7 @@ func TestUprobeExtWithOpts(t *testing.T) {
 }
 
 func TestUprobeWithPID(t *testing.T) {
-	prog, err := ebpf.NewProgram(&kprobeSpec)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer prog.Close()
+	prog := mustLoadProgram(t, ebpf.Kprobe, 0, "")
 
 	up, err := bashEx.Uprobe(bashSym, prog, &UprobeOptions{PID: os.Getpid()})
 	if err != nil {
@@ -103,14 +87,10 @@ func TestUprobeWithPID(t *testing.T) {
 }
 
 func TestUprobeWithNonExistentPID(t *testing.T) {
-	prog, err := ebpf.NewProgram(&kprobeSpec)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer prog.Close()
+	prog := mustLoadProgram(t, ebpf.Kprobe, 0, "")
 
 	// trying to open a perf event on a non-existent PID will return ESRCH.
-	_, err = bashEx.Uprobe(bashSym, prog, &UprobeOptions{PID: -2})
+	_, err := bashEx.Uprobe(bashSym, prog, &UprobeOptions{PID: -2})
 	if !errors.Is(err, unix.ESRCH) {
 		t.Fatalf("expected ESRCH, got %v", err)
 	}
@@ -119,11 +99,7 @@ func TestUprobeWithNonExistentPID(t *testing.T) {
 func TestUretprobe(t *testing.T) {
 	c := qt.New(t)
 
-	prog, err := ebpf.NewProgram(&kprobeSpec)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer prog.Close()
+	prog := mustLoadProgram(t, ebpf.Kprobe, 0, "")
 
 	up, err := bashEx.Uretprobe(bashSym, prog, nil)
 	c.Assert(err, qt.IsNil)

--- a/link/xdp_test.go
+++ b/link/xdp_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/cilium/ebpf"
-	"github.com/cilium/ebpf/asm"
 	"github.com/cilium/ebpf/internal/testutils"
 )
 
@@ -12,18 +11,8 @@ const IfIndexLO = 1
 
 func TestAttachXDP(t *testing.T) {
 	testutils.SkipOnOldKernel(t, "5.9", "BPF_LINK_TYPE_XDP")
-	prog, err := ebpf.NewProgram(&ebpf.ProgramSpec{
-		Type: ebpf.XDP,
-		Instructions: asm.Instructions{
-			asm.LoadImm(asm.R0, 2, asm.DWord),
-			asm.Return(),
-		},
-		License: "MIT",
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer prog.Close()
+
+	prog := mustLoadProgram(t, ebpf.XDP, 0, "")
 
 	l, err := AttachXDP(XDPOptions{
 		Program:   prog,

--- a/prog_test.go
+++ b/prog_test.go
@@ -90,8 +90,7 @@ func TestProgramRun(t *testing.T) {
 }
 
 func TestProgramBenchmark(t *testing.T) {
-	prog := createSocketFilter(t)
-	defer prog.Close()
+	prog := mustSocketFilter(t)
 
 	ret, duration, err := prog.Benchmark(make([]byte, 14), 1, nil)
 	testutils.SkipIfNotSupported(t, err)
@@ -111,8 +110,7 @@ func TestProgramBenchmark(t *testing.T) {
 func TestProgramTestRunInterrupt(t *testing.T) {
 	testutils.SkipOnOldKernel(t, "5.0", "EINTR from BPF_PROG_TEST_RUN")
 
-	prog := createSocketFilter(t)
-	defer prog.Close()
+	prog := mustSocketFilter(t)
 
 	var (
 		tgid    = unix.Getpid()
@@ -177,7 +175,7 @@ func TestProgramTestRunInterrupt(t *testing.T) {
 }
 
 func TestProgramClose(t *testing.T) {
-	prog := createSocketFilter(t)
+	prog := mustSocketFilter(t)
 
 	if err := prog.Close(); err != nil {
 		t.Fatal("Can't close program:", err)
@@ -185,9 +183,8 @@ func TestProgramClose(t *testing.T) {
 }
 
 func TestProgramPin(t *testing.T) {
-	prog := createSocketFilter(t)
+	prog := mustSocketFilter(t)
 	c := qt.New(t)
-	defer prog.Close()
 
 	tmp := testutils.TempBPFFS(t)
 
@@ -218,9 +215,8 @@ func TestProgramPin(t *testing.T) {
 }
 
 func TestProgramUnpin(t *testing.T) {
-	prog := createSocketFilter(t)
+	prog := mustSocketFilter(t)
 	c := qt.New(t)
-	defer prog.Close()
 
 	tmp := testutils.TempBPFFS(t)
 
@@ -244,8 +240,7 @@ func TestProgramLoadPinnedWithFlags(t *testing.T) {
 	// Introduced in commit 6e71b04a8224.
 	testutils.SkipOnOldKernel(t, "4.14", "file_flags in BPF_OBJ_GET")
 
-	prog := createSocketFilter(t)
-	defer prog.Close()
+	prog := mustSocketFilter(t)
 
 	tmp := testutils.TempBPFFS(t)
 
@@ -355,8 +350,7 @@ func TestProgramName(t *testing.T) {
 		t.Skip(err)
 	}
 
-	prog := createSocketFilter(t)
-	defer prog.Close()
+	prog := mustSocketFilter(t)
 
 	var info sys.ProgInfo
 	if err := sys.ObjInfo(prog.fd, &info); err != nil {
@@ -398,18 +392,7 @@ func TestProgramMarshaling(t *testing.T) {
 	arr := createProgramArray(t)
 	defer arr.Close()
 
-	prog, err := NewProgram(&ProgramSpec{
-		Type: SocketFilter,
-		Instructions: asm.Instructions{
-			asm.LoadImm(asm.R0, 0, asm.DWord),
-			asm.Return(),
-		},
-		License: "MIT",
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer prog.Close()
+	prog := mustSocketFilter(t)
 
 	if err := arr.Put(idx, prog); err != nil {
 		t.Fatal("Can't put program:", err)
@@ -438,18 +421,7 @@ func TestProgramMarshaling(t *testing.T) {
 }
 
 func TestProgramFromFD(t *testing.T) {
-	prog, err := NewProgram(&ProgramSpec{
-		Type: SocketFilter,
-		Instructions: asm.Instructions{
-			asm.LoadImm(asm.R0, 0, asm.DWord),
-			asm.Return(),
-		},
-		License: "MIT",
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer prog.Close()
+	prog := mustSocketFilter(t)
 
 	// If you're thinking about copying this, don't. Use
 	// Clone() instead.
@@ -473,62 +445,39 @@ func TestHaveProgTestRun(t *testing.T) {
 
 func TestProgramGetNextID(t *testing.T) {
 	testutils.SkipOnOldKernel(t, "4.13", "bpf_prog_get_next_id")
-	var next ProgramID
 
-	prog, err := NewProgram(&ProgramSpec{
-		Type: SkSKB,
-		Instructions: asm.Instructions{
-			asm.LoadImm(asm.R0, 0, asm.DWord),
-			asm.Return(),
-		},
-		License: "MIT",
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer prog.Close()
-
-	if next, err = ProgramGetNextID(ProgramID(0)); err != nil {
-		t.Fatal("Can't get next ID:", err)
-	}
-	if next == ProgramID(0) {
-		t.Fatal("Expected next ID other than 0")
-	}
+	// Ensure there is at least one program loaded
+	_ = mustSocketFilter(t)
 
 	// As there can be multiple eBPF programs, we loop over all of them and
 	// make sure, the IDs increase and the last call will return ErrNotExist
+	last := ProgramID(0)
 	for {
-		last := next
-		if next, err = ProgramGetNextID(last); err != nil {
-			if !errors.Is(err, ErrNotExist) {
-				t.Fatal("Expected ErrNotExist, got:", err)
+		next, err := ProgramGetNextID(last)
+		if errors.Is(err, ErrNotExist) {
+			if last == 0 {
+				t.Fatal("Got ErrNotExist on the first iteration")
 			}
 			break
+		}
+		if err != nil {
+			t.Fatal("Unexpected error:", err)
 		}
 		if next <= last {
 			t.Fatalf("Expected next ID (%d) to be higher than the last ID (%d)", next, last)
 		}
+		last = next
 	}
 }
 
 func TestNewProgramFromID(t *testing.T) {
 	testutils.SkipOnOldKernel(t, "4.13", "bpf_prog_get_fd_by_id")
 
-	prog, err := NewProgram(&ProgramSpec{
-		Type: SkSKB,
-		Instructions: asm.Instructions{
-			asm.LoadImm(asm.R0, 0, asm.DWord),
-			asm.Return(),
-		},
-		License: "MIT",
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer prog.Close()
+	prog := mustSocketFilter(t)
+
 	var next ProgramID
 
-	next, err = prog.ID()
+	next, err := prog.ID()
 	if err != nil {
 		t.Fatal("Could not get ID of program:", err)
 	}
@@ -691,11 +640,7 @@ func TestProgramBindMap(t *testing.T) {
 	}
 	defer arr.Close()
 
-	prog, err := NewProgram(socketFilterSpec)
-	if err != nil {
-		t.Errorf("Failed to load program: %v", err)
-	}
-	defer prog.Close()
+	prog := mustSocketFilter(t)
 
 	// The attached map does not contain BTF information. So
 	// the metadata part of the program will be empty. This
@@ -740,13 +685,14 @@ var socketFilterSpec = &ProgramSpec{
 	License: "MIT",
 }
 
-func createSocketFilter(t *testing.T) *Program {
-	t.Helper()
+func mustSocketFilter(tb testing.TB) *Program {
+	tb.Helper()
 
 	prog, err := NewProgram(socketFilterSpec)
 	if err != nil {
-		t.Fatal(err)
+		tb.Fatal(err)
 	}
+	tb.Cleanup(func() { prog.Close() })
 
 	return prog
 }


### PR DESCRIPTION
Our tests very often create very simple BPF programs that just return 0. Add helpers for this, which allows us to remove a lot of identical code.