### PR TITLE
btf: rename FindType to TypeByName, add TypesByName and TypeByID methods

### DIFF
--- a/elf_reader.go
+++ b/elf_reader.go
@@ -580,7 +580,7 @@ func (ec *elfCode) loadBTFMaps(maps map[string]*MapSpec) error {
 
 		// Each section must appear as a DataSec in the ELF's BTF blob.
 		var ds *btf.Datasec
-		if err := ec.btf.FindType(sec.Name, &ds); err != nil {
+		if err := ec.btf.TypeByName(sec.Name, &ds); err != nil {
 			return fmt.Errorf("cannot find section '%s' in BTF: %w", sec.Name, err)
 		}
 
@@ -952,7 +952,7 @@ func (ec *elfCode) loadDataSections(maps map[string]*MapSpec) error {
 		}
 
 		var datasec *btf.Datasec
-		if err := ec.btf.FindType(sec.Name, &datasec); err != nil {
+		if err := ec.btf.TypeByName(sec.Name, &datasec); err != nil {
 			return fmt.Errorf("data section %s: can't get BTF: %w", sec.Name, err)
 		}
 

--- a/internal/btf/btf_test.go
+++ b/internal/btf/btf_test.go
@@ -112,6 +112,29 @@ func TestTypeByName(t *testing.T) {
 	}
 }
 
+func TestTypeByNameAmbiguous(t *testing.T) {
+	testutils.Files(t, testutils.Glob(t, "testdata/relocs-*.elf"), func(t *testing.T, file string) {
+		spec := parseELFBTF(t, file)
+
+		var typ *Struct
+		if err := spec.TypeByName("ambiguous", &typ); err != nil {
+			t.Fatal(err)
+		}
+
+		if name := typ.TypeName(); name != "ambiguous" {
+			t.Fatal("expected type name 'ambiguous', got:", name)
+		}
+
+		if err := spec.TypeByName("ambiguous___flavour", &typ); err != nil {
+			t.Fatal(err)
+		}
+
+		if name := typ.TypeName(); name != "ambiguous___flavour" {
+			t.Fatal("expected type name 'ambiguous___flavour', got:", name)
+		}
+	})
+}
+
 func TestParseVmlinux(t *testing.T) {
 	spec, err := parseVMLinuxBTF(t)
 	if err != nil {

--- a/internal/btf/btf_test.go
+++ b/internal/btf/btf_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/cilium/ebpf/internal/testutils"
 )
 
-func parseVmLinux(tb testing.TB) (*Spec, error) {
+func parseVMLinuxBTF(tb testing.TB) (*Spec, error) {
 	fh, err := os.Open("testdata/vmlinux-btf.gz")
 	if err != nil {
 		tb.Fatal(err)
@@ -34,13 +34,52 @@ func parseVmLinux(tb testing.TB) (*Spec, error) {
 	return spec, nil
 }
 
-func TestFindType(t *testing.T) {
-	spec, err := parseVmLinux(t)
+func parseELFBTF(tb testing.TB, file string) (*Spec, error) {
+	fh, err := os.Open(file)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	defer fh.Close()
+
+	elf, err := internal.NewSafeELFFile(fh)
+	if err != nil {
+		tb.Fatal(err)
+	}
+
+	sec := elf.Section(".BTF")
+	if sec == nil {
+		tb.Fatalf("ELF %s does not contain .BTF section", file)
+	}
+	rd := sec.Open()
+
+	return loadRawSpec(rd, elf.ByteOrder, nil, nil)
+}
+
+func TestAnyTypesByName(t *testing.T) {
+	testutils.Files(t, testutils.Glob(t, "testdata/relocs-*.elf"), func(t *testing.T, file string) {
+		spec, err := parseELFBTF(t, file)
+		if err != nil {
+			t.Fatalf("parsing ELF BTF: %v", err)
+		}
+
+		types, err := spec.AnyTypesByName("ambiguous")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(types) != 2 {
+			t.Fatalf("expected to receive exactly 2 types from querying ambiguous type, got: %v", types)
+		}
+	})
+}
+
+func TestTypeByName(t *testing.T) {
+	spec, err := parseVMLinuxBTF(t)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	// spec.FindType MUST fail if typ is not a non-nil **T, where T satisfies btf.Type.
+	// spec.TypeByName MUST fail if typ is a nil btf.Type.
 	i := 0
 	p := &i
 	for _, typ := range []interface{}{
@@ -54,33 +93,33 @@ func TestFindType(t *testing.T) {
 		p,
 		&p,
 	} {
-		if err := spec.FindType("iphdr", typ); err == nil {
-			t.Fatalf("FindType does not fail with type %T", typ)
+		if err := spec.TypeByName("iphdr", typ); err == nil {
+			t.Fatalf("TypeByName does not fail with type %T", typ)
 		}
 	}
 
-	// spec.FindType MUST return the same address for multiple calls with the same type name.
+	// spec.TypeByName MUST return the same address for multiple calls with the same type name.
 	var iphdr1, iphdr2 *Struct
-	if err := spec.FindType("iphdr", &iphdr1); err != nil {
+	if err := spec.TypeByName("iphdr", &iphdr1); err != nil {
 		t.Fatal(err)
 	}
-	if err := spec.FindType("iphdr", &iphdr2); err != nil {
+	if err := spec.TypeByName("iphdr", &iphdr2); err != nil {
 		t.Fatal(err)
 	}
 
 	if iphdr1 != iphdr2 {
-		t.Fatal("multiple FindType calls for `iphdr` name do not return the same addresses")
+		t.Fatal("multiple TypeByName calls for `iphdr` name do not return the same addresses")
 	}
 }
 
 func TestParseVmlinux(t *testing.T) {
-	spec, err := parseVmLinux(t)
+	spec, err := parseVMLinuxBTF(t)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	var iphdr *Struct
-	err = spec.FindType("iphdr", &iphdr)
+	err = spec.TypeByName("iphdr", &iphdr)
 	if err != nil {
 		t.Fatalf("unable to find `iphdr` struct: %s", err)
 	}
@@ -181,18 +220,26 @@ func TestLoadSpecFromElf(t *testing.T) {
 			t.Error("Missing BTF for the socket section")
 		}
 
+		vt, err := spec.TypeByID(0)
+		if err != nil {
+			t.Error("Can't retrieve void type by ID:", err)
+		}
+		if _, ok := vt.(*Void); !ok {
+			t.Errorf("Expected Void for type id 0, but got: %T", vt)
+		}
+
 		var bpfMapDef *Struct
-		if err := spec.FindType("bpf_map_def", &bpfMapDef); err != nil {
+		if err := spec.TypeByName("bpf_map_def", &bpfMapDef); err != nil {
 			t.Error("Can't find bpf_map_def:", err)
 		}
 
 		var tmp *Void
-		if err := spec.FindType("totally_bogus_type", &tmp); !errors.Is(err, ErrNotFound) {
-			t.Error("FindType doesn't return ErrNotFound:", err)
+		if err := spec.TypeByName("totally_bogus_type", &tmp); !errors.Is(err, ErrNotFound) {
+			t.Error("TypeByName doesn't return ErrNotFound:", err)
 		}
 
 		var fn *Func
-		if err := spec.FindType("global_fn", &fn); err != nil {
+		if err := spec.TypeByName("global_fn", &fn); err != nil {
 			t.Error("Can't find global_fn():", err)
 		} else {
 			if fn.Linkage != GlobalFunc {
@@ -201,7 +248,7 @@ func TestLoadSpecFromElf(t *testing.T) {
 		}
 
 		var v *Var
-		if err := spec.FindType("key3", &v); err != nil {
+		if err := spec.TypeByName("key3", &v); err != nil {
 			t.Error("Cant find key3:", err)
 		} else {
 			if v.Linkage != GlobalVar {
@@ -274,14 +321,14 @@ func TestHaveFuncLinkage(t *testing.T) {
 	testutils.CheckFeatureTest(t, haveFuncLinkage)
 }
 
-func ExampleSpec_FindType() {
+func ExampleSpec_TypeByName() {
 	// Acquire a Spec via one of its constructors.
 	spec := new(Spec)
 
 	// Declare a variable of the desired type
 	var foo *Struct
 
-	if err := spec.FindType("foo", &foo); err != nil {
+	if err := spec.TypeByName("foo", &foo); err != nil {
 		// There is no struct with name foo, or there
 		// are multiple possibilities.
 	}

--- a/internal/btf/core.go
+++ b/internal/btf/core.go
@@ -234,13 +234,13 @@ func coreRelocate(local, target *Spec, relos coreRelos) (COREFixups, error) {
 		}
 
 		localType := local.types[id]
-		named, ok := localType.(NamedType)
-		if !ok || named.TypeName() == "" {
+		localTypeName := localType.TypeName()
+		if localTypeName == "" {
 			return nil, fmt.Errorf("relocate unnamed or anonymous type %s: %w", localType, ErrNotSupported)
 		}
 
 		relos := relosByID[id]
-		targets := target.namedTypes[essentialName(named.TypeName())]
+		targets := target.namedTypes[essentialName(localTypeName)]
 		fixups, err := coreCalculateFixups(localType, targets, relos)
 		if err != nil {
 			return nil, fmt.Errorf("relocate %s: %w", localType, err)
@@ -262,7 +262,7 @@ var errImpossibleRelocation = errors.New("impossible relocation")
 //
 // The best target is determined by scoring: the less poisoning we have to do
 // the better the target is.
-func coreCalculateFixups(local Type, targets []NamedType, relos coreRelos) ([]COREFixup, error) {
+func coreCalculateFixups(local Type, targets []Type, relos coreRelos) ([]COREFixup, error) {
 	localID := local.ID()
 	local, err := copyType(local, skipQualifiersAndTypedefs)
 	if err != nil {

--- a/internal/btf/format_test.go
+++ b/internal/btf/format_test.go
@@ -151,16 +151,16 @@ func TestGoTypeDeclarationNamed(t *testing.T) {
 
 	tests := []struct {
 		typ    Type
-		named  []NamedType
+		named  []Type
 		output string
 	}{
-		{e1, []NamedType{e1}, "type t int32"},
-		{s1, []NamedType{e1, s1}, "type t struct { frob E1; }"},
-		{s2, []NamedType{e1}, "type t struct { frood struct { frob E1; }; }"},
-		{s2, []NamedType{e1, s1}, "type t struct { frood S1; }"},
+		{e1, []Type{e1}, "type t int32"},
+		{s1, []Type{e1, s1}, "type t struct { frob E1; }"},
+		{s2, []Type{e1}, "type t struct { frood struct { frob E1; }; }"},
+		{s2, []Type{e1, s1}, "type t struct { frood S1; }"},
 		{td, nil, "type t int32"},
-		{td, []NamedType{td}, "type t int32"},
-		{arr, []NamedType{td}, "type t [1]TD"},
+		{td, []Type{td}, "type t int32"},
+		{arr, []Type{td}, "type t [1]TD"},
 	}
 
 	for _, test := range tests {

--- a/internal/btf/types.go
+++ b/internal/btf/types.go
@@ -763,7 +763,7 @@ func (dq *typeDeque) all() []*Type {
 // Returns a map of named types (so, where NameOff is non-zero) and a slice of types
 // indexed by TypeID. Since BTF ignores compilation units, multiple types may share
 // the same name. A Type may form a cyclic graph by pointing at itself.
-func inflateRawTypes(rawTypes []rawType, rawStrings stringTable) (types []Type, namedTypes map[string][]Type, err error) {
+func inflateRawTypes(rawTypes []rawType, rawStrings stringTable) (types []Type, namedTypes map[essentialname][]Type, err error) {
 	type fixupDef struct {
 		id           TypeID
 		expectedKind btfKind
@@ -802,7 +802,7 @@ func inflateRawTypes(rawTypes []rawType, rawStrings stringTable) (types []Type, 
 
 	types = make([]Type, 0, len(rawTypes))
 	types = append(types, (*Void)(nil))
-	namedTypes = make(map[string][]Type)
+	namedTypes = make(map[essentialname][]Type)
 
 	for i, raw := range rawTypes {
 		var (
@@ -979,10 +979,10 @@ func inflateRawTypes(rawTypes []rawType, rawStrings stringTable) (types []Type, 
 // changes in kernel data structures. Anything after three underscores
 // in a type name is ignored for the purpose of finding a candidate type
 // in the kernel's BTF.
-func essentialName(name string) string {
+func essentialName(name string) essentialname {
 	lastIdx := strings.LastIndex(name, "___")
 	if lastIdx > 0 {
-		return name[:lastIdx]
+		return essentialname(name[:lastIdx])
 	}
-	return name
+	return essentialname(name)
 }

--- a/internal/btf/types.go
+++ b/internal/btf/types.go
@@ -18,9 +18,12 @@ func (tid TypeID) ID() TypeID {
 
 // Type represents a type described by BTF.
 type Type interface {
+	// The type ID of the Type within this BTF spec.
 	ID() TypeID
 
-	String() string
+	// Name of the type, empty for anonymous types and types that cannot
+	// carry a name, like Void and Pointer.
+	TypeName() string
 
 	// Make a copy of the type, without copying Type members.
 	copy() Type
@@ -28,37 +31,32 @@ type Type interface {
 	// Enumerate all nested Types. Repeated calls must visit nested
 	// types in the same order.
 	walk(*typeDeque)
-}
 
-// NamedType is a type with a name.
-type NamedType interface {
-	Type
-
-	// Name of the type, empty for anonymous types.
-	TypeName() string
+	String() string
 }
 
 var (
-	_ NamedType = (*Int)(nil)
-	_ NamedType = (*Struct)(nil)
-	_ NamedType = (*Union)(nil)
-	_ NamedType = (*Enum)(nil)
-	_ NamedType = (*Fwd)(nil)
-	_ NamedType = (*Func)(nil)
-	_ NamedType = (*Typedef)(nil)
-	_ NamedType = (*Var)(nil)
-	_ NamedType = (*Datasec)(nil)
-	_ NamedType = (*Float)(nil)
+	_ Type = (*Int)(nil)
+	_ Type = (*Struct)(nil)
+	_ Type = (*Union)(nil)
+	_ Type = (*Enum)(nil)
+	_ Type = (*Fwd)(nil)
+	_ Type = (*Func)(nil)
+	_ Type = (*Typedef)(nil)
+	_ Type = (*Var)(nil)
+	_ Type = (*Datasec)(nil)
+	_ Type = (*Float)(nil)
 )
 
 // Void is the unit type of BTF.
 type Void struct{}
 
-func (v *Void) ID() TypeID      { return 0 }
-func (v *Void) String() string  { return "void#0" }
-func (v *Void) size() uint32    { return 0 }
-func (v *Void) copy() Type      { return (*Void)(nil) }
-func (v *Void) walk(*typeDeque) {}
+func (v *Void) ID() TypeID       { return 0 }
+func (v *Void) String() string   { return "void#0" }
+func (v *Void) TypeName() string { return "" }
+func (v *Void) size() uint32     { return 0 }
+func (v *Void) copy() Type       { return (*Void)(nil) }
+func (v *Void) walk(*typeDeque)  {}
 
 type IntEncoding byte
 
@@ -83,6 +81,7 @@ func (ie IntEncoding) IsBool() bool {
 // Int is an integer of a given length.
 type Int struct {
 	TypeID
+
 	Name string
 
 	// The size of the integer in bytes.
@@ -141,6 +140,7 @@ func (p *Pointer) String() string {
 	return fmt.Sprintf("pointer#%d[target=#%d]", p.TypeID, p.Target.ID())
 }
 
+func (p *Pointer) TypeName() string    { return "" }
 func (p *Pointer) size() uint32        { return 8 }
 func (p *Pointer) walk(tdq *typeDeque) { tdq.push(&p.Target) }
 func (p *Pointer) copy() Type {
@@ -158,6 +158,8 @@ type Array struct {
 func (arr *Array) String() string {
 	return fmt.Sprintf("array#%d[type=#%d n=%d]", arr.TypeID, arr.Type.ID(), arr.Nelems)
 }
+
+func (arr *Array) TypeName() string { return "" }
 
 func (arr *Array) walk(tdq *typeDeque) { tdq.push(&arr.Type) }
 func (arr *Array) copy() Type {
@@ -355,6 +357,8 @@ func (v *Volatile) String() string {
 	return fmt.Sprintf("volatile#%d[#%d]", v.TypeID, v.Type.ID())
 }
 
+func (v *Volatile) TypeName() string { return "" }
+
 func (v *Volatile) qualify() Type       { return v.Type }
 func (v *Volatile) walk(tdq *typeDeque) { tdq.push(&v.Type) }
 func (v *Volatile) copy() Type {
@@ -372,6 +376,8 @@ func (c *Const) String() string {
 	return fmt.Sprintf("const#%d[#%d]", c.TypeID, c.Type.ID())
 }
 
+func (c *Const) TypeName() string { return "" }
+
 func (c *Const) qualify() Type       { return c.Type }
 func (c *Const) walk(tdq *typeDeque) { tdq.push(&c.Type) }
 func (c *Const) copy() Type {
@@ -388,6 +394,8 @@ type Restrict struct {
 func (r *Restrict) String() string {
 	return fmt.Sprintf("restrict#%d[#%d]", r.TypeID, r.Type.ID())
 }
+
+func (r *Restrict) TypeName() string { return "" }
 
 func (r *Restrict) qualify() Type       { return r.Type }
 func (r *Restrict) walk(tdq *typeDeque) { tdq.push(&r.Type) }
@@ -432,6 +440,8 @@ func (fp *FuncProto) String() string {
 	fmt.Fprintf(&s, "return=#%d]", fp.Return.ID())
 	return s.String()
 }
+
+func (fp *FuncProto) TypeName() string { return "" }
 
 func (fp *FuncProto) walk(tdq *typeDeque) {
 	tdq.push(&fp.Return)
@@ -753,7 +763,7 @@ func (dq *typeDeque) all() []*Type {
 // Returns a map of named types (so, where NameOff is non-zero) and a slice of types
 // indexed by TypeID. Since BTF ignores compilation units, multiple types may share
 // the same name. A Type may form a cyclic graph by pointing at itself.
-func inflateRawTypes(rawTypes []rawType, rawStrings stringTable) (types []Type, namedTypes map[string][]NamedType, err error) {
+func inflateRawTypes(rawTypes []rawType, rawStrings stringTable) (types []Type, namedTypes map[string][]Type, err error) {
 	type fixupDef struct {
 		id           TypeID
 		expectedKind btfKind
@@ -792,7 +802,7 @@ func inflateRawTypes(rawTypes []rawType, rawStrings stringTable) (types []Type, 
 
 	types = make([]Type, 0, len(rawTypes))
 	types = append(types, (*Void)(nil))
-	namedTypes = make(map[string][]NamedType)
+	namedTypes = make(map[string][]Type)
 
 	for i, raw := range rawTypes {
 		var (
@@ -936,10 +946,8 @@ func inflateRawTypes(rawTypes []rawType, rawStrings stringTable) (types []Type, 
 
 		types = append(types, typ)
 
-		if named, ok := typ.(NamedType); ok {
-			if name := essentialName(named.TypeName()); name != "" {
-				namedTypes[name] = append(namedTypes[name], named)
-			}
+		if name := essentialName(typ.TypeName()); name != "" {
+			namedTypes[name] = append(namedTypes[name], typ)
 		}
 	}
 
@@ -966,6 +974,11 @@ func inflateRawTypes(rawTypes []rawType, rawStrings stringTable) (types []Type, 
 }
 
 // essentialName returns name without a ___ suffix.
+//
+// CO-RE has the concept of 'struct flavors', which are used to deal with
+// changes in kernel data structures. Anything after three underscores
+// in a type name is ignored for the purpose of finding a candidate type
+// in the kernel's BTF.
 func essentialName(name string) string {
 	lastIdx := strings.LastIndex(name, "___")
 	if lastIdx > 0 {

--- a/internal/cmd/gentypes/main.go
+++ b/internal/cmd/gentypes/main.go
@@ -132,7 +132,7 @@ import (
 		fmt.Println("enum", o.goType)
 
 		var t *btf.Enum
-		if err := spec.FindType(o.cType, &t); err != nil {
+		if err := spec.TypeByName(o.cType, &t); err != nil {
 			return nil, err
 		}
 
@@ -192,7 +192,7 @@ import (
 		fmt.Println("struct", s.goType)
 
 		var t *btf.Struct
-		if err := spec.FindType(s.cType, &t); err != nil {
+		if err := spec.TypeByName(s.cType, &t); err != nil {
 			return nil, err
 		}
 
@@ -414,7 +414,7 @@ func outputPatchedStruct(gf *btf.GoFormatter, w *bytes.Buffer, id string, s *btf
 
 func splitBpfAttr(spec *btf.Spec) (map[string]*btf.Struct, error) {
 	var bpfAttr *btf.Union
-	if err := spec.FindType("bpf_attr", &bpfAttr); err != nil {
+	if err := spec.TypeByName("bpf_attr", &bpfAttr); err != nil {
 		return nil, err
 	}
 
@@ -564,7 +564,7 @@ func flattenAnon(s *btf.Struct) error {
 		m := &s.Members[i]
 
 		cs, ok := m.Type.(*btf.Struct)
-		if !ok || cs.Name != "" {
+		if !ok || cs.TypeName() != "" {
 			continue
 		}
 

--- a/link/tracing.go
+++ b/link/tracing.go
@@ -56,7 +56,7 @@ func AttachFreplace(targetProg *ebpf.Program, name string, prog *ebpf.Program) (
 		defer btfHandle.Close()
 
 		var function *btf.Func
-		if err := btfHandle.Spec().FindType(name, &function); err != nil {
+		if err := btfHandle.Spec().TypeByName(name, &function); err != nil {
 			return nil, err
 		}
 

--- a/prog.go
+++ b/prog.go
@@ -761,11 +761,11 @@ func resolveBTFType(spec *btf.Spec, name string, progType ProgramType, attachTyp
 
 	if isBTFTypeFunc {
 		var targetFunc *btf.Func
-		err = spec.FindType(typeName, &targetFunc)
+		err = spec.TypeByName(typeName, &targetFunc)
 		target = targetFunc
 	} else {
 		var targetTypedef *btf.Typedef
-		err = spec.FindType(typeName, &targetTypedef)
+		err = spec.TypeByName(typeName, &targetTypedef)
 		target = targetTypedef
 	}
 


### PR DESCRIPTION
This patch adds two querying primitives to btf.Spec:

- `TypeByID()` looks up a `btf.Type` by its ID in the btf.Spec
- `TypesByName()` returns a list of `btf.Type`s that satisfy the given essential name. This can be used to obtain all CO-RE flavors of a struct, to perform a quick lookup without retaining the result, or if the kind or signature of the type you're looking for is not known up front.

In order to simplify the internal graph bookkeeping, harmonize on a single `btf.Type` interface all BTF types must implement instead of the `Type` and `NamedType` interfaces. This facilitates implementing an intuitive API for querying the graph.

Further document the purpose of `essentialName()`.