### PR TITLE
cmd/bpf2go: infer llvm-strip suffix from clang binary

### DIFF
--- a/cmd/bpf2go/compile.go
+++ b/cmd/bpf2go/compile.go
@@ -208,7 +208,8 @@ func parseDependencies(baseDir string, in io.Reader) ([]dependency, error) {
 	return deps, nil
 }
 
-func strip(exe string, file string) error {
+// strip DWARF debug info from file by executing exe.
+func strip(exe, file string) error {
 	cmd := exec.Command(exe, "-g", file)
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {

--- a/cmd/bpf2go/compile_test.go
+++ b/cmd/bpf2go/compile_test.go
@@ -14,7 +14,6 @@ const minimalSocketFilter = `__attribute__((section("socket"), used)) int main()
 // Test against the minimum supported version of clang to avoid regressions.
 const (
 	clangBin = "clang-9"
-	stripBin = "llvm-strip-9"
 )
 
 func TestCompile(t *testing.T) {

--- a/cmd/bpf2go/main_test.go
+++ b/cmd/bpf2go/main_test.go
@@ -62,7 +62,6 @@ func TestRun(t *testing.T) {
 
 	err = run(io.Discard, "foo", tmpDir, []string{
 		"-cc", clangBin,
-		"-strip", stripBin,
 		"bar",
 		filepath.Join(dir, "test.c"),
 	})


### PR DESCRIPTION
llvm is often available in multiple versions, with binaries having the
major version attached as a suffix, for example clang-13. Since adding
stripping it's now necessary to pass two flags when using such
versioned binaries:

    bpf2go -cc clang-13 -strip llvm-strip-13 ...

Add a heuristic which derives the version suffix from the clang binary
and uses that to look for llvm-strip. This allows skipping the -strip
flag in the example above.