### PR TITLE
CI: remove coveralls integration

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -23,7 +23,6 @@ blocks:
           - curl -sSfL http://security.ubuntu.com/ubuntu/pool/main/c/ca-certificates/ca-certificates_20210119~20.04.2_all.deb -o /tmp/ca-certificates.deb && sudo dpkg -i /tmp/ca-certificates.deb
           - sudo mkdir -p /usr/local/golang/1.17 && curl -fL "https://golang.org/dl/go1.17.linux-amd64.tar.gz" | sudo tar -xz -C /usr/local/golang/1.17
           - sem-version go 1.17
-          - go install github.com/mattn/goveralls@latest
           - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.42.1
           - export PATH="$PATH:$(go env GOPATH)/bin"
           - cache restore
@@ -65,4 +64,3 @@ blocks:
             values: ["5.14", "5.10", "5.4", "4.19", "4.9", "4.4"]
         commands:
           - timeout -s KILL 600s ./run-tests.sh $KERNEL_VERSION
-          - goveralls -coverprofile="coverage.out" -service=semaphore -repotoken "$COVERALLS_TOKEN" || echo Submission to coveralls failed


### PR DESCRIPTION
For some reason the coveralls integration accepts our reports, but doesn't
show a diff. The interface is also very confusing and hard to navigate.
Let's remove the integration.