### PR TITLE
remove $BPF_STRIP from Makefile and bpf2go invocations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,6 @@ all: $(addsuffix -el.elf,$(TARGETS)) $(addsuffix -eb.elf,$(TARGETS)) generate
 
 # $BPF_CLANG is used in go:generate invocations.
 generate: export BPF_CLANG := $(CLANG)
-generate: export BPF_STRIP := $(STRIP)
 generate: export BPF_CFLAGS := $(CFLAGS)
 generate:
 	go generate ./cmd/bpf2go/test

--- a/cmd/bpf2go/test/doc.go
+++ b/cmd/bpf2go/test/doc.go
@@ -2,5 +2,5 @@
 // specific API.
 package test
 
-// $BPF_CLANG, $BPF_STRIP and $BPF_CFLAGS are set by the Makefile.
-//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc $BPF_CLANG -strip $BPF_STRIP test ../testdata/minimal.c
+// $BPF_CLANG and $BPF_CFLAGS are set by the Makefile.
+//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc $BPF_CLANG test ../testdata/minimal.c

--- a/examples/cgroup_skb/main.go
+++ b/examples/cgroup_skb/main.go
@@ -22,8 +22,8 @@ import (
 	"github.com/cilium/ebpf/rlimit"
 )
 
-// $BPF_CLANG, $BPF_STRIP and $BPF_CFLAGS are set by the Makefile.
-//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc $BPF_CLANG -strip $BPF_STRIP -cflags $BPF_CFLAGS bpf ./bpf/cgroup_skb_example.c -- -I../headers
+// $BPF_CLANG and $BPF_CFLAGS are set by the Makefile.
+//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc $BPF_CLANG -cflags $BPF_CFLAGS bpf ./bpf/cgroup_skb_example.c -- -I../headers
 
 var cgroupPath = ""
 

--- a/examples/fentry/main.go
+++ b/examples/fentry/main.go
@@ -33,8 +33,8 @@ import (
 	"github.com/cilium/ebpf/rlimit"
 )
 
-// $BPF_CLANG, $BPF_STRIP and $BPF_CFLAGS are set by the Makefile.
-//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc $BPF_CLANG -strip $BPF_STRIP -cflags $BPF_CFLAGS bpf ./bpf/fentry_example.c -- -I../headers
+// $BPF_CLANG and $BPF_CFLAGS are set by the Makefile.
+//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc $BPF_CLANG -cflags $BPF_CFLAGS bpf ./bpf/fentry_example.c -- -I../headers
 
 // Length of struct event_t sent from kernelspace.
 var eventLength = 28

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -3,6 +3,6 @@ module github.com/cilium/ebpf/examples
 go 1.16
 
 require (
-	github.com/cilium/ebpf v0.7.1-0.20211123152238-8df2d8a42fb0
+	github.com/cilium/ebpf v0.7.1-0.20211126075831-9ead52e53c13
 	golang.org/x/sys v0.0.0-20211001092434-39dca1131b70
 )

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -1,5 +1,5 @@
-github.com/cilium/ebpf v0.7.1-0.20211123152238-8df2d8a42fb0 h1:Qs71uPZOk0Jplz4Dj9BNQidNL7t2R6NewE4t7kCQ3yA=
-github.com/cilium/ebpf v0.7.1-0.20211123152238-8df2d8a42fb0/go.mod h1:f5zLIM0FSNuAkSyLAN7X+Hy6yznlF1mNiWUMfxMtrgk=
+github.com/cilium/ebpf v0.7.1-0.20211126075831-9ead52e53c13 h1:VrGaFU0ySWPDWlVQ7upRMX16MmU/hr6zw3Hia2HHmFM=
+github.com/cilium/ebpf v0.7.1-0.20211126075831-9ead52e53c13/go.mod h1:f5zLIM0FSNuAkSyLAN7X+Hy6yznlF1mNiWUMfxMtrgk=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/frankban/quicktest v1.14.0 h1:+cqqvzZV87b4adx/5ayVOaYZ2CrvM4ejQvUdBzPPUss=
 github.com/frankban/quicktest v1.14.0/go.mod h1:NeW+ay9A/U67EYXNFA1nPE8e/tnQv/09mUdL/ijj8og=

--- a/examples/kprobe/main.go
+++ b/examples/kprobe/main.go
@@ -18,8 +18,8 @@ import (
 	"github.com/cilium/ebpf/rlimit"
 )
 
-// $BPF_CLANG, $BPF_STRIP and $BPF_CFLAGS are set by the Makefile.
-//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc $BPF_CLANG -strip $BPF_STRIP -cflags $BPF_CFLAGS bpf ./bpf/kprobe_example.c -- -I../headers
+// $BPF_CLANG and $BPF_CFLAGS are set by the Makefile.
+//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc $BPF_CLANG -cflags $BPF_CFLAGS bpf ./bpf/kprobe_example.c -- -I../headers
 
 const mapKey uint32 = 0
 

--- a/examples/kprobe_percpu/main.go
+++ b/examples/kprobe_percpu/main.go
@@ -18,8 +18,8 @@ import (
 	"github.com/cilium/ebpf/rlimit"
 )
 
-// $BPF_CLANG, $BPF_STRIP and $BPF_CFLAGS are set by the Makefile.
-//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc $BPF_CLANG -strip $BPF_STRIP -cflags $BPF_CFLAGS bpf ./bpf/kprobe_percpu_example.c -- -I../headers
+// $BPF_CLANG and $BPF_CFLAGS are set by the Makefile.
+//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc $BPF_CLANG -cflags $BPF_CFLAGS bpf ./bpf/kprobe_percpu_example.c -- -I../headers
 
 const mapKey uint32 = 0
 

--- a/examples/kprobepin/main.go
+++ b/examples/kprobepin/main.go
@@ -20,8 +20,8 @@ import (
 	"github.com/cilium/ebpf/rlimit"
 )
 
-// $BPF_CLANG, $BPF_STRIP and $BPF_CFLAGS are set by the Makefile.
-//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc $BPF_CLANG -strip $BPF_STRIP -cflags $BPF_CFLAGS bpf ./bpf/kprobe_pin_example.c -- -I../headers
+// $BPF_CLANG and $BPF_CFLAGS are set by the Makefile.
+//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc $BPF_CLANG -cflags $BPF_CFLAGS bpf ./bpf/kprobe_pin_example.c -- -I../headers
 
 const (
 	mapKey    uint32 = 0

--- a/examples/ringbuffer/main.go
+++ b/examples/ringbuffer/main.go
@@ -18,8 +18,8 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// $BPF_CLANG, $BPF_STRIP and $BPF_CFLAGS are set by the Makefile.
-//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc $BPF_CLANG -strip $BPF_STRIP -cflags $BPF_CFLAGS bpf ./bpf/ringbuffer_example.c -- -I../headers
+// $BPF_CLANG and $BPF_CFLAGS are set by the Makefile.
+//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc $BPF_CLANG -cflags $BPF_CFLAGS bpf ./bpf/ringbuffer_example.c -- -I../headers
 
 // An Event represents a ringbuf event sent to userspace from the eBPF program
 // running in the kernel. Note that this must match the C event_t structure,

--- a/examples/tracepoint_in_c/main.go
+++ b/examples/tracepoint_in_c/main.go
@@ -18,8 +18,8 @@ import (
 	"github.com/cilium/ebpf/rlimit"
 )
 
-// $BPF_CLANG, $BPF_STRIP and $BPF_CFLAGS are set by the Makefile.
-//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc $BPF_CLANG -strip $BPF_STRIP -cflags $BPF_CFLAGS bpf ./bpf/handler.c -- -I../headers
+// $BPF_CLANG and $BPF_CFLAGS are set by the Makefile.
+//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc $BPF_CLANG -cflags $BPF_CFLAGS bpf ./bpf/handler.c -- -I../headers
 
 const mapKey uint32 = 0
 

--- a/examples/uretprobe/main.go
+++ b/examples/uretprobe/main.go
@@ -21,8 +21,8 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// $BPF_CLANG, $BPF_STRIP and $BPF_CFLAGS are set by the Makefile.
-//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc $BPF_CLANG -strip $BPF_STRIP -cflags $BPF_CFLAGS bpf ./bpf/uretprobe_example.c -- -I../headers
+// $BPF_CLANG and $BPF_CFLAGS are set by the Makefile.
+//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc $BPF_CLANG -cflags $BPF_CFLAGS bpf ./bpf/uretprobe_example.c -- -I../headers
 
 // An Event represents a perf event sent to userspace from the eBPF program
 // running in the kernel. Note that this must match the C event_t structure,


### PR DESCRIPTION
It's not necessary to pass separate -strip flags since we have the
version suffix heuristic. Remove $BPF_STRIP from bpf2go invocations.