### PR TITLE
elf_reader,btf: support multiple programs per ELF section

### DIFF
--- a/asm/instruction.go
+++ b/asm/instruction.go
@@ -26,13 +26,17 @@ func (rio RawInstructionOffset) Bytes() uint64 {
 
 // Instruction is a single eBPF instruction.
 type Instruction struct {
-	OpCode    OpCode
-	Dst       Register
-	Src       Register
-	Offset    int16
-	Constant  int64
+	OpCode   OpCode
+	Dst      Register
+	Src      Register
+	Offset   int16
+	Constant int64
+
+	// Reference denotes a reference (e.g. a jump) to another symbol.
 	Reference string
-	Symbol    string
+
+	// Symbol denotes an instruction at the start of a function body.
+	Symbol string
 }
 
 // Sym creates a symbol.
@@ -184,6 +188,13 @@ func (ins *Instruction) IsFunctionCall() bool {
 // IsLoadOfFunctionPointer returns true if the instruction loads a function pointer.
 func (ins *Instruction) IsLoadOfFunctionPointer() bool {
 	return ins.OpCode.IsDWordLoad() && ins.Src == PseudoFunc
+}
+
+// IsFunctionReference returns true if the instruction references another BPF
+// function, either by invoking a Call jump operation or by loading a function
+// pointer.
+func (ins *Instruction) IsFunctionReference() bool {
+	return ins.IsFunctionCall() || ins.IsLoadOfFunctionPointer()
 }
 
 // IsBuiltinCall returns true if the instruction is a built-in call, i.e. BPF helper call.
@@ -348,6 +359,31 @@ func (insns Instructions) SymbolOffsets() (map[string]int, error) {
 	}
 
 	return offsets, nil
+}
+
+// FunctionReferences returns a set of symbol names these Instructions make
+// bpf-to-bpf calls to.
+func (insns Instructions) FunctionReferences() map[string]bool {
+	calls := make(map[string]bool)
+
+	for _, ins := range insns {
+		if ins.Constant != -1 {
+			// BPF-to-BPF calls have -1 constants.
+			continue
+		}
+
+		if ins.Reference == "" {
+			continue
+		}
+
+		if !ins.IsFunctionReference() {
+			continue
+		}
+
+		calls[ins.Reference] = true
+	}
+
+	return calls
 }
 
 // ReferenceOffsets returns the set of references and their offset in

--- a/asm/instruction.go
+++ b/asm/instruction.go
@@ -299,6 +299,14 @@ func (ins Instruction) Size() uint64 {
 // Instructions is an eBPF program.
 type Instructions []Instruction
 
+// Name returns the name of the function insns belongs to, if any.
+func (insns Instructions) Name() string {
+	if len(insns) == 0 {
+		return ""
+	}
+	return insns[0].Symbol
+}
+
 func (insns Instructions) String() string {
 	return fmt.Sprint(insns)
 }

--- a/collection.go
+++ b/collection.go
@@ -426,7 +426,8 @@ func (cl *collectionLoader) loadProgram(progName string) (*Program, error) {
 
 	progSpec = progSpec.Copy()
 
-	// Rewrite any reference to a valid map.
+	// Rewrite any reference to a valid map in the program's instructions,
+	// which includes all of its dependencies.
 	for i := range progSpec.Instructions {
 		ins := &progSpec.Instructions[i]
 

--- a/elf_reader.go
+++ b/elf_reader.go
@@ -100,37 +100,6 @@ func LoadCollectionSpecFromReader(rd io.ReaderAt) (*CollectionSpec, error) {
 		return nil, fmt.Errorf("load BTF: %w", err)
 	}
 
-	// Assign symbols to all the sections we're interested in.
-	symbols, err := f.Symbols()
-	if err != nil {
-		return nil, fmt.Errorf("load symbols: %v", err)
-	}
-
-	for _, symbol := range symbols {
-		idx := symbol.Section
-		symType := elf.ST_TYPE(symbol.Info)
-
-		section := sections[idx]
-		if section == nil {
-			continue
-		}
-
-		// Older versions of LLVM don't tag symbols correctly, so keep
-		// all NOTYPE ones.
-		keep := symType == elf.STT_NOTYPE
-		switch section.kind {
-		case mapSection, btfMapSection, dataSection:
-			keep = keep || symType == elf.STT_OBJECT
-		case programSection:
-			keep = keep || symType == elf.STT_FUNC
-		}
-		if !keep || symbol.Name == "" {
-			continue
-		}
-
-		section.symbols[symbol.Value] = symbol
-	}
-
 	ec := &elfCode{
 		SafeELFFile: f,
 		sections:    sections,
@@ -138,6 +107,13 @@ func LoadCollectionSpecFromReader(rd io.ReaderAt) (*CollectionSpec, error) {
 		version:     version,
 		btf:         btfSpec,
 	}
+
+	symbols, err := f.Symbols()
+	if err != nil {
+		return nil, fmt.Errorf("load symbols: %v", err)
+	}
+
+	ec.assignSymbols(symbols)
 
 	// Go through relocation sections, and parse the ones for sections we're
 	// interested in. Make sure that relocations point at valid sections.
@@ -244,6 +220,48 @@ func newElfSection(section *elf.Section, kind elfSectionKind) *elfSection {
 		make(map[uint64]elf.Symbol),
 		make(map[uint64]elf.Symbol),
 		0,
+	}
+}
+
+// assignSymbols takes a list of symbols and assigns them to their
+// respective sections, indexed by name.
+func (ec *elfCode) assignSymbols(symbols []elf.Symbol) {
+	for _, symbol := range symbols {
+		symType := elf.ST_TYPE(symbol.Info)
+		symSection := ec.sections[symbol.Section]
+		if symSection == nil {
+			continue
+		}
+
+		// Anonymous symbols only occur in debug sections which we don't process
+		// relocations for. Anonymous symbols are not referenced from other sections.
+		if symbol.Name == "" {
+			continue
+		}
+
+		// Older versions of LLVM don't tag symbols correctly, so keep
+		// all NOTYPE ones.
+		switch symSection.kind {
+		case mapSection, btfMapSection, dataSection:
+			if symType != elf.STT_NOTYPE && symType != elf.STT_OBJECT {
+				continue
+			}
+		case programSection:
+			if symType != elf.STT_NOTYPE && symType != elf.STT_FUNC {
+				continue
+			}
+			// LLVM emits LBB_ (Local Basic Block) symbols that seem to be jump
+			// targets within sections, but BPF has no use for them.
+			if symType == elf.STT_NOTYPE && elf.ST_BIND(symbol.Info) == elf.STB_LOCAL &&
+				strings.HasPrefix(symbol.Name, "LBB") {
+				continue
+			}
+		// Only collect symbols that occur in program/maps/data sections.
+		default:
+			continue
+		}
+
+		symSection.symbols[symbol.Value] = symbol
 	}
 }
 

--- a/elf_reader.go
+++ b/elf_reader.go
@@ -390,8 +390,13 @@ func (ec *elfCode) loadFunctions(section *elfSection) (map[string]asm.Instructio
 			// When splitting sections into subprograms, the targets of these calls
 			// are no longer in scope, so they must be resolved here.
 			if ins.IsFunctionReference() && ins.Constant != -1 {
-				jmp := uint64(int64(offset) + (ins.Constant+1)*asm.InstructionSize)
-				ins.Reference = section.symbols[jmp].Name
+				tgt := jumpTarget(offset, ins)
+				sym := section.symbols[tgt].Name
+				if sym == "" {
+					return nil, fmt.Errorf("offset %d: no jump target found at offset %d", offset, tgt)
+				}
+
+				ins.Reference = sym
 				ins.Constant = -1
 			}
 		}
@@ -401,6 +406,24 @@ func (ec *elfCode) loadFunctions(section *elfSection) (map[string]asm.Instructio
 	}
 
 	return funcs, nil
+}
+
+// jumpTarget takes ins' offset within an instruction stream (in bytes)
+// and returns its absolute jump destination (in bytes) within the
+// instruction stream.
+func jumpTarget(offset uint64, ins asm.Instruction) uint64 {
+	// A relative jump instruction describes the amount of raw BPF instructions
+	// to jump, convert the offset into bytes.
+	dest := ins.Constant * asm.InstructionSize
+
+	// The starting point of the jump is the end of the current instruction.
+	dest += int64(offset + asm.InstructionSize)
+
+	if dest < 0 {
+		return 0
+	}
+
+	return uint64(dest)
 }
 
 func (ec *elfCode) relocateInstruction(ins *asm.Instruction, rel elf.Symbol) error {

--- a/elf_reader.go
+++ b/elf_reader.go
@@ -339,48 +339,42 @@ func (ec *elfCode) loadProgramSections() (map[string]*ProgramSpec, error) {
 //
 // The resulting map is indexed by function name.
 func (ec *elfCode) loadFunctions(section *elfSection) (map[string]asm.Instructions, error) {
-	funcs := make(map[string]asm.Instructions)
-	for _, sym := range section.symbols {
-		// Load the function's instructions given the ELF section and the
-		// function's symbol containing the offset and length of the function.
-		si, err := ec.loadInstructions(section, sym)
-		if err != nil {
-			return nil, fmt.Errorf("loading instructions: %w", err)
+	var (
+		r      = bufio.NewReader(section.Open())
+		funcs  = make(map[string]asm.Instructions)
+		offset uint64
+		insns  asm.Instructions
+	)
+	for {
+		ins := asm.Instruction{
+			// Symbols denote the first instruction of a function body.
+			Symbol: section.symbols[offset].Name,
 		}
 
-		funcs[sym.Name] = si
-	}
-
-	return funcs, nil
-}
-
-// loadInstructions extracts the instruction stream of the given symbol
-// from the given ELF section.
-func (ec *elfCode) loadInstructions(section *elfSection, sym elf.Symbol) (asm.Instructions, error) {
-	// clang up until at least version 7 does not set the symbol's size field.
-	// In this case, buffer the remainder of the section, since we only read up
-	// to the first Exit instruction.
-	if sym.Size == 0 {
-		// Don't use Max(U)Int64, the offset is added to this number
-		// during SectionReader creation and will overflow.
-		sym.Size = section.Size
-	}
-
-	r := internal.NewBufferedSectionReader(section, int64(sym.Value), int64(sym.Size))
-
-	// Starting point of the function within the section.
-	offset := sym.Value
-
-	var insns asm.Instructions
-	for {
-		var ins asm.Instruction
+		// Pull one instruction from the instruction stream.
 		n, err := ins.Unmarshal(r, ec.ByteOrder)
+		if errors.Is(err, io.EOF) {
+			fn := insns.Name()
+			if fn == "" {
+				return nil, errors.New("reached EOF before finding a valid symbol")
+			}
+
+			// Reached the end of the section and the decoded instruction buffer
+			// contains at least one valid instruction belonging to a function.
+			// Store the result and stop processing instructions.
+			funcs[fn] = insns
+			break
+		}
 		if err != nil {
-			// EOF is an error, a valid instruction stream ends with an Exit instruction.
 			return nil, fmt.Errorf("offset %d: %w", offset, err)
 		}
 
-		ins.Symbol = section.symbols[offset].Name
+		// Decoded the first instruction of a function body but insns already
+		// holds a valid instruction stream. Store the result and flush insns.
+		if ins.Symbol != "" && insns.Name() != "" {
+			funcs[insns.Name()] = insns
+			insns = nil
+		}
 
 		if rel, ok := section.relocations[offset]; ok {
 			// A relocation was found for the current offset. Apply it to the insn.
@@ -404,18 +398,9 @@ func (ec *elfCode) loadInstructions(section *elfSection, sym elf.Symbol) (asm.In
 
 		insns = append(insns, ins)
 		offset += n
-
-		// Read up until the first exit instruction.
-		if ins.OpCode.JumpOp() == asm.Exit {
-			break
-		}
 	}
 
-	if len(insns) == 0 {
-		return nil, errors.New("no instructions")
-	}
-
-	return insns, nil
+	return funcs, nil
 }
 
 func (ec *elfCode) relocateInstruction(ins *asm.Instruction, rel elf.Symbol) error {

--- a/elf_reader.go
+++ b/elf_reader.go
@@ -159,7 +159,7 @@ func LoadCollectionSpecFromReader(rd io.ReaderAt) (*CollectionSpec, error) {
 	}
 
 	// Finally, collect programs and link them.
-	progs, err := ec.loadPrograms()
+	progs, err := ec.loadProgramSections()
 	if err != nil {
 		return nil, fmt.Errorf("load programs: %w", err)
 	}
@@ -265,12 +265,15 @@ func (ec *elfCode) assignSymbols(symbols []elf.Symbol) {
 	}
 }
 
-func (ec *elfCode) loadPrograms() (map[string]*ProgramSpec, error) {
-	var (
-		progs []*ProgramSpec
-		libs  []*ProgramSpec
-	)
+// loadProgramSections iterates ec's sections and emits a ProgramSpec
+// for each function it finds.
+//
+// The resulting map is indexed by function name.
+func (ec *elfCode) loadProgramSections() (map[string]*ProgramSpec, error) {
 
+	progs := make(map[string]*ProgramSpec)
+
+	// Generate a ProgramSpec for each function found in each program section.
 	for _, sec := range ec.sections {
 		if sec.kind != programSection {
 			continue
@@ -280,86 +283,139 @@ func (ec *elfCode) loadPrograms() (map[string]*ProgramSpec, error) {
 			return nil, fmt.Errorf("section %v: missing symbols", sec.Name)
 		}
 
-		funcSym, ok := sec.symbols[0]
-		if !ok {
-			return nil, fmt.Errorf("section %v: no label at start", sec.Name)
-		}
-
-		insns, length, err := ec.loadInstructions(sec)
+		funcs, err := ec.loadFunctions(sec)
 		if err != nil {
-			return nil, fmt.Errorf("program %s: %w", funcSym.Name, err)
+			return nil, fmt.Errorf("section %v: %w", sec.Name, err)
 		}
 
 		progType, attachType, progFlags, attachTo := getProgType(sec.Name)
 
-		spec := &ProgramSpec{
-			Name:          funcSym.Name,
-			Type:          progType,
-			Flags:         progFlags,
-			AttachType:    attachType,
-			AttachTo:      attachTo,
-			License:       ec.license,
-			KernelVersion: ec.version,
-			Instructions:  insns,
-			ByteOrder:     ec.ByteOrder,
-		}
-
-		if ec.btf != nil {
-			spec.BTF, err = ec.btf.Program(sec.Name, length)
-			if err != nil && !errors.Is(err, btf.ErrNoExtendedInfo) {
-				return nil, fmt.Errorf("program %s: %w", funcSym.Name, err)
+		for name, insns := range funcs {
+			spec := &ProgramSpec{
+				Name:          name,
+				Type:          progType,
+				Flags:         progFlags,
+				AttachType:    attachType,
+				AttachTo:      attachTo,
+				License:       ec.license,
+				KernelVersion: ec.version,
+				Instructions:  insns,
+				ByteOrder:     ec.ByteOrder,
 			}
-		}
 
-		if spec.Type == UnspecifiedProgram {
-			// There is no single name we can use for "library" sections,
-			// since they may contain multiple functions. We'll decode the
-			// labels they contain later on, and then link sections that way.
-			libs = append(libs, spec)
-		} else {
-			progs = append(progs, spec)
+			if ec.btf != nil {
+				spec.BTF, err = ec.btf.Program(name)
+				if err != nil && !errors.Is(err, btf.ErrNoExtendedInfo) {
+					return nil, fmt.Errorf("program %s: %w", name, err)
+				}
+			}
+
+			// Function names must be unique within a single ELF blob.
+			if progs[name] != nil {
+				return nil, fmt.Errorf("duplicate program name %s", name)
+			}
+			progs[name] = spec
 		}
 	}
 
-	res := make(map[string]*ProgramSpec, len(progs))
-	for _, prog := range progs {
-		err := link(prog, libs)
-		if err != nil {
-			return nil, fmt.Errorf("program %s: %w", prog.Name, err)
-		}
-		res[prog.Name] = prog
+	// Populate each prog's references with pointers to all of its callees.
+	if err := populateReferences(progs); err != nil {
+		return nil, fmt.Errorf("populating references: %w", err)
 	}
 
-	return res, nil
+	// Don't emit programs of unknown type to preserve backwards compatibility.
+	for n, p := range progs {
+		if p.Type == UnspecifiedProgram {
+			delete(progs, n)
+		}
+	}
+
+	return progs, nil
 }
 
-func (ec *elfCode) loadInstructions(section *elfSection) (asm.Instructions, uint64, error) {
-	var (
-		r      = bufio.NewReader(section.Open())
-		insns  asm.Instructions
-		offset uint64
-	)
+// loadFunctions extracts instruction streams from the given program section
+// starting at each symbol in the section. The section's symbols must already
+// be narrowed down to STT_NOTYPE (emitted by clang <8) or STT_FUNC.
+//
+// The resulting map is indexed by function name.
+func (ec *elfCode) loadFunctions(section *elfSection) (map[string]asm.Instructions, error) {
+	funcs := make(map[string]asm.Instructions)
+	for _, sym := range section.symbols {
+		// Load the function's instructions given the ELF section and the
+		// function's symbol containing the offset and length of the function.
+		si, err := ec.loadInstructions(section, sym)
+		if err != nil {
+			return nil, fmt.Errorf("loading instructions: %w", err)
+		}
+
+		funcs[sym.Name] = si
+	}
+
+	return funcs, nil
+}
+
+// loadInstructions extracts the instruction stream of the given symbol
+// from the given ELF section.
+func (ec *elfCode) loadInstructions(section *elfSection, sym elf.Symbol) (asm.Instructions, error) {
+	// clang up until at least version 7 does not set the symbol's size field.
+	// In this case, buffer the remainder of the section, since we only read up
+	// to the first Exit instruction.
+	if sym.Size == 0 {
+		// Don't use Max(U)Int64, the offset is added to this number
+		// during SectionReader creation and will overflow.
+		sym.Size = section.Size
+	}
+
+	r := internal.NewBufferedSectionReader(section, int64(sym.Value), int64(sym.Size))
+
+	// Starting point of the function within the section.
+	offset := sym.Value
+
+	var insns asm.Instructions
 	for {
 		var ins asm.Instruction
 		n, err := ins.Unmarshal(r, ec.ByteOrder)
-		if err == io.EOF {
-			return insns, offset, nil
-		}
 		if err != nil {
-			return nil, 0, fmt.Errorf("offset %d: %w", offset, err)
+			// EOF is an error, a valid instruction stream ends with an Exit instruction.
+			return nil, fmt.Errorf("offset %d: %w", offset, err)
 		}
 
 		ins.Symbol = section.symbols[offset].Name
 
 		if rel, ok := section.relocations[offset]; ok {
+			// A relocation was found for the current offset. Apply it to the insn.
 			if err = ec.relocateInstruction(&ins, rel); err != nil {
-				return nil, 0, fmt.Errorf("offset %d: relocate instruction: %w", offset, err)
+				return nil, fmt.Errorf("offset %d: relocate instruction: %w", offset, err)
+			}
+		} else {
+			// Up to LLVM 9, calls to subprograms within the same ELF section are
+			// sometimes encoded using relative jumps without relocation entries.
+			// If, after all relocations entries have been processed, there are
+			// still relative pseudocalls left, they must point to an existing
+			// symbol within the section.
+			// When splitting sections into subprograms, the targets of these calls
+			// are no longer in scope, so they must be resolved here.
+			if ins.IsFunctionReference() && ins.Constant != -1 {
+				jmp := uint64(int64(offset) + (ins.Constant+1)*asm.InstructionSize)
+				ins.Reference = section.symbols[jmp].Name
+				ins.Constant = -1
 			}
 		}
 
 		insns = append(insns, ins)
 		offset += n
+
+		// Read up until the first exit instruction.
+		if ins.OpCode.JumpOp() == asm.Exit {
+			break
+		}
 	}
+
+	if len(insns) == 0 {
+		return nil, errors.New("no instructions")
+	}
+
+	return insns, nil
 }
 
 func (ec *elfCode) relocateInstruction(ins *asm.Instruction, rel elf.Symbol) error {

--- a/elf_reader_test.go
+++ b/elf_reader_test.go
@@ -129,6 +129,7 @@ func TestLoadCollectionSpec(t *testing.T) {
 		cmpopts.IgnoreTypes(new(btf.Map), new(btf.Program)),
 		cmpopts.IgnoreFields(CollectionSpec{}, "ByteOrder"),
 		cmpopts.IgnoreFields(ProgramSpec{}, "Instructions", "ByteOrder"),
+		cmpopts.IgnoreUnexported(ProgramSpec{}),
 		cmpopts.IgnoreMapEntries(func(key string, _ *MapSpec) bool {
 			switch key {
 			case ".bss", ".data", ".rodata":

--- a/internal/btf/btf_test.go
+++ b/internal/btf/btf_test.go
@@ -190,16 +190,12 @@ func TestLoadSpecFromElf(t *testing.T) {
 	testutils.Files(t, testutils.Glob(t, "../../testdata/loader-e*.elf"), func(t *testing.T, file string) {
 		spec := parseELFBTF(t, file)
 
-		if sec, err := spec.Program("xdp", 1); err != nil {
-			t.Error("Can't get BTF for the xdp section:", err)
-		} else if sec == nil {
-			t.Error("Missing BTF for the xdp section")
+		if prog, err := spec.Program("xdp_prog"); err != nil || prog == nil {
+			t.Error("Can't get BTF for program xdp_prog:", err)
 		}
 
-		if sec, err := spec.Program("socket", 1); err != nil {
-			t.Error("Can't get BTF for the socket section:", err)
-		} else if sec == nil {
-			t.Error("Missing BTF for the socket section")
+		if prog, err := spec.Program("no_relocation"); err != nil || prog == nil {
+			t.Error("Can't get BTF for program no_relocation:", err)
 		}
 
 		vt, err := spec.TypeByID(0)

--- a/internal/btf/core.go
+++ b/internal/btf/core.go
@@ -97,7 +97,7 @@ func (f COREFixup) isNonExistant() bool {
 
 type COREFixups map[uint64]COREFixup
 
-// Apply a set of CO-RE relocations to a BPF program.
+// Apply returns a copy of insns with CO-RE relocations applied.
 func (fs COREFixups) Apply(insns asm.Instructions) (asm.Instructions, error) {
 	if len(fs) == 0 {
 		cpy := make(asm.Instructions, len(insns))
@@ -191,13 +191,13 @@ func (k COREKind) checksForExistence() bool {
 	return k == reloEnumvalExists || k == reloTypeExists || k == reloFieldExists
 }
 
-func coreRelocate(local, target *Spec, relos coreRelos) (COREFixups, error) {
+func coreRelocate(local, target *Spec, relos CoreRelos) (COREFixups, error) {
 	if local.byteOrder != target.byteOrder {
 		return nil, fmt.Errorf("can't relocate %s against %s", local.byteOrder, target.byteOrder)
 	}
 
 	var ids []TypeID
-	relosByID := make(map[TypeID]coreRelos)
+	relosByID := make(map[TypeID]CoreRelos)
 	result := make(COREFixups, len(relos))
 	for _, relo := range relos {
 		if relo.kind == reloTypeIDLocal {
@@ -262,7 +262,7 @@ var errImpossibleRelocation = errors.New("impossible relocation")
 //
 // The best target is determined by scoring: the less poisoning we have to do
 // the better the target is.
-func coreCalculateFixups(local Type, targets []Type, relos coreRelos) ([]COREFixup, error) {
+func coreCalculateFixups(local Type, targets []Type, relos CoreRelos) ([]COREFixup, error) {
 	localID := local.ID()
 	local, err := copyType(local, skipQualifiersAndTypedefs)
 	if err != nil {
@@ -326,7 +326,7 @@ func coreCalculateFixups(local Type, targets []Type, relos coreRelos) ([]COREFix
 
 // coreCalculateFixup calculates the fixup for a single local type, target type
 // and relocation.
-func coreCalculateFixup(local Type, localID TypeID, target Type, targetID TypeID, relo coreRelo) (COREFixup, error) {
+func coreCalculateFixup(local Type, localID TypeID, target Type, targetID TypeID, relo CoreRelo) (COREFixup, error) {
 	fixup := func(local, target uint32) (COREFixup, error) {
 		return COREFixup{relo.kind, local, target, false}, nil
 	}

--- a/internal/btf/core_test.go
+++ b/internal/btf/core_test.go
@@ -504,7 +504,7 @@ func TestCoreRelocation(t *testing.T) {
 		for section := range spec.funcInfos {
 			name := strings.TrimPrefix(section, "socket_filter/")
 			t.Run(name, func(t *testing.T) {
-				prog, err := spec.Program(section, 1)
+				prog, err := spec.Program(section)
 				if err != nil {
 					t.Fatal("Retrieve program:", err)
 				}

--- a/internal/btf/ext_info_test.go
+++ b/internal/btf/ext_info_test.go
@@ -10,8 +10,12 @@ import (
 func TestParseExtInfoBigRecordSize(t *testing.T) {
 	rd := strings.NewReader("\xff\xff\xff\xff\x00\x00\x00\x000709171295166016")
 	table := stringTable("\x00")
-	_, err := parseExtInfo(rd, internal.NativeEndian, table)
-	if err == nil {
-		t.Error("Parsing ext info with large record size doesn't return an error")
+
+	if _, err := parseFuncInfos(rd, internal.NativeEndian, table); err == nil {
+		t.Error("Parsing func info with large record size doesn't return an error")
+	}
+
+	if _, err := parseLineInfos(rd, internal.NativeEndian, table); err == nil {
+		t.Error("Parsing line info with large record size doesn't return an error")
 	}
 }

--- a/linker.go
+++ b/linker.go
@@ -1,87 +1,115 @@
 package ebpf
 
 import (
+	"bytes"
+	"encoding/binary"
 	"fmt"
 
 	"github.com/cilium/ebpf/asm"
+	"github.com/cilium/ebpf/internal/btf"
 )
 
-// link resolves bpf-to-bpf calls.
+// The linker is responsible for resolving bpf-to-bpf calls between programs
+// within an ELF. Each BPF program must be a self-contained binary blob,
+// so when an instruction in one ELF program section wants to jump to
+// a function in another, the linker needs to pull in the bytecode
+// (and BTF info) of the target function and concatenate the instruction
+// streams.
 //
-// Each library may contain multiple functions / labels, and is only linked
-// if prog references one of these functions.
+// Later on in the pipeline, all call sites are fixed up with relative jumps
+// within this newly-created instruction stream to then finally hand off to
+// the kernel with BPF_PROG_LOAD.
 //
-// Libraries also linked.
-func link(prog *ProgramSpec, libs []*ProgramSpec) error {
-	var (
-		linked  = make(map[*ProgramSpec]bool)
-		pending = []asm.Instructions{prog.Instructions}
-		insns   asm.Instructions
-	)
-	for len(pending) > 0 {
-		insns, pending = pending[0], pending[1:]
-		for _, lib := range libs {
-			if linked[lib] {
-				continue
-			}
+// Each function is denoted by an ELF symbol and the compiler takes care of
+// register setup before each jump instruction.
 
-			needed, err := needSection(insns, lib.Instructions)
-			if err != nil {
-				return fmt.Errorf("linking %s: %w", lib.Name, err)
-			}
+// populateReferences populates all of progs' Instructions and references
+// with their full dependency chains including transient dependencies.
+func populateReferences(progs map[string]*ProgramSpec) error {
+	type props struct {
+		insns asm.Instructions
+		refs  map[string]*ProgramSpec
+	}
 
-			if !needed {
-				continue
-			}
+	out := make(map[string]props)
 
-			linked[lib] = true
-			prog.Instructions = append(prog.Instructions, lib.Instructions...)
-			pending = append(pending, lib.Instructions)
+	// Resolve and store direct references between all progs.
+	if err := findReferences(progs); err != nil {
+		return fmt.Errorf("finding references: %w", err)
+	}
 
-			if prog.BTF != nil && lib.BTF != nil {
-				if err := prog.BTF.Append(lib.BTF); err != nil {
-					return fmt.Errorf("linking BTF of %s: %w", lib.Name, err)
-				}
+	// Flatten all progs' instruction streams.
+	for name, prog := range progs {
+		insns, refs := prog.flatten(nil)
+
+		prop := props{
+			insns: insns,
+			refs:  refs,
+		}
+
+		out[name] = prop
+	}
+
+	// Replace all progs' instructions and references
+	for name, props := range out {
+		progs[name].Instructions = props.insns
+		progs[name].references = props.refs
+	}
+
+	return nil
+}
+
+// findReferences finds bpf-to-bpf calls between progs and populates each
+// prog's references field with its direct neighbours.
+func findReferences(progs map[string]*ProgramSpec) error {
+	// Check all ProgramSpecs in the collection against each other.
+	for _, prog := range progs {
+		prog.references = make(map[string]*ProgramSpec)
+
+		// Look up call targets in progs and store pointers to their corresponding
+		// ProgramSpecs as direct references.
+		for refname := range prog.Instructions.FunctionReferences() {
+			ref := progs[refname]
+			if ref == nil {
+				return fmt.Errorf("symbol reference %s not present in progs", refname)
 			}
+			prog.references[refname] = ref
 		}
 	}
 
 	return nil
 }
 
-func needSection(insns, section asm.Instructions) (bool, error) {
-	// A map of symbols to the libraries which contain them.
-	symbols, err := section.SymbolOffsets()
-	if err != nil {
-		return false, err
+// marshalFuncInfos returns the BTF func infos of all progs in order.
+func marshalFuncInfos(layout []reference) ([]byte, error) {
+	if len(layout) == 0 {
+		return nil, nil
 	}
 
-	for _, ins := range insns {
-		if ins.Reference == "" {
-			continue
+	buf := bytes.NewBuffer(make([]byte, 0, binary.Size(&btf.FuncInfo{})*len(layout)))
+	for _, sym := range layout {
+		if err := sym.spec.BTF.FuncInfo.Marshal(buf, sym.offset); err != nil {
+			return nil, fmt.Errorf("marshaling prog %s func info: %w", sym.spec.Name, err)
 		}
-
-		if !ins.IsFunctionCall() && !ins.IsLoadOfFunctionPointer() {
-			continue
-		}
-
-		if ins.Constant != -1 {
-			// This is already a valid call, no need to link again.
-			continue
-		}
-
-		if _, ok := symbols[ins.Reference]; !ok {
-			// Symbol isn't available in this section
-			continue
-		}
-
-		// At this point we know that at least one function in the
-		// library is called from insns, so we have to link it.
-		return true, nil
 	}
 
-	// None of the functions in the section are called.
-	return false, nil
+	return buf.Bytes(), nil
+}
+
+// marshalLineInfos returns the BTF line infos of all progs in order.
+func marshalLineInfos(layout []reference) ([]byte, error) {
+	if len(layout) == 0 {
+		return nil, nil
+	}
+
+	buf := bytes.NewBuffer(make([]byte, 0, binary.Size(&btf.LineInfo{})*len(layout)))
+	for _, sym := range layout {
+		if err := sym.spec.BTF.LineInfos.Marshal(buf, sym.offset); err != nil {
+			return nil, fmt.Errorf("marshaling prog %s line infos: %w", sym.spec.Name, err)
+		}
+	}
+
+	return buf.Bytes(), nil
 }
 
 func fixupJumpsAndCalls(insns asm.Instructions) error {
@@ -113,10 +141,7 @@ func fixupJumpsAndCalls(insns asm.Instructions) error {
 
 		symOffset, ok := symbolOffsets[ins.Reference]
 		switch {
-		case ins.IsLoadOfFunctionPointer() && ins.Constant == -1:
-			fallthrough
-
-		case ins.IsFunctionCall() && ins.Constant == -1:
+		case ins.IsFunctionReference() && ins.Constant == -1:
 			if !ok {
 				break
 			}

--- a/linker_test.go
+++ b/linker_test.go
@@ -7,27 +7,26 @@ import (
 	"github.com/cilium/ebpf/internal/testutils"
 )
 
-func TestLink(t *testing.T) {
-	spec := &ProgramSpec{
-		Type: SocketFilter,
-		Instructions: asm.Instructions{
-			// Make sure the call doesn't happen at instruction 0
-			// to exercise the relative offset calculation.
-			asm.Mov.Reg(asm.R0, asm.R1),
-			asm.Call.Label("my_func"),
-			asm.Return(),
+func TestFindReferences(t *testing.T) {
+	progs := map[string]*ProgramSpec{
+		"entrypoint": {
+			Type: SocketFilter,
+			Instructions: asm.Instructions{
+				// Make sure the call doesn't happen at instruction 0
+				// to exercise the relative offset calculation.
+				asm.Mov.Reg(asm.R0, asm.R1),
+				asm.Call.Label("my_func"),
+				asm.Return(),
+			},
+			License: "MIT",
 		},
-		License: "MIT",
-	}
-
-	libs := []*ProgramSpec{
-		{
+		"my_other_func": {
 			Instructions: asm.Instructions{
 				asm.LoadImm(asm.R0, 1337, asm.DWord).Sym("my_other_func"),
 				asm.Return(),
 			},
 		},
-		{
+		"my_func": {
 			Instructions: asm.Instructions{
 				asm.Call.Label("my_other_func").Sym("my_func"),
 				asm.Return(),
@@ -35,16 +34,13 @@ func TestLink(t *testing.T) {
 		},
 	}
 
-	err := link(spec, libs)
-	if err != nil {
+	if err := populateReferences(progs); err != nil {
 		t.Fatal(err)
 	}
 
-	t.Log(spec.Instructions)
-
 	testutils.SkipOnOldKernel(t, "4.16", "bpf2bpf calls")
 
-	prog, err := NewProgram(spec)
+	prog, err := NewProgram(progs["entrypoint"])
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This patch adds support for emitting multiple eBPF functions/programs
to the same ELF section.

Significant changes were necessary, both to the BPF linker and the BTF
ext_info parser, as previously most of the code (rightfully) made the
assumption that one ELF section equaled one BPF function. In order to
remove this limitation, all 'offset' logic that used to track positions
within an ELF section had to be modified to track positions within a
function body instead.

Secondly, in order to reassemble instruction streams and BTF func_infos,
line_infos and also CO-RE relocations back into a flat format the kernel
expects, the linking logic had to be broken up into smaller pieces.
This allows the instruction linker and the BTF extinfo linkers to
operate on the same source of truth, so they can generate their outputs
using the same program layout. Additionally, by computing neighbours
(which requires scanning all progs' instruction streams for references
to other programs) only once during ELF loading, any marshaling logic
can simply request the flattened program layout, saving cycles.

To simplify the neighbour discovery process, the internal distinction
between 'libs' and 'progs' has been eliminated. This allows any function
to be called from anywhere, regardless of section name. For backwards
compatibility reasons, programs of type UnspecifiedProgram are not yet
emitted to the CollectionSpec. How we treat functions from .text and
other unknown sections is still to be debated.

From a high level, the linker is now split into multiple stages:

- Finding neighbours - a program's instruction stream is checked for
  references to any other program in the ELF. If a direct dependency is
  found (a jump to another function), a pointer to that function is
  stored in the program's neighbour table.
- Flattening - when the program is about to be marshaled for hand-off to
  the kernel, a unique, flat list of dependent programs is generated by
  stepping through each program's neighbour table in a depth-first
  manner. This list must be used by both the instruction and BTF extinfo
  linkers, so they generate their outputs using the same layout.
- Marshaling - the flat list of programs is simply iterated over and its
  instructions and BTF extinfo's are marshaled to their respective
  output buffers.

---

**Note: includes and depends on #503**

Possible follow-ups to be discussed:
- Emit UnspecifiedPrograms to `CollectionSpec.Programs`, including the section they were declared in. (need for `cilium/cilium`)
- Regarding previous point, special-case `.text`; hide it from the caller completely or expose in `CollectionSpec.Functions` or something (cc @arthurfabre)