### PR TITLE
link: expose link info with type-specific information

### DIFF
--- a/internal/sys/types.go
+++ b/internal/sys/types.go
@@ -427,6 +427,8 @@ type LinkInfo struct {
 	Type   LinkType
 	Id     LinkID
 	ProgId uint32
+	_      [4]byte
+	Extra  [16]uint8
 }
 
 type MapInfo struct {
@@ -920,3 +922,33 @@ func RawTracepointOpen(attr *RawTracepointOpenAttr) (*FD, error) {
 	}
 	return NewFD(int(fd))
 }
+
+type CgroupLinkInfo struct {
+	CgroupId   uint64
+	AttachType AttachType
+	_          [4]byte
+}
+
+type IterLinkInfo struct {
+	TargetName    Pointer
+	TargetNameLen uint32
+}
+
+type NetNsLinkInfo struct {
+	NetnsIno   uint32
+	AttachType AttachType
+}
+
+type RawTracepointLinkInfo struct {
+	TpName    Pointer
+	TpNameLen uint32
+	_         [4]byte
+}
+
+type TracingLinkInfo struct {
+	AttachType  AttachType
+	TargetObjId uint32
+	TargetBtfId uint32
+}
+
+type XDPLinkInfo struct{ Ifindex uint32 }

--- a/link/cgroup.go
+++ b/link/cgroup.go
@@ -153,6 +153,10 @@ func (cg *progAttachCgroup) Unpin() error {
 	return fmt.Errorf("can't pin cgroup: %w", ErrNotSupported)
 }
 
+func (cg *progAttachCgroup) Info() (*Info, error) {
+	return nil, fmt.Errorf("can't get cgroup info: %w", ErrNotSupported)
+}
+
 type linkCgroup struct {
 	RawLink
 }

--- a/link/netns.go
+++ b/link/netns.go
@@ -6,11 +6,6 @@ import (
 	"github.com/cilium/ebpf"
 )
 
-// NetNsInfo contains metadata about a network namespace link.
-type NetNsInfo struct {
-	RawLinkInfo
-}
-
 // NetNsLink is a program attached to a network namespace.
 type NetNsLink struct {
 	RawLink
@@ -50,13 +45,4 @@ func LoadPinnedNetNs(fileName string, opts *ebpf.LoadPinOptions) (*NetNsLink, er
 	}
 
 	return &NetNsLink{*link}, nil
-}
-
-// Info returns information about the link.
-func (nns *NetNsLink) Info() (*NetNsInfo, error) {
-	info, err := nns.RawLink.Info()
-	if err != nil {
-		return nil, err
-	}
-	return &NetNsInfo{*info}, nil
 }

--- a/link/netns_test.go
+++ b/link/netns_test.go
@@ -25,11 +25,6 @@ func TestSkLookup(t *testing.T) {
 		t.Fatal("Can't attach link:", err)
 	}
 
-	_, err = link.Info()
-	if err != nil {
-		t.Fatal("Info returns an error:", err)
-	}
-
 	testLink(t, link, prog)
 }
 

--- a/link/perf_event.go
+++ b/link/perf_event.go
@@ -109,6 +109,10 @@ func (pe *perfEvent) Update(prog *ebpf.Program) error {
 	return fmt.Errorf("can't replace eBPF program in perf event: %w", ErrNotSupported)
 }
 
+func (pe *perfEvent) Info() (*Info, error) {
+	return nil, fmt.Errorf("can't get perf event info: %w", ErrNotSupported)
+}
+
 func (pe *perfEvent) Close() error {
 	if pe.fd == nil {
 		return nil

--- a/link/raw_tracepoint.go
+++ b/link/raw_tracepoint.go
@@ -72,6 +72,10 @@ func (frt *simpleRawTracepoint) Unpin() error {
 	return fmt.Errorf("unpin raw_tracepoint: %w", ErrNotSupported)
 }
 
+func (frt *simpleRawTracepoint) Info() (*Info, error) {
+	return nil, fmt.Errorf("can't get raw_tracepoint info: %w", ErrNotSupported)
+}
+
 type rawTracepoint struct {
 	RawLink
 }


### PR DESCRIPTION
This PR is related to issue #506 
- add new method: Info() (*RawLinkInfo, error) to Link interface.
- add bpf_link_info union member types to types generator.
- update sys/types with generator.
- add info method to types that they don't support.
- enhance a few tests to cover info. (needs to add more) 
- fix NetNsInfo type.

