### PR TITLE
prog: don't panic when prog load EPERMs with empty verifier log

### DIFF
--- a/prog.go
+++ b/prog.go
@@ -314,7 +314,7 @@ func newProgramWithOptions(spec *ProgramSpec, opts ProgramOptions, handles *hand
 		}
 	}
 
-	if errors.Is(logErr, unix.EPERM) && logBuf[0] == 0 {
+	if errors.Is(logErr, unix.EPERM) && len(logBuf) > 0 && logBuf[0] == 0 {
 		// EPERM due to RLIMIT_MEMLOCK happens before the verifier, so we can
 		// check that the log is empty to reduce false positives.
 		return nil, fmt.Errorf("load program: %w (MEMLOCK bay be too low, consider rlimit.RemoveMemlock)", logErr)


### PR DESCRIPTION
Observed this while running kernel selftests without permissions.

Signed-off-by: Timo Beckers <timo@isovalent.com>