### PR TITLE
btf: support raw BTF in LoadSpecFromReader

### DIFF
--- a/internal/btf/btf_test.go
+++ b/internal/btf/btf_test.go
@@ -97,7 +97,7 @@ func TestTypeByNameAmbiguous(t *testing.T) {
 }
 
 func TestTypeByName(t *testing.T) {
-	spec, err := loadRawSpec(readVMLinux(t), binary.LittleEndian, nil, nil)
+	spec, err := LoadSpecFromReader(readVMLinux(t))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -261,6 +261,13 @@ func TestLoadKernelSpec(t *testing.T) {
 	_, err := LoadKernelSpec()
 	if err != nil {
 		t.Fatal("Can't load kernel spec:", err)
+	}
+}
+
+func TestGuessBTFByteOrder(t *testing.T) {
+	bo := guessRawBTFByteOrder(readVMLinux(t))
+	if bo != binary.LittleEndian {
+		t.Fatalf("Guessed %s instead of %s", bo, binary.LittleEndian)
 	}
 }
 

--- a/internal/cmd/gentypes/main.go
+++ b/internal/cmd/gentypes/main.go
@@ -6,7 +6,6 @@ package main
 
 import (
 	"bytes"
-	"compress/gzip"
 	"encoding/binary"
 	"fmt"
 	"os"
@@ -37,19 +36,12 @@ func run(args []string) error {
 		return fmt.Errorf("expect location of compressed vmlinux .BTF as argument")
 	}
 
-	fh, err := os.Open(args[0])
+	raw, err := internal.ReadAllCompressed(args[0])
 	if err != nil {
 		return err
 	}
-	defer fh.Close()
 
-	gz, err := gzip.NewReader(fh)
-	if err != nil {
-		return err
-	}
-	defer gz.Close()
-
-	spec, err := btf.LoadRawSpec(gz, binary.LittleEndian)
+	spec, err := btf.LoadRawSpec(bytes.NewReader(raw), binary.LittleEndian)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/gentypes/main.go
+++ b/internal/cmd/gentypes/main.go
@@ -6,7 +6,6 @@ package main
 
 import (
 	"bytes"
-	"encoding/binary"
 	"fmt"
 	"os"
 	"sort"
@@ -41,7 +40,7 @@ func run(args []string) error {
 		return err
 	}
 
-	spec, err := btf.LoadRawSpec(bytes.NewReader(raw), binary.LittleEndian)
+	spec, err := btf.LoadSpecFromReader(bytes.NewReader(raw))
 	if err != nil {
 		return err
 	}

--- a/internal/io.go
+++ b/internal/io.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bufio"
+	"compress/gzip"
 	"errors"
 	"io"
 	"os"
@@ -41,4 +42,21 @@ func (DiscardZeroes) Write(p []byte) (int, error) {
 		}
 	}
 	return len(p), nil
+}
+
+// ReadAllCompressed decompresses a gzipped file into memory.
+func ReadAllCompressed(file string) ([]byte, error) {
+	fh, err := os.Open(file)
+	if err != nil {
+		return nil, err
+	}
+	defer fh.Close()
+
+	gz, err := gzip.NewReader(fh)
+	if err != nil {
+		return nil, err
+	}
+	defer gz.Close()
+
+	return io.ReadAll(gz)
 }

--- a/prog_test.go
+++ b/prog_test.go
@@ -593,9 +593,11 @@ func TestProgramTypeLSM(t *testing.T) {
 }
 
 func TestProgramTargetBTF(t *testing.T) {
-	// Load a file that contains valid BTF, but doesn't contain the types
-	// we need for bpf_iter.
-	fh, err := os.Open("testdata/invalid_btf_map_init-el.elf")
+	if _, err := os.Stat("/sys/kernel/btf/vmlinux"); os.IsNotExist(err) {
+		t.Skip("/sys/kernel/btf/vmlinux not present")
+	}
+
+	fh, err := os.Open("/sys/kernel/btf/vmlinux")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -615,12 +617,11 @@ func TestProgramTargetBTF(t *testing.T) {
 	}, ProgramOptions{
 		TargetBTF: reader,
 	})
-	if err == nil {
-		prog.Close()
+	testutils.SkipIfNotSupported(t, err)
+	if err != nil {
+		t.Fatal("NewProgram with TargetBTF:", err)
 	}
-	if !errors.Is(err, ErrNotSupported) {
-		t.Error("Expected ErrNotSupported, got", err)
-	}
+	prog.Close()
 	if !reader.read {
 		t.Error("TargetBTF is not read")
 	}


### PR DESCRIPTION
Allow passing BTF not wrapped in an ELF to LoadSpecFromReader. This
allows users to use external BTF for vmlinux, which is usually shipped
without the ELF.