### PR TITLE
Add ReadTimeout to perf/ring buffer

### DIFF
--- a/internal/epoll/poller.go
+++ b/internal/epoll/poller.go
@@ -119,7 +119,7 @@ func (p *Poller) Add(fd int, id int) error {
 //
 // Returns the number of pending events or an error wrapping os.ErrClosed if
 // Close is called.
-func (p *Poller) Wait(events []unix.EpollEvent) (int, error) {
+func (p *Poller) Wait(events []unix.EpollEvent, msec int) (int, error) {
 	p.epollMu.Lock()
 	defer p.epollMu.Unlock()
 
@@ -128,7 +128,7 @@ func (p *Poller) Wait(events []unix.EpollEvent) (int, error) {
 	}
 
 	for {
-		n, err := unix.EpollWait(p.epollFd, events, -1)
+		n, err := unix.EpollWait(p.epollFd, events, msec)
 		if temp, ok := err.(temporaryError); ok && temp.Temporary() {
 			// Retry the syscall if we were interrupted, see https://github.com/golang/go/issues/20400
 			continue

--- a/internal/epoll/poller_test.go
+++ b/internal/epoll/poller_test.go
@@ -34,7 +34,7 @@ func TestPoller(t *testing.T) {
 
 		events := make([]unix.EpollEvent, 1)
 
-		n, err := poller.Wait(events)
+		n, err := poller.Wait(events, -1)
 		if errors.Is(err, os.ErrClosed) {
 			return
 		}

--- a/perf/reader.go
+++ b/perf/reader.go
@@ -290,7 +290,12 @@ func (pr *Reader) read(timeout time.Duration) (Record, error) {
 
 	for {
 		if len(pr.epollRings) == 0 {
-			nEvents, err := pr.poller.Wait(pr.epollEvents, int(timeout.Milliseconds()))
+			msec := int(timeout.Milliseconds())
+			if timeout == -1 {
+				msec = -1
+			}
+
+			nEvents, err := pr.poller.Wait(pr.epollEvents, msec)
 			if err != nil {
 				return Record{}, err
 			}

--- a/perf/reader.go
+++ b/perf/reader.go
@@ -288,13 +288,13 @@ func (pr *Reader) read(timeout time.Duration) (Record, error) {
 		return Record{}, fmt.Errorf("perf ringbuffer: %w", ErrClosed)
 	}
 
+	msec := int(timeout.Milliseconds())
+	if timeout == -1 {
+		msec = -1
+	}
+
 	for {
 		if len(pr.epollRings) == 0 {
-			msec := int(timeout.Milliseconds())
-			if timeout == -1 {
-				msec = -1
-			}
-
 			nEvents, err := pr.poller.Wait(pr.epollEvents, msec)
 			if err != nil {
 				return Record{}, err

--- a/perf/reader_test.go
+++ b/perf/reader_test.go
@@ -398,12 +398,8 @@ func TestPerfReaderReadTimeout(t *testing.T) {
 	defer rd.Close()
 
 	_, err = rd.ReadTimeout(1 * time.Millisecond)
-	if err != nil {
-		if !errors.Is(err, ErrNoRecords) {
-			t.Fatal("Can't read samples:", err)
-		}
-	} else {
-		t.Fatal("Expected no records")
+	if !errors.Is(err, os.ErrDeadlineExceeded) {
+		t.Fatal("Expected timeout")
 	}
 
 	ret, _, err := prog.Test(make([]byte, 14))
@@ -415,7 +411,7 @@ func TestPerfReaderReadTimeout(t *testing.T) {
 		t.Fatal("Expected 0 as return value, got", errno)
 	}
 
-	record, err := rd.Read()
+	record, err := rd.ReadTimeout(100 * time.Millisecond)
 	if err != nil {
 		t.Fatal("Can't read samples:", err)
 	}

--- a/perf/reader_test.go
+++ b/perf/reader_test.go
@@ -386,6 +386,46 @@ func TestPause(t *testing.T) {
 	qt.Assert(t, errors.Is(err, ErrClosed), qt.IsTrue, qt.Commentf("doesn't wrap ErrClosed"))
 }
 
+func TestPerfReaderReadTimeout(t *testing.T) {
+	prog, events := mustOutputSamplesProg(t, 5)
+	defer prog.Close()
+	defer events.Close()
+
+	rd, err := NewReader(events, 4096)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rd.Close()
+
+	_, err = rd.ReadTimeout(1 * time.Millisecond)
+	if err != nil {
+		if !errors.Is(err, ErrNoRecords) {
+			t.Fatal("Can't read samples:", err)
+		}
+	} else {
+		t.Fatal("Expected no records")
+	}
+
+	ret, _, err := prog.Test(make([]byte, 14))
+	testutils.SkipIfNotSupported(t, err)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if errno := syscall.Errno(-int32(ret)); errno != 0 {
+		t.Fatal("Expected 0 as return value, got", errno)
+	}
+
+	record, err := rd.Read()
+	if err != nil {
+		t.Fatal("Can't read samples:", err)
+	}
+	want := []byte{1, 2, 3, 4, 4, 0, 0, 0, 0, 0, 0, 0}
+	if !bytes.Equal(record.RawSample, want) {
+		t.Log(record.RawSample)
+		t.Error("Sample doesn't match expected output")
+	}
+}
+
 func BenchmarkReader(b *testing.B) {
 	prog, events := mustOutputSamplesProg(b, 80)
 	defer prog.Close()

--- a/ringbuf/reader.go
+++ b/ringbuf/reader.go
@@ -181,8 +181,13 @@ func (r *Reader) read(timeout time.Duration) (Record, error) {
 		return Record{}, fmt.Errorf("ringbuffer: %w", ErrClosed)
 	}
 
+	msec := int(timeout.Milliseconds())
+	if timeout == -1 {
+		msec = -1
+	}
+
 	for {
-		nEvents, err := r.poller.Wait(r.epollEvents, int(timeout.Milliseconds()))
+		nEvents, err := r.poller.Wait(r.epollEvents, msec)
 		if err != nil {
 			return Record{}, err
 		}

--- a/ringbuf/reader_test.go
+++ b/ringbuf/reader_test.go
@@ -3,6 +3,7 @@ package ringbuf
 import (
 	"bytes"
 	"errors"
+	"os"
 	"syscall"
 	"testing"
 	"time"
@@ -227,12 +228,8 @@ func TestRingBufferReaderTimeout(t *testing.T) {
 	defer rd.Close()
 
 	_, err = rd.ReadTimeout(1 * time.Millisecond)
-	if err != nil {
-		if !errors.Is(err, ErrNoRecords) {
-			t.Fatal("Can't read samples:", err)
-		}
-	} else {
-		t.Fatal("Expected no records")
+	if !errors.Is(err, os.ErrDeadlineExceeded) {
+		t.Fatal("Expected timeout")
 	}
 
 	ret, _, err := prog.Test(make([]byte, 14))
@@ -244,7 +241,7 @@ func TestRingBufferReaderTimeout(t *testing.T) {
 		t.Fatal("Expected 0 as return value, got", errno)
 	}
 
-	record, err := rd.Read()
+	record, err := rd.ReadTimeout(100 * time.Millisecond)
 	if err != nil {
 		t.Fatal("Can't read samples:", err)
 	}

--- a/ringbuf/reader_test.go
+++ b/ringbuf/reader_test.go
@@ -217,9 +217,7 @@ func TestRingbufReaderClose(t *testing.T) {
 func TestRingBufferReaderTimeout(t *testing.T) {
 	testutils.SkipOnOldKernel(t, "5.8", "BPF ring buffer")
 
-	prog, events := mustOutputSamplesProg(t, 5)
-	defer prog.Close()
-	defer events.Close()
+	prog, events := mustOutputSamplesProg(t, 0, 5)
 
 	rd, err := NewReader(events)
 	if err != nil {
@@ -245,7 +243,7 @@ func TestRingBufferReaderTimeout(t *testing.T) {
 	if err != nil {
 		t.Fatal("Can't read samples:", err)
 	}
-	want := []byte{1, 2, 3, 4, 4, 0, 0, 0, 0, 0, 0, 0}
+	want := []byte{1, 2, 3, 4, 4}
 	if !bytes.Equal(record.RawSample, want) {
 		t.Log(record.RawSample)
 		t.Error("Sample doesn't match expected output")


### PR DESCRIPTION
Adds the function `ReadTimeout` to allow non-indefinite waits when reading from a perf buffer.

I'm not in love with the `ErrNoRecords` sentinel error, but I wanted to see what you folks thought. Maybe `io.EOF` or exporting `errEOR` instead?

Alternatively, I could make it more Go-ish, changing the function signature to `ReadContext(ctx context.Context)`, but it would need to handle manual cancellation too.