### PR TITLE
btf: only return exact matches from AnyTypesByName

### DIFF
--- a/internal/btf/btf.go
+++ b/internal/btf/btf.go
@@ -29,10 +29,6 @@ var (
 // ID represents the unique ID of a BTF object.
 type ID uint32
 
-// essentialName represents the name of a BTF type stripped of any flavor
-// suffixes after a ___ delimiter.
-type essentialname string
-
 // Spec represents decoded BTF.
 type Spec struct {
 	// Data from .BTF.
@@ -44,7 +40,7 @@ type Spec struct {
 
 	// Types indexed by essential name.
 	// Includes all struct flavors and types with the same name.
-	namedTypes map[essentialname][]Type
+	namedTypes map[essentialName][]Type
 
 	// Data from .BTF.ext.
 	funcInfos map[string]FuncInfo
@@ -516,10 +512,10 @@ func fixupDatasec(rawTypes []rawType, rawStrings stringTable, sectionSizes map[s
 func (s *Spec) Copy() *Spec {
 	types, _ := copyTypes(s.types, nil)
 
-	namedTypes := make(map[essentialname][]Type)
+	namedTypes := make(map[essentialName][]Type)
 	for _, typ := range types {
 		if name := typ.TypeName(); name != "" {
-			en := essentialName(name)
+			en := newEssentialName(name)
 			namedTypes[en] = append(namedTypes[en], typ)
 		}
 	}
@@ -640,7 +636,7 @@ func (s *Spec) TypeByID(id TypeID) (Type, error) {
 //
 // Returns an error wrapping ErrNotFound if no matching Type exists in the Spec.
 func (s *Spec) AnyTypesByName(name string) ([]Type, error) {
-	types := s.namedTypes[essentialName(name)]
+	types := s.namedTypes[newEssentialName(name)]
 	if len(types) == 0 {
 		return nil, fmt.Errorf("type name %s: %w", name, ErrNotFound)
 	}

--- a/internal/btf/btf.go
+++ b/internal/btf/btf.go
@@ -632,14 +632,7 @@ func (s *Spec) TypeByID(id TypeID) (Type, error) {
 	return s.types[id], nil
 }
 
-// AnyTypesByName returns a list of BTF Types with the given name. If name
-// contains a struct flavor suffix (e.g. 'thread_struct___v46'), an exact match
-// will be performed. Otherwise, returns all types that carry the given name,
-// including all struct flavors.
-//
-// Multiple Types of the same name can exist in case multiple 'struct flavors'
-// are described in BTF info. These are used to deal with changes in kernel
-// data structures.
+// AnyTypesByName returns a list of BTF Types with the given name.
 //
 // If the BTF blob describes multiple compilation units like vmlinux, multiple
 // Types with the same name and kind can exist, but might not describe the same
@@ -647,34 +640,21 @@ func (s *Spec) TypeByID(id TypeID) (Type, error) {
 //
 // Returns an error wrapping ErrNotFound if no matching Type exists in the Spec.
 func (s *Spec) AnyTypesByName(name string) ([]Type, error) {
-	en := essentialName(name)
-
-	// Named types are indexed by essential name.
-	types, ok := s.namedTypes[en]
-	if !ok {
+	types := s.namedTypes[essentialName(name)]
+	if len(types) == 0 {
 		return nil, fmt.Errorf("type name %s: %w", name, ErrNotFound)
 	}
 
-	if string(en) == name {
-		// Return a copy to prevent changes to namedTypes.
-		cpy := make([]Type, len(types))
-		copy(cpy, types)
-		return cpy, nil
-	}
-
-	// If name contains a flavor suffix, require an exact match.
-	var filtered []Type
+	// Return a copy to prevent changes to namedTypes.
+	result := make([]Type, 0, len(types))
 	for _, t := range types {
+		// Match against the full name, not just the essential one
+		// in case the type being looked up is a struct flavor.
 		if t.TypeName() == name {
-			filtered = append(filtered, t)
+			result = append(result, t)
 		}
 	}
-
-	if len(filtered) == 0 {
-		return nil, fmt.Errorf("type flavor %s: %w", name, ErrNotFound)
-	}
-
-	return filtered, nil
+	return result, nil
 }
 
 // TypeByName searches for a Type with a specific name. Since multiple
@@ -711,12 +691,6 @@ func (s *Spec) TypeByName(name string, typ interface{}) error {
 	var candidate Type
 	for _, typ := range types {
 		if reflect.TypeOf(typ) != wanted {
-			continue
-		}
-
-		// Match against the full name, not just the essential one
-		// in case the type being looked up is a struct flavor.
-		if typ.TypeName() != name {
 			continue
 		}
 

--- a/internal/btf/btf_test.go
+++ b/internal/btf/btf_test.go
@@ -58,8 +58,8 @@ func TestAnyTypesByName(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if len(types) != 2 {
-			t.Fatalf("expected to receive exactly 2 types from querying ambiguous type, got: %v", types)
+		if len(types) != 1 {
+			t.Fatalf("expected to receive exactly 1 types from querying ambiguous type, got: %v", types)
 		}
 
 		types, err = spec.AnyTypesByName("ambiguous___flavour")

--- a/internal/btf/core.go
+++ b/internal/btf/core.go
@@ -240,7 +240,7 @@ func coreRelocate(local, target *Spec, relos CoreRelos) (COREFixups, error) {
 		}
 
 		relos := relosByID[id]
-		targets := target.namedTypes[essentialName(localTypeName)]
+		targets := target.namedTypes[newEssentialName(localTypeName)]
 		fixups, err := coreCalculateFixups(localType, targets, relos)
 		if err != nil {
 			return nil, fmt.Errorf("relocate %s: %w", localType, err)
@@ -704,9 +704,9 @@ func coreFindEnumValue(local Type, localAcc coreAccessor, target Type) (localVal
 		return nil, nil, errImpossibleRelocation
 	}
 
-	localName := essentialName(localValue.Name)
+	localName := newEssentialName(localValue.Name)
 	for i, targetValue := range targetEnum.Values {
-		if essentialName(targetValue.Name) != localName {
+		if newEssentialName(targetValue.Name) != localName {
 			continue
 		}
 
@@ -831,7 +831,7 @@ func coreAreMembersCompatible(localType Type, targetType Type) error {
 			return nil
 		}
 
-		if essentialName(a) == essentialName(b) {
+		if newEssentialName(a) == newEssentialName(b) {
 			return nil
 		}
 


### PR DESCRIPTION
Change AnyTypesByName so that essential names stay an implementation
detail of the btf package: we need spec.namedTypes for fast
flavour lookup, but it's not clear that we should expose the flavour
name distinction to the users.

Fix this by only returning types which have an exact name match. This
means that `AnyTypesByName("ambiguous")` does not return ambiguous___flavour.