### PR TITLE
cmd/bpf2go: allow to specify native target

### DIFF
--- a/cmd/bpf2go/main.go
+++ b/cmd/bpf2go/main.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 )
@@ -357,6 +358,10 @@ func collectTargets(targets []string) (map[target][]string, error) {
 			}
 			sort.Strings(goarches)
 			result[target{tgt, ""}] = goarches
+
+		case "native":
+			tgt = runtime.GOARCH
+			fallthrough
 
 		default:
 			archTarget, ok := targetByGoArch[tgt]

--- a/cmd/bpf2go/main_test.go
+++ b/cmd/bpf2go/main_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 	"testing"
@@ -142,6 +143,18 @@ func TestCollectTargets(t *testing.T) {
 		sort.Strings(linuxArchesBE[i])
 	}
 
+	nativeTarget := make(map[target][]string)
+	for arch, archTarget := range targetByGoArch {
+		if arch == runtime.GOARCH {
+			if archTarget.clang == "bpfel" {
+				nativeTarget[archTarget] = linuxArchesLE[archTarget.linux]
+			} else {
+				nativeTarget[archTarget] = linuxArchesBE[archTarget.linux]
+			}
+			break
+		}
+	}
+
 	tests := []struct {
 		targets []string
 		want    map[target][]string
@@ -166,6 +179,10 @@ func TestCollectTargets(t *testing.T) {
 				{"bpfeb", "arm64"}: linuxArchesBE["arm64"],
 				{"bpfel", "x86"}:   linuxArchesLE["x86"],
 			},
+		},
+		{
+			[]string{"native"},
+			nativeTarget,
 		},
 	}
 


### PR DESCRIPTION
This allows to invoke `bpf2go` to build for the native architecture and
have `__TARGET_ARCH_xxx` defined based on `GOARCH` without having to
derive the  architecture e.g. as part of the build system.

For example this would be useful in github.com/cilium/pwru:

    //go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc clang -target native KProbePWRU ./bpf/kprobe_pwru.c -- -DOUTPUT_SKB -I./bpf/headers