### PR TITLE
Eliminate binary.Read in instruction (un)marshaler

### DIFF
--- a/asm/instruction.go
+++ b/asm/instruction.go
@@ -47,33 +47,45 @@ func (ins Instruction) Sym(name string) Instruction {
 
 // Unmarshal decodes a BPF instruction.
 func (ins *Instruction) Unmarshal(r io.Reader, bo binary.ByteOrder) (uint64, error) {
-	var bi bpfInstruction
-	err := binary.Read(r, bo, &bi)
-	if err != nil {
+	data := make([]byte, InstructionSize)
+	if _, err := io.ReadFull(r, data); err != nil {
 		return 0, err
 	}
 
-	ins.OpCode = bi.OpCode
-	ins.Offset = bi.Offset
-	ins.Constant = int64(bi.Constant)
-	ins.Dst, ins.Src, err = bi.Registers.Unmarshal(bo)
-	if err != nil {
-		return 0, fmt.Errorf("can't unmarshal registers: %s", err)
+	ins.OpCode = OpCode(data[0])
+
+	regs := data[1]
+	switch bo {
+	case binary.LittleEndian:
+		ins.Dst, ins.Src = Register(regs&0xF), Register(regs>>4)
+	case binary.BigEndian:
+		ins.Dst, ins.Src = Register(regs>>4), Register(regs&0xf)
 	}
 
-	if !bi.OpCode.IsDWordLoad() {
+	ins.Offset = int16(bo.Uint16(data[2:4]))
+	// Convert to int32 before widening to int64
+	// to ensure the signed bit is carried over.
+	ins.Constant = int64(int32(bo.Uint32(data[4:8])))
+
+	if !ins.OpCode.IsDWordLoad() {
 		return InstructionSize, nil
 	}
 
-	var bi2 bpfInstruction
-	if err := binary.Read(r, bo, &bi2); err != nil {
+	// Pull another instruction from the stream to retrieve the second
+	// half of the 64-bit immediate value.
+	if _, err := io.ReadFull(r, data); err != nil {
 		// No Wrap, to avoid io.EOF clash
 		return 0, errors.New("64bit immediate is missing second half")
 	}
-	if bi2.OpCode != 0 || bi2.Offset != 0 || bi2.Registers != 0 {
+
+	// Require that all fields other than the value are zero.
+	if bo.Uint32(data[0:4]) != 0 {
 		return 0, errors.New("64bit immediate has non-zero fields")
 	}
-	ins.Constant = int64(uint64(uint32(bi2.Constant))<<32 | uint64(uint32(bi.Constant)))
+
+	cons1 := uint32(ins.Constant)
+	cons2 := int32(bo.Uint32(data[4:8]))
+	ins.Constant = int64(cons2)<<32 | int64(cons1)
 
 	return 2 * InstructionSize, nil
 }
@@ -97,14 +109,12 @@ func (ins Instruction) Marshal(w io.Writer, bo binary.ByteOrder) (uint64, error)
 		return 0, fmt.Errorf("can't marshal registers: %s", err)
 	}
 
-	bpfi := bpfInstruction{
-		ins.OpCode,
-		regs,
-		ins.Offset,
-		cons,
-	}
-
-	if err := binary.Write(w, bo, &bpfi); err != nil {
+	data := make([]byte, InstructionSize)
+	data[0] = byte(ins.OpCode)
+	data[1] = byte(regs)
+	bo.PutUint16(data[2:4], uint16(ins.Offset))
+	bo.PutUint32(data[4:8], uint32(cons))
+	if _, err := w.Write(data); err != nil {
 		return 0, err
 	}
 
@@ -112,11 +122,11 @@ func (ins Instruction) Marshal(w io.Writer, bo binary.ByteOrder) (uint64, error)
 		return InstructionSize, nil
 	}
 
-	bpfi = bpfInstruction{
-		Constant: int32(ins.Constant >> 32),
-	}
-
-	if err := binary.Write(w, bo, &bpfi); err != nil {
+	// The first half of the second part of a double-wide instruction
+	// must be zero. The second half carries the value.
+	bo.PutUint32(data[0:4], 0)
+	bo.PutUint32(data[4:8], uint32(ins.Constant>>32))
+	if _, err := w.Write(data); err != nil {
 		return 0, err
 	}
 
@@ -527,13 +537,6 @@ func (iter *InstructionIterator) Next() bool {
 	return true
 }
 
-type bpfInstruction struct {
-	OpCode    OpCode
-	Registers bpfRegisters
-	Offset    int16
-	Constant  int32
-}
-
 type bpfRegisters uint8
 
 func newBPFRegisters(dst, src Register, bo binary.ByteOrder) (bpfRegisters, error) {
@@ -544,17 +547,6 @@ func newBPFRegisters(dst, src Register, bo binary.ByteOrder) (bpfRegisters, erro
 		return bpfRegisters((dst << 4) | (src & 0xF)), nil
 	default:
 		return 0, fmt.Errorf("unrecognized ByteOrder %T", bo)
-	}
-}
-
-func (r bpfRegisters) Unmarshal(bo binary.ByteOrder) (dst, src Register, err error) {
-	switch bo {
-	case binary.LittleEndian:
-		return Register(r & 0xF), Register(r >> 4), nil
-	case binary.BigEndian:
-		return Register(r >> 4), Register(r & 0xf), nil
-	default:
-		return 0, 0, fmt.Errorf("unrecognized ByteOrder %T", bo)
 	}
 }
 

--- a/asm/instruction_test.go
+++ b/asm/instruction_test.go
@@ -33,6 +33,18 @@ func TestRead64bitImmediate(t *testing.T) {
 	}
 }
 
+func BenchmarkRead64bitImmediate(b *testing.B) {
+	r := &bytes.Reader{}
+	for i := 0; i < b.N; i++ {
+		r.Reset(test64bitImmProg)
+
+		var ins Instruction
+		if _, err := ins.Unmarshal(r, binary.LittleEndian); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 func TestWrite64bitImmediate(t *testing.T) {
 	insns := Instructions{
 		LoadImm(R0, math.MinInt32-1, DWord),
@@ -45,6 +57,19 @@ func TestWrite64bitImmediate(t *testing.T) {
 
 	if prog := buf.Bytes(); !bytes.Equal(prog, test64bitImmProg) {
 		t.Errorf("Marshalled program does not match:\n%s", hex.Dump(prog))
+	}
+}
+
+func BenchmarkWrite64BitImmediate(b *testing.B) {
+	ins := LoadImm(R0, math.MinInt32-1, DWord)
+
+	var buf bytes.Buffer
+	for i := 0; i < b.N; i++ {
+		buf.Reset()
+
+		if _, err := ins.Marshal(&buf, binary.LittleEndian); err != nil {
+			b.Fatal(err)
+		}
 	}
 }
 


### PR DESCRIPTION
This still needs to be fuzzed, but the gains are nice so far:

```
name                    old time/op    new time/op    delta
Read64bitImmediate-16      479ns ±12%      74ns ± 1%  -84.62%  (p=0.008 n=5+5)
Write64BitImmediate-16     417ns ±10%      63ns ± 2%  -84.97%  (p=0.008 n=5+5)

name                    old alloc/op   new alloc/op   delta
Read64bitImmediate-16      32.0B ± 0%      8.0B ± 0%  -75.00%  (p=0.008 n=5+5)
Write64BitImmediate-16     24.0B ± 0%      8.0B ± 0%  -66.67%  (p=0.008 n=5+5)

name                    old allocs/op  new allocs/op  delta
Read64bitImmediate-16       4.00 ± 0%      1.00 ± 0%  -75.00%  (p=0.008 n=5+5)
Write64BitImmediate-16      3.00 ± 0%      1.00 ± 0%  -66.67%  (p=0.008 n=5+5)
```

The use of `internal.DiscardZeroes{}` was considered for checking for `64bit immediate has non-zero fields`, but ended up being a lot slower than just including those bits in the read. The fact that it aligns with a single u32 interpretation is quite convenient. :)