### PR TITLE
rlimit: avoid lowering Max rlimit

### DIFF
--- a/rlimit/rlimit.go
+++ b/rlimit/rlimit.go
@@ -37,8 +37,17 @@ func init() {
 }
 
 func detectMemcgAccounting() error {
-	// Reduce the limit to zero and store the previous limit. This should always succeed.
+	// Retrieve the original limit to prevent lowering Max, since
+	// doing so is a permanent operation when running unprivileged.
 	var oldLimit unix.Rlimit
+	if err := unix.Prlimit(0, unix.RLIMIT_MEMLOCK, nil, &oldLimit); err != nil {
+		return fmt.Errorf("getting original memlock rlimit: %s", err)
+	}
+
+	// Drop the current limit to zero, maintaining the old Max value.
+	// This is always permitted by the kernel for unprivileged users.
+	// Retrieve a new copy of the old limit tuple to minimize the chances
+	// of failing the restore operation below.
 	zeroLimit := unix.Rlimit{Cur: 0, Max: oldLimit.Max}
 	if err := unix.Prlimit(0, unix.RLIMIT_MEMLOCK, &zeroLimit, &oldLimit); err != nil {
 		return fmt.Errorf("lowering memlock rlimit: %s", err)


### PR DESCRIPTION
In an unprivileged process, the restore operation will always fail with EPERM, since oldLimit.Max is always zero at the start of the function. Once Max has been lowered, it's not possible to restore it without permissions.

This patch adds an extra Getrlimit call to obtain an appropriate value for Max so it is never blindly lowered to zero.

Not sure if there are any other solutions, but IMO this is fine because the detection logic now runs as `init()`, meaning no other Go code can manipulate rlimit concurrently. Any potential clashes would have to be caused by external programs.