### PR TITLE
Remove BTF type IDs on map creation if not supported 

### DIFF
--- a/map.go
+++ b/map.go
@@ -390,7 +390,7 @@ func (spec *MapSpec) createMap(inner *sys.FD, opts MapOptions, handles *handleCa
 	}
 
 	var btfDisabled bool
-	if spec.BTF != nil {
+	if spec.BTF != nil && spec.Type.hasBTF() {
 		handle, err := handles.btfHandle(spec.BTF.Spec)
 		btfDisabled = errors.Is(err, btf.ErrNotSupported)
 		if err != nil && !btfDisabled {

--- a/types.go
+++ b/types.go
@@ -126,6 +126,17 @@ func (mt MapType) canStoreProgram() bool {
 	return mt == ProgramArray
 }
 
+// hasBTF returns true if the map type supports BTF key/value metadata.
+func (mt MapType) hasBTF() bool {
+	switch mt {
+	case PerfEventArray, CGroupArray, StackTrace, ArrayOfMaps, HashOfMaps, DevMap,
+		DevMapHash, CPUMap, XSKMap, SockMap, SockHash, Queue, Stack, RingBuf:
+		return false
+	default:
+		return true
+	}
+}
+
 // ProgramType of the eBPF program
 type ProgramType uint32
 

--- a/types.go
+++ b/types.go
@@ -11,7 +11,7 @@ import (
 type MapType uint32
 
 // Max returns the latest supported MapType.
-func (_ MapType) Max() MapType {
+func (MapType) Max() MapType {
 	return maxMapType - 1
 }
 
@@ -141,7 +141,7 @@ func (mt MapType) hasBTF() bool {
 type ProgramType uint32
 
 // Max return the latest supported ProgramType.
-func (_ ProgramType) Max() ProgramType {
+func (ProgramType) Max() ProgramType {
 	return maxProgramType - 1
 }
 


### PR DESCRIPTION
In libbpf commit 962f24137978 ([0]), we teach libbpf to recognize
BPF maps that do not support BTF-defined key/value and remove
BTF type IDs quietly on map creation. Make ebpf library support
this feature.

  [0]: https://github.com/libbpf/libbpf/commit/962f24137978bf3321bed97785bae59b5a3f3b06