### PR TITLE
info: Use unix.ByteSliceToString instead of internal.CString

### DIFF
--- a/internal/btf/info.go
+++ b/internal/btf/info.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/cilium/ebpf/internal"
 	"github.com/cilium/ebpf/internal/sys"
+	"github.com/cilium/ebpf/internal/unix"
 )
 
 // info describes a BTF object.
@@ -44,7 +45,7 @@ func newInfoFromFd(fd *sys.FD) (*info, error) {
 	return &info{
 		BTF:       spec,
 		ID:        ID(btfInfo.Id),
-		Name:      internal.CString(nameBuffer),
+		Name:      unix.ByteSliceToString(nameBuffer),
 		KernelBTF: btfInfo.KernelBtf != 0,
 	}, nil
 }

--- a/internal/errors.go
+++ b/internal/errors.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"strings"
@@ -15,7 +14,7 @@ import (
 // logErr should be the error returned by the syscall that generated
 // the log. It is used to check for truncation of the output.
 func ErrorWithLog(err error, log []byte, logErr error) error {
-	logStr := strings.Trim(CString(log), "\t\r\n ")
+	logStr := strings.Trim(unix.ByteSliceToString(log), "\t\r\n ")
 	if errors.Is(logErr, unix.ENOSPC) {
 		logStr += " (truncated...)"
 	}
@@ -39,13 +38,4 @@ func (le *VerifierError) Error() string {
 	}
 
 	return fmt.Sprintf("%s: %s", le.cause, le.log)
-}
-
-// CString turns a NUL / zero terminated byte buffer into a string.
-func CString(in []byte) string {
-	inLen := bytes.IndexByte(in, 0)
-	if inLen == -1 {
-		return ""
-	}
-	return string(in[:inLen])
 }

--- a/map_test.go
+++ b/map_test.go
@@ -1520,7 +1520,7 @@ func TestMapName(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if name := internal.CString(info.Name[:]); name != "test" {
+	if name := unix.ByteSliceToString(info.Name[:]); name != "test" {
 		t.Error("Expected name to be test, got", name)
 	}
 }

--- a/prog.go
+++ b/prog.go
@@ -392,7 +392,7 @@ func newProgramWithOptions(spec *ProgramSpec, opts ProgramOptions, handles *hand
 
 	fd, err := sys.ProgLoad(attr)
 	if err == nil {
-		return &Program{internal.CString(logBuf), fd, spec.Name, "", spec.Type}, nil
+		return &Program{unix.ByteSliceToString(logBuf), fd, spec.Name, "", spec.Type}, nil
 	}
 
 	logErr := err

--- a/prog_test.go
+++ b/prog_test.go
@@ -392,7 +392,7 @@ func TestProgramName(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if name := internal.CString(info.Name[:]); name != "test" {
+	if name := unix.ByteSliceToString(info.Name[:]); name != "test" {
 		t.Errorf("Name is not test, got '%s'", name)
 	}
 }


### PR DESCRIPTION
Also document availability of tag and name fields somewhere it's not lost on the user.