### PR TITLE
prog: default Program.Test() 'in' argument to 14-byte slice

### DIFF
--- a/collection_test.go
+++ b/collection_test.go
@@ -145,7 +145,7 @@ func TestCollectionSpecRewriteMaps(t *testing.T) {
 	}
 	defer coll.Close()
 
-	ret, _, err := coll.Programs["test-prog"].Test(make([]byte, 14))
+	ret, _, err := coll.Programs["test-prog"].Test(nil)
 	testutils.SkipIfNotSupported(t, err)
 	if err != nil {
 		t.Fatal(err)

--- a/elf_reader_test.go
+++ b/elf_reader_test.go
@@ -211,7 +211,7 @@ func TestLoadCollectionSpec(t *testing.T) {
 		}
 		defer coll.Close()
 
-		ret, _, err := coll.Programs["xdp_prog"].Test(make([]byte, 14))
+		ret, _, err := coll.Programs["xdp_prog"].Test(nil)
 		if err != nil {
 			t.Fatal("Can't run program:", err)
 		}
@@ -242,7 +242,7 @@ func TestDataSections(t *testing.T) {
 	}
 	defer obj.Program.Close()
 
-	ret, _, err := obj.Program.Test(make([]byte, 14))
+	ret, _, err := obj.Program.Test(nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -460,7 +460,7 @@ func TestTailCall(t *testing.T) {
 		}
 		defer obj.TailMain.Close()
 
-		ret, _, err := obj.TailMain.Test(make([]byte, 14))
+		ret, _, err := obj.TailMain.Test(nil)
 		testutils.SkipIfNotSupported(t, err)
 		if err != nil {
 			t.Fatal(err)
@@ -498,7 +498,7 @@ func TestSubprogRelocation(t *testing.T) {
 		}
 		defer obj.Main.Close()
 
-		ret, _, err := obj.Main.Test(make([]byte, 14))
+		ret, _, err := obj.Main.Test(nil)
 		testutils.SkipIfNotSupported(t, err)
 		if err != nil {
 			t.Fatal(err)

--- a/internal/btf/core_reloc_test.go
+++ b/internal/btf/core_reloc_test.go
@@ -47,7 +47,7 @@ func TestCoreRelocationLoad(t *testing.T) {
 				}
 				defer prog.Close()
 
-				ret, _, err := prog.Test(make([]byte, 14))
+				ret, _, err := prog.Test(nil)
 				testutils.SkipIfNotSupported(t, err)
 				if err != nil {
 					t.Fatal("Error when running:", err)

--- a/linker_test.go
+++ b/linker_test.go
@@ -45,7 +45,7 @@ func TestFindReferences(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ret, _, err := prog.Test(make([]byte, 14))
+	ret, _, err := prog.Test(nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/perf/reader_test.go
+++ b/perf/reader_test.go
@@ -34,7 +34,7 @@ func TestPerfReader(t *testing.T) {
 	}
 	defer rd.Close()
 
-	ret, _, err := prog.Test(make([]byte, 14))
+	ret, _, err := prog.Test(nil)
 	testutils.SkipIfNotSupported(t, err)
 	if err != nil {
 		t.Fatal(err)
@@ -214,7 +214,7 @@ func TestPerfReaderLostSample(t *testing.T) {
 	}
 	defer rd.Close()
 
-	ret, _, err := prog.Test(make([]byte, 14))
+	ret, _, err := prog.Test(nil)
 	testutils.SkipIfNotSupported(t, err)
 	if err != nil {
 		t.Fatal(err)
@@ -319,7 +319,7 @@ func TestPause(t *testing.T) {
 	}
 
 	// Write a sample. The reader should read it.
-	ret, _, err := prog.Test(make([]byte, 14))
+	ret, _, err := prog.Test(nil)
 	testutils.SkipIfNotSupported(t, err)
 	if err != nil || ret != 0 {
 		t.Fatal("Can't write sample")
@@ -338,7 +338,7 @@ func TestPause(t *testing.T) {
 		_, err := rd.Read()
 		errChan <- err
 	}()
-	ret, _, err = prog.Test(make([]byte, 14))
+	ret, _, err = prog.Test(nil)
 	if err == nil && ret == 0 {
 		t.Fatal("Unexpectedly wrote sample while paused")
 	} // else Success
@@ -359,7 +359,7 @@ func TestPause(t *testing.T) {
 	if err = rd.Resume(); err != nil {
 		t.Fatal(err)
 	}
-	ret, _, err = prog.Test(make([]byte, 14))
+	ret, _, err = prog.Test(nil)
 	if err != nil || ret != 0 {
 		t.Fatal("Can't write sample")
 	}
@@ -455,7 +455,7 @@ func ExampleReader() {
 	defer rd.Close()
 
 	// Writes out a sample with content 1,2,3,4,4
-	ret, _, err := prog.Test(make([]byte, 14))
+	ret, _, err := prog.Test(nil)
 	if err != nil || ret != 0 {
 		panic("Can't write sample")
 	}

--- a/prog.go
+++ b/prog.go
@@ -23,6 +23,8 @@ var ErrNotSupported = internal.ErrNotSupported
 
 var errUnsatisfiedReference = errors.New("unsatisfied reference")
 
+var emptyProgTestInput = make([]byte, 14)
+
 // ProgramID represents the unique ID of an eBPF program.
 type ProgramID uint32
 
@@ -549,11 +551,16 @@ func (p *Program) Close() error {
 // Test runs the Program in the kernel with the given input and returns the
 // value returned by the eBPF program. outLen may be zero.
 //
-// Note: the kernel expects at least 14 bytes input for an ethernet header for
-// XDP and SKB programs.
+// If in is nil, the Program's test invocation is automatically provided
+// an input of 14 zero bytes, as the kernel expects at least 14 bytes input
+// for an ethernet header for XDP and SKB programs.
 //
 // This function requires at least Linux 4.12.
 func (p *Program) Test(in []byte) (uint32, []byte, error) {
+	if in == nil {
+		in = emptyProgTestInput
+	}
+
 	ret, out, _, err := p.testRun(in, 1, nil)
 	if err != nil {
 		return ret, nil, fmt.Errorf("can't test program: %w", err)

--- a/ringbuf/reader_test.go
+++ b/ringbuf/reader_test.go
@@ -46,7 +46,7 @@ func TestRingbufReader(t *testing.T) {
 			}
 			defer rd.Close()
 
-			ret, _, err := prog.Test(make([]byte, 14))
+			ret, _, err := prog.Test(nil)
 			testutils.SkipIfNotSupported(t, err)
 			if err != nil {
 				t.Fatal(err)


### PR DESCRIPTION
As a shorthand for providing an empty input, allow nil to be specified.
This seems to be the common case in the test suite.

---

I haven't been able to pinpoint where exactly the 14-byte requirement comes from within the kernel. Sure, it's the length of an ethernet header, but I'd like to be able to document why it's a requirement for tracing progs etc. that don't expect to operate on network frames/packets.