### PR TITLE
program: retrieve xlated Instructions from Program

### DIFF
--- a/asm/instruction.go
+++ b/asm/instruction.go
@@ -309,6 +309,31 @@ func (ins Instruction) Size() uint64 {
 // Instructions is an eBPF program.
 type Instructions []Instruction
 
+// Unmarshal unmarshals an Instructions from a binary instruction stream.
+// All instructions in insns are replaced by instructions decoded from r.
+func (insns *Instructions) Unmarshal(r io.Reader, bo binary.ByteOrder) error {
+	if len(*insns) > 0 {
+		*insns = nil
+	}
+
+	var offset uint64
+	for {
+		var ins Instruction
+		n, err := ins.Unmarshal(r, bo)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("offset %d: %w", offset, err)
+		}
+
+		*insns = append(*insns, ins)
+		offset += n
+	}
+
+	return nil
+}
+
 // Name returns the name of the function insns belongs to, if any.
 func (insns Instructions) Name() string {
 	if len(insns) == 0 {

--- a/asm/instruction_test.go
+++ b/asm/instruction_test.go
@@ -73,6 +73,26 @@ func BenchmarkWrite64BitImmediate(b *testing.B) {
 	}
 }
 
+func TestUnmarshalInstructions(t *testing.T) {
+	r := bytes.NewReader(test64bitImmProg)
+
+	var insns Instructions
+	if err := insns.Unmarshal(r, binary.LittleEndian); err != nil {
+		t.Fatal(err)
+	}
+
+	// Unmarshaling into the same Instructions multiple times replaces
+	// the instruction stream.
+	r.Reset(test64bitImmProg)
+	if err := insns.Unmarshal(r, binary.LittleEndian); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(insns) != 1 {
+		t.Fatalf("Expected one instruction, got %d", len(insns))
+	}
+}
+
 func TestSignedJump(t *testing.T) {
 	insns := Instructions{
 		JSGT.Imm(R0, -1, "foo"),

--- a/internal/cmd/gentypes/main.go
+++ b/internal/cmd/gentypes/main.go
@@ -153,7 +153,11 @@ import (
 	}{
 		{
 			"ProgInfo", "bpf_prog_info",
-			[]patch{replace(objName, "name"), replace(pointer, "map_ids")},
+			[]patch{
+				replace(objName, "name"),
+				replace(pointer, "xlated_prog_insns"),
+				replace(pointer, "map_ids"),
+			},
 		},
 		{
 			"MapInfo", "bpf_map_info",

--- a/internal/sys/types.go
+++ b/internal/sys/types.go
@@ -456,7 +456,7 @@ type ProgInfo struct {
 	JitedProgLen         uint32
 	XlatedProgLen        uint32
 	JitedProgInsns       uint64
-	XlatedProgInsns      uint64
+	XlatedProgInsns      Pointer
 	LoadTime             uint64
 	CreatedByUid         uint32
 	NrMapIds             uint32

--- a/prog_test.go
+++ b/prog_test.go
@@ -686,6 +686,41 @@ func TestProgramBindMap(t *testing.T) {
 	}
 }
 
+func TestProgramInstructions(t *testing.T) {
+	name := "test_prog"
+	spec := &ProgramSpec{
+		Type: SocketFilter,
+		Name: name,
+		Instructions: asm.Instructions{
+			asm.LoadImm(asm.R0, -1, asm.DWord).Sym(name),
+			asm.Mov.Imm32(asm.R0, 0),
+			asm.Return(),
+		},
+		License: "MIT",
+	}
+
+	prog, err := NewProgram(spec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer prog.Close()
+
+	pi, err := prog.Info()
+	testutils.SkipIfNotSupported(t, err)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	insns, err := pi.Instructions()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if diff := cmp.Diff(insns, spec.Instructions); diff != "" {
+		t.Fatal(diff)
+	}
+}
+
 type testReaderAt struct {
 	file *os.File
 	read bool


### PR DESCRIPTION
Allow introspecting instructions after they have been translated by and loaded into the kernel.

Just putting this up here for discussion, I remember there being some prior discussion around this a while back.

---

There's also the following cosmetic bug:
```
tail_main:
	0: LoadMapPtr dst: r2 fd: 226
```
226 is the map's BPF ID, not its fd. Not sure if this needs to be taken into account.