### PR TITLE
Support attaching SocketFilter programs to raw sockets

### DIFF
--- a/internal/unix/types_linux.go
+++ b/internal/unix/types_linux.go
@@ -66,6 +66,9 @@ const (
 	PERF_RECORD_SAMPLE       = linux.PERF_RECORD_SAMPLE
 	AT_FDCWD                 = linux.AT_FDCWD
 	RENAME_NOREPLACE         = linux.RENAME_NOREPLACE
+	SO_ATTACH_BPF            = linux.SO_ATTACH_BPF
+	SO_DETACH_BPF            = linux.SO_DETACH_BPF
+	SOL_SOCKET               = linux.SOL_SOCKET
 )
 
 // Statfs_t is a wrapper

--- a/internal/unix/types_other.go
+++ b/internal/unix/types_other.go
@@ -68,6 +68,9 @@ const (
 	PERF_RECORD_SAMPLE       = 9
 	AT_FDCWD                 = -0x2
 	RENAME_NOREPLACE         = 0x1
+	SO_ATTACH_BPF            = 0x32
+	SO_DETACH_BPF            = 0x1b
+	SOL_SOCKET               = 0x1
 )
 
 // Statfs_t is a wrapper

--- a/link/socket_filter.go
+++ b/link/socket_filter.go
@@ -1,0 +1,40 @@
+package link
+
+import (
+	"syscall"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/internal/unix"
+)
+
+// AttachSocketFilter attaches a SocketFilter BPF program to a socket.
+func AttachSocketFilter(conn syscall.Conn, program *ebpf.Program) error {
+	rawConn, err := conn.SyscallConn()
+	if err != nil {
+		return err
+	}
+	var ssoErr error
+	err = rawConn.Control(func(fd uintptr) {
+		ssoErr = syscall.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_ATTACH_BPF, program.FD())
+	})
+	if ssoErr != nil {
+		return ssoErr
+	}
+	return err
+}
+
+// DetachSocketFilter detaches a SocketFilter BPF program from a socket.
+func DetachSocketFilter(conn syscall.Conn) error {
+	rawConn, err := conn.SyscallConn()
+	if err != nil {
+		return err
+	}
+	var ssoErr error
+	err = rawConn.Control(func(fd uintptr) {
+		ssoErr = syscall.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_DETACH_BPF, 0)
+	})
+	if ssoErr != nil {
+		return ssoErr
+	}
+	return err
+}

--- a/link/socket_filter_test.go
+++ b/link/socket_filter_test.go
@@ -1,0 +1,28 @@
+package link
+
+import (
+	"net"
+	"testing"
+
+	"github.com/cilium/ebpf"
+)
+
+func TestSocketFilterAttach(t *testing.T) {
+	prog := mustLoadProgram(t, ebpf.SocketFilter, 0, "")
+
+	defer prog.Close()
+
+	conn, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	if err := AttachSocketFilter(conn, prog); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := DetachSocketFilter(conn); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Adds support for attaching Socket Filter programs to raw sockets. It would look like this:

```go
link.SocketFilterAttachProgram(conn, objs.Filter)

link.SocketFilterDetachProgram(conn)
```

Any feedback is welcome. I'll also provide an example.