### PR TITLE
Deprecate StructOpts and perf.IsClosed()

### DIFF
--- a/perf/reader.go
+++ b/perf/reader.go
@@ -353,14 +353,6 @@ func (pr *Reader) Resume() error {
 	return nil
 }
 
-// IsClosed returns true if the error occurred because
-// a Reader was closed.
-//
-// Deprecated: use errors.Is(err, ErrClosed) instead.
-func IsClosed(err error) bool {
-	return errors.Is(err, ErrClosed)
-}
-
 type unknownEventError struct {
 	eventType uint32
 }

--- a/types.go
+++ b/types.go
@@ -103,12 +103,6 @@ const (
 	maxMapType
 )
 
-// Deprecated: StructOpts was a typo, use StructOpsMap instead.
-//
-// Declared as a variable to prevent stringer from picking it up
-// as an enum value.
-var StructOpts MapType = StructOpsMap
-
 // hasPerCPUValue returns true if the Map stores a value per CPU.
 func (mt MapType) hasPerCPUValue() bool {
 	return mt == PerCPUHash || mt == PerCPUArray || mt == LRUCPUHash || mt == PerCPUCGroupStorage


### PR DESCRIPTION
These were deprecated and scheduled to be removed in 0.8.0.

https://github.com/cilium/ebpf/pull/397: `IsClosed()`
https://github.com/cilium/ebpf/pull/381: `StructOpts`