### PR TITLE
btf: remove symbol value bounds check to support vmlinux ELFs

### DIFF
--- a/internal/btf/btf.go
+++ b/internal/btf/btf.go
@@ -90,6 +90,17 @@ func LoadSpecFromReader(rd io.ReaderAt) (*Spec, error) {
 	}
 	defer file.Close()
 
+	return loadSpecFromELF(file)
+}
+
+// variableOffsets extracts all symbols offsets from an ELF and indexes them by
+// section and variable name.
+//
+// References to variables in BTF data sections carry unsigned 32-bit offsets.
+// Some ELF symbols (e.g. in vmlinux) may point to virtual memory that is well
+// beyond this range. Since these symbols cannot be described by BTF info,
+// ignore them here.
+func variableOffsets(file *internal.SafeELFFile) (map[variable]uint32, error) {
 	symbols, err := file.Symbols()
 	if err != nil {
 		return nil, fmt.Errorf("can't read symbols: %v", err)
@@ -115,10 +126,10 @@ func LoadSpecFromReader(rd io.ReaderAt) (*Spec, error) {
 		variableOffsets[variable{secName, symbol.Name}] = uint32(symbol.Value)
 	}
 
-	return loadSpecFromELF(file, variableOffsets)
+	return variableOffsets, nil
 }
 
-func loadSpecFromELF(file *internal.SafeELFFile, variableOffsets map[variable]uint32) (*Spec, error) {
+func loadSpecFromELF(file *internal.SafeELFFile) (*Spec, error) {
 	var (
 		btfSection    *elf.Section
 		btfExtSection *elf.Section
@@ -148,7 +159,12 @@ func loadSpecFromELF(file *internal.SafeELFFile, variableOffsets map[variable]ui
 		return nil, fmt.Errorf("btf: %w", ErrNotFound)
 	}
 
-	spec, err := loadRawSpec(btfSection.Open(), file.ByteOrder, sectionSizes, variableOffsets)
+	vars, err := variableOffsets(file)
+	if err != nil {
+		return nil, err
+	}
+
+	spec, err := loadRawSpec(btfSection.Open(), file.ByteOrder, sectionSizes, vars)
 	if err != nil {
 		return nil, err
 	}
@@ -339,7 +355,7 @@ func loadKernelSpec() (*Spec, error) {
 		}
 		defer file.Close()
 
-		return loadSpecFromELF(file, nil)
+		return loadSpecFromELF(file)
 	}
 
 	return nil, fmt.Errorf("no BTF for kernel version %s: %w", release, internal.ErrNotSupported)

--- a/internal/btf/btf.go
+++ b/internal/btf/btf.go
@@ -102,15 +102,16 @@ func LoadSpecFromReader(rd io.ReaderAt) (*Spec, error) {
 			continue
 		}
 
+		if symbol.Value > math.MaxUint32 {
+			// VarSecinfo offset is u32, cannot reference symbols in higher regions.
+			continue
+		}
+
 		if int(symbol.Section) >= len(file.Sections) {
 			return nil, fmt.Errorf("symbol %s: invalid section %d", symbol.Name, symbol.Section)
 		}
 
 		secName := file.Sections[symbol.Section].Name
-		if symbol.Value > math.MaxUint32 {
-			return nil, fmt.Errorf("section %s: symbol %s: size exceeds maximum", secName, symbol.Name)
-		}
-
 		variableOffsets[variable{secName, symbol.Name}] = uint32(symbol.Value)
 	}
 

--- a/internal/btf/btf_test.go
+++ b/internal/btf/btf_test.go
@@ -186,6 +186,23 @@ func TestParseCurrentKernelBTF(t *testing.T) {
 	}
 }
 
+func TestFindVMLinux(t *testing.T) {
+	file, err := findVMLinux()
+	testutils.SkipIfNotSupported(t, err)
+	if err != nil {
+		t.Fatal("Can't find vmlinux:", err)
+	}
+
+	spec, err := loadSpecFromELF(file)
+	if err != nil {
+		t.Fatal("Can't load BTF:", err)
+	}
+
+	if len(spec.namedTypes) == 0 {
+		t.Fatal("Empty kernel BTF")
+	}
+}
+
 func TestLoadSpecFromElf(t *testing.T) {
 	testutils.Files(t, testutils.Glob(t, "../../testdata/loader-e*.elf"), func(t *testing.T, file string) {
 		spec := parseELFBTF(t, file)

--- a/internal/version.go
+++ b/internal/version.go
@@ -3,6 +3,8 @@ package internal
 import (
 	"fmt"
 	"sync"
+
+	"github.com/cilium/ebpf/internal/unix"
 )
 
 const (
@@ -104,4 +106,17 @@ func detectKernelVersion() (Version, error) {
 		return Version{}, err
 	}
 	return NewVersionFromCode(vc), nil
+}
+
+// KernelRelease returns the release string of the running kernel.
+// Its format depends on the Linux distribution and corresponds to directory
+// names in /lib/modules by convention. Some examples are 5.15.17-1-lts and
+// 4.19.0-16-amd64.
+func KernelRelease() (string, error) {
+	var uname unix.Utsname
+	if err := unix.Uname(&uname); err != nil {
+		return "", fmt.Errorf("uname failed: %w", err)
+	}
+
+	return unix.ByteSliceToString(uname.Release[:]), nil
 }

--- a/internal/version_test.go
+++ b/internal/version_test.go
@@ -84,3 +84,14 @@ func TestVersionFromCode(t *testing.T) {
 		})
 	}
 }
+
+func TestKernelRelease(t *testing.T) {
+	r, err := KernelRelease()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if r == "" {
+		t.Fatal("unexpected empty kernel release")
+	}
+}


### PR DESCRIPTION
In vmlinux ELFs, symbol values are (virtual) memory addresses and don't necessarily correspond to offsets within ELF sections or even files.

For example:

```
~ llvm-objdump -t /usr/lib/modules/*/build/vmlinux | head -5

/usr/lib/modules/5.15.17-1-lts/build/vmlinux:	file format elf64-x86-64

SYMBOL TABLE:
ffffffff81000000 l    d  .text	0000000000000000 .text
```

Explanation on why this is the case: https://0xax.gitbooks.io/linux-insides/content/Theory/linux-theory-2.html#vmlinux

Remove the check as the MaxU32 assumption no longer holds. This allows the caller to specify an unstripped vmlinux TargetBTF and would result in correct fallback behaviour to one of the files in /boot, /lib and /usr as specified in loadKernelSpec(), which is currently also broken as a result.