### PR TITLE
CI: try to fix error 42

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -33,7 +33,7 @@ blocks:
           - go mod tidy
           - sudo pip3 install https://github.com/amluto/virtme/archive/beb85146cd91de37ae455eccb6ab67c393e6e290.zip
           - sudo apt-get update
-          - sudo apt-get install -y --no-install-recommends qemu-system-x86 clang-9 llvm-9
+          - sudo apt-get install -y --no-install-recommends qemu-system-x86 clang-9 llvm-9 linux-tools-5.13.0-30-generic
           - sudo dmesg -C
       epilogue:
         always:

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -48,21 +48,25 @@ if [[ "${1:-}" = "--exec-vm" ]]; then
     rm "${output}/fake-stdin"
   fi
 
-  if ! $sudo virtme-run --kimg "${input}/bzImage" --memory 768M --pwd \
+  if ! sudo perf record -o "${output}/perf.dat" -a -e "kvm:*" virtme-run --kimg "${input}/bzImage" --memory 768M --pwd --show-boot-console \
     --rwdir="${testdir}=${testdir}" \
     --rodir=/run/input="${input}" \
     --rwdir=/run/output="${output}" \
     --script-sh "PATH=\"$PATH\" CI_MAX_KERNEL_VERSION="${CI_MAX_KERNEL_VERSION:-}" \"$script\" --exec-test $cmd" \
-    --kopt possible_cpus=2; then # need at least two CPUs for some tests
+    --kopt possible_cpus=2 \
+    --qemu-opts -trace "qemu_system_*" -trace "kvm_run_exit" 1>&2; then # need at least two CPUs for some tests
     exit 23
   fi
 
-  if [[ ! -e "${output}/success" ]]; then
+  if [[ ! -e "${output}/status" ]]; then
+    sudo perf script -i "${output}/perf.dat" > "${output}/perf.log"
+    artifact push job "${output}/perf.log"
     exit 42
   fi
 
+  rc=$(<"${output}/status")
   $sudo rm -r "$output"
-  exit 0
+  exit $rc
 elif [[ "${1:-}" = "--exec-test" ]]; then
   shift
 
@@ -73,13 +77,13 @@ elif [[ "${1:-}" = "--exec-test" ]]; then
     export KERNEL_SELFTESTS="/run/input/bpf"
   fi
 
-  dmesg -C
-  if ! "$@"; then
-    dmesg
-    exit 1 # this return code is "swallowed" by qemu
-  fi
-  touch "/run/output/success"
-  exit 0
+  dmesg --clear
+  rc=0
+  "$@" || rc=$?
+  dmesg
+  echo $rc > "/run/output/status"
+  echo exiting with $rc
+  exit $rc # this return code is "swallowed" by qemu
 fi
 
 readonly kernel_version="${1:-}"


### PR DESCRIPTION
We get somewhat regular "exit status 42" failures on CI. This happens
when a file indicating success of the test doesn't exist:

    if [[ ! -e "${output}/success" ]]; then
      exit 42
    fi

Weirdly, error 42 always happens without any output from the Go test
runner itself. I have a theory that maybe it's not the test that fails,
but that creating the success file doesn't complete before the VM
stops. Try to work around this by syncing the filesystem which the
success file resides on before exiting.