### PR TITLE
Add add sparse per-instruction metadata 

### DIFF
--- a/asm/instruction_test.go
+++ b/asm/instruction_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -141,7 +142,7 @@ func TestInstructionLoadMapValue(t *testing.T) {
 	if !ins.IsLoadFromMap() {
 		t.Error("isLoadFromMap returns false")
 	}
-	if fd := ins.MapPtr(); fd != 1 {
+	if fd := ins.mapFd(); fd != 1 {
 		t.Error("Expected map fd to be 1, got", fd)
 	}
 	if off := ins.mapOffset(); off != 123 {
@@ -171,7 +172,7 @@ func TestInstructionsRewriteMapPtr(t *testing.T) {
 		t.Error("Constant should be 2, have", insns[0].Constant)
 	}
 
-	if err := insns.RewriteMapPtr("bad", 1); !IsUnreferencedSymbol(err) {
+	if err := insns.RewriteMapPtr("bad", 1); !errors.Is(err, ErrUnreferencedSymbol) {
 		t.Error("Rewriting unreferenced map doesn't return appropriate error")
 	}
 }

--- a/elf_reader.go
+++ b/elf_reader.go
@@ -450,12 +450,6 @@ func (ec *elfCode) relocateInstruction(ins *asm.Instruction, rel elf.Symbol) err
 
 		ins.Src = asm.PseudoMapFD
 
-		// Mark the instruction as needing an update when creating the
-		// collection.
-		if err := ins.RewriteMapPtr(-1); err != nil {
-			return err
-		}
-
 	case dataSection:
 		var offset uint32
 		switch typ {
@@ -488,12 +482,6 @@ func (ec *elfCode) relocateInstruction(ins *asm.Instruction, rel elf.Symbol) err
 		// The kernel expects the offset in the second basic BPF instruction.
 		ins.Constant = int64(uint64(offset) << 32)
 		ins.Src = asm.PseudoMapValue
-
-		// Mark the instruction as needing an update when creating the
-		// collection.
-		if err := ins.RewriteMapPtr(-1); err != nil {
-			return err
-		}
 
 	case programSection:
 		switch opCode := ins.OpCode; {

--- a/linker.go
+++ b/linker.go
@@ -120,7 +120,8 @@ func fixupAndValidate(insns asm.Instructions) error {
 	for iter.Next() {
 		ins := iter.Ins
 
-		if ins.IsLoadFromMap() && ins.MapPtr() == -1 {
+		// Map load was tagged with a Reference, but does not contain a Map pointer.
+		if ins.IsLoadFromMap() && ins.Reference() != "" && ins.Map() == nil {
 			return fmt.Errorf("instruction %d: map %s: %w", iter.Index, ins.Reference(), asm.ErrUnsatisfiedMapReference)
 		}
 


### PR DESCRIPTION
This PR improves the existing per-instruction metadata, as discussed in #564 and fixes #515.

This PR moves the existing `Instruction.Reference` and `Instruction.Symbol` metadata to a separate struct called `metadata`. `asm.Instruction` now has a pointer to this `metadata` struct. The `Instruction` struct now has exported getters and setters to get and modify this metadata. The design is such that we only assign metadata to instructions if we have to, since most instructions don't have metadata.

Copying instructions will not automatically copy the metadata since `Instruction` has a pointer to metadata. Therefor the setters will perform a copy-on-write, so upon the first modification of metadata, the instruction will get a new metadata object which is copied from the existing one and then modified. 

These setters all have value receivers which return the modified instruction. This choice was made because it makes it easier to use the setters in the DSL, since you can't call functions with pointer receivers on literals. By returning a modified instruction we make method chaining possible, which fits well with the rest of the DSL.

We also added Filename, Line and LineCol to the `metadata` and getters and setters for them to `Instruction`. The ELF reader was modified to add looked-up `LineInfo` from the .BTF.ext section to the program instructions. This allows us to print the original source code info along with the program instructions when formatting `asm.Instructions`. 

By attaching this info the the instruction makes it relocation-proof. In future PRs we might even be able to marshal blobs to be loaded into the kernel so would guarantee correct BTF line info for relocated programs and BTF line info for programs created via the DSL.

Lastly, this PR adds map references to the per-instruction metadata. This allows us to add references to `ebpf.Map` to the program instructions themselves, specifically during rewriting, which prevents the maps from being garbage collected, thus fixing #515 