### PR TITLE
Hide BTF wire format of FuncInfo and LineInfo

### DIFF
--- a/internal/btf/btf.go
+++ b/internal/btf/btf.go
@@ -10,6 +10,7 @@ import (
 	"math"
 	"os"
 	"reflect"
+	"sort"
 	"sync"
 
 	"github.com/cilium/ebpf/internal"
@@ -42,7 +43,7 @@ type Spec struct {
 	// Includes all struct flavors and types with the same name.
 	namedTypes map[essentialName][]Type
 
-	// Data from .BTF.ext.
+	// Data from .BTF.ext. indexed by function name.
 	funcInfos map[string]FuncInfo
 	lineInfos map[string]LineInfos
 	coreRelos map[string]CoreRelos
@@ -193,67 +194,80 @@ func loadSpecFromELF(file *internal.SafeELFFile) (*Spec, error) {
 // transforms them to be indexed by function. Retrieves function names from
 // the BTF spec.
 func (spec *Spec) splitExtInfos(info *extInfo) error {
-
 	ofi := make(map[string]FuncInfo)
 	oli := make(map[string]LineInfos)
 	ocr := make(map[string]CoreRelos)
 
-	for secName, secFuncs := range info.funcInfos {
+	for secName, secFuncInfos := range info.funcInfos {
 		// Collect functions from each section and organize them by name.
-		for _, fi := range secFuncs {
-			name, err := fi.Name(spec)
+		var funcs []*Func
+		for _, fi := range secFuncInfos {
+			typ, err := spec.TypeByID(fi.TypeID)
 			if err != nil {
-				return fmt.Errorf("looking up function name: %w", err)
+				return err
 			}
 
-			// FuncInfo offsets are scoped to the ELF section. Zero them out
-			// since they are meaningless outside of that context. The linker
-			// will determine the offset of the function within the final
-			// instruction stream before handing it off to the kernel.
-			fi.InsnOff = 0
+			fn, ok := typ.(*Func)
+			if !ok {
+				return fmt.Errorf("type ID %d is a %T, but expected a Func", fi.TypeID, typ)
+			}
 
-			ofi[name] = fi
+			// C doesn't have anonymous functions, but check just in case.
+			if fn.Name == "" {
+				return fmt.Errorf("func with type ID %d doesn't have a name", fi.TypeID)
+			}
+
+			ofi[fn.Name] = FuncInfo{fn}
+			funcs = append(funcs, fn)
+		}
+
+		sort.Slice(secFuncInfos, func(i, j int) bool {
+			return secFuncInfos[i].InsnOff < secFuncInfos[j].InsnOff
+		})
+
+		// Consider an ELF section that contains 3 functions (a, b, c)
+		// at offsets 0, 10 and 15 respectively. Offset 5 will return function a,
+		// offset 12 will return b, offset >= 15 will return c, etc.
+		funcForInstruction := func(offset uint32) (fn *Func, fnOffset uint32) {
+			for i, fi := range secFuncInfos {
+				if fi.InsnOff > offset {
+					break
+				}
+				fn = funcs[i]
+				fnOffset = fi.InsnOff
+			}
+			return fn, fnOffset
 		}
 
 		// Attribute LineInfo records to their respective functions, if any.
 		if lines := info.lineInfos[secName]; lines != nil {
 			for _, li := range lines {
-				fi := secFuncs.funcForOffset(li.InsnOff)
-				if fi == nil {
+				fn, fnOffset := funcForInstruction(li.InsnOff)
+				if fn == nil {
 					return fmt.Errorf("section %s: error looking up FuncInfo for LineInfo %v", secName, li)
 				}
 
 				// Offsets are ELF section-scoped, make them function-scoped by
 				// subtracting the function's start offset.
-				li.InsnOff -= fi.InsnOff
+				li.InsnOff -= fnOffset
 
-				name, err := fi.Name(spec)
-				if err != nil {
-					return fmt.Errorf("looking up function name: %w", err)
-				}
-
-				oli[name] = append(oli[name], li)
+				oli[fn.Name] = append(oli[fn.Name], li)
 			}
 		}
 
 		// Attribute CO-RE relocations to their respective functions, if any.
 		if relos := info.relos[secName]; relos != nil {
 			for _, r := range relos {
-				fi := secFuncs.funcForOffset(r.insnOff)
-				if fi == nil {
+				fn, fnOffset := funcForInstruction(r.insnOff)
+				if fn == nil {
 					return fmt.Errorf("section %s: error looking up FuncInfo for CO-RE relocation %v", secName, r)
 				}
 
 				// Offsets are ELF section-scoped, make them function-scoped by
 				// subtracting the function's start offset.
-				r.insnOff -= fi.InsnOff
+				r.insnOff -= fnOffset
 
-				name, err := fi.Name(spec)
-				if err != nil {
-					return fmt.Errorf("looking up function name: %w", err)
-				}
-
-				ocr[name] = append(ocr[name], r)
+				ocr[fn.Name] = append(ocr[fn.Name], r)
 			}
 		}
 	}
@@ -588,7 +602,7 @@ func (s *Spec) Program(name string) (*Program, error) {
 		return nil, fmt.Errorf("BTF for function %s: %w", name, ErrNoExtendedInfo)
 	}
 
-	funcInfos, funcOK := s.funcInfos[name]
+	funcInfo, funcOK := s.funcInfos[name]
 	lineInfos, lineOK := s.lineInfos[name]
 	relos, coreOK := s.coreRelos[name]
 
@@ -596,7 +610,7 @@ func (s *Spec) Program(name string) (*Program, error) {
 		return nil, fmt.Errorf("no extended BTF info for function %s", name)
 	}
 
-	return &Program{s, funcInfos, lineInfos, relos}, nil
+	return &Program{s, funcInfo, lineInfos, relos}, nil
 }
 
 // TypeByID returns the BTF Type with the given type ID.

--- a/linker.go
+++ b/linker.go
@@ -2,11 +2,9 @@ package ebpf
 
 import (
 	"bytes"
-	"encoding/binary"
 	"fmt"
 
 	"github.com/cilium/ebpf/asm"
-	"github.com/cilium/ebpf/internal/btf"
 )
 
 // The linker is responsible for resolving bpf-to-bpf calls between programs
@@ -104,9 +102,9 @@ func marshalLineInfos(layout []reference) ([]byte, error) {
 		return nil, nil
 	}
 
-	buf := bytes.NewBuffer(make([]byte, 0, binary.Size(&btf.LineInfo{})*len(layout)))
+	var buf bytes.Buffer
 	for _, sym := range layout {
-		if err := sym.spec.BTF.LineInfos.Marshal(buf, sym.offset); err != nil {
+		if err := sym.spec.BTF.LineInfos.Marshal(&buf, sym.offset); err != nil {
 			return nil, fmt.Errorf("marshaling prog %s line infos: %w", sym.spec.Name, err)
 		}
 	}

--- a/linker.go
+++ b/linker.go
@@ -88,9 +88,9 @@ func marshalFuncInfos(layout []reference) ([]byte, error) {
 		return nil, nil
 	}
 
-	buf := bytes.NewBuffer(make([]byte, 0, binary.Size(&btf.FuncInfo{})*len(layout)))
+	var buf bytes.Buffer
 	for _, sym := range layout {
-		if err := sym.spec.BTF.FuncInfo.Marshal(buf, sym.offset); err != nil {
+		if err := sym.spec.BTF.FuncInfo.Marshal(&buf, sym.offset); err != nil {
 			return nil, fmt.Errorf("marshaling prog %s func info: %w", sym.spec.Name, err)
 		}
 	}

--- a/prog.go
+++ b/prog.go
@@ -319,8 +319,8 @@ func newProgramWithOptions(spec *ProgramSpec, opts ProgramOptions, handles *hand
 			if err != nil {
 				return nil, err
 			}
-			attr.LineInfoRecSize = uint32(binary.Size(btf.LineInfo{}))
-			attr.LineInfoCnt = uint32(len(lib)) / attr.LineInfoRecSize
+			attr.LineInfoRecSize = btf.LineInfoSize
+			attr.LineInfoCnt = uint32(len(lib)) / btf.LineInfoSize
 			attr.LineInfo = sys.NewSlicePointer(lib)
 		}
 	}

--- a/prog.go
+++ b/prog.go
@@ -311,8 +311,8 @@ func newProgramWithOptions(spec *ProgramSpec, opts ProgramOptions, handles *hand
 			if err != nil {
 				return nil, err
 			}
-			attr.FuncInfoRecSize = uint32(binary.Size(btf.FuncInfo{}))
-			attr.FuncInfoCnt = uint32(len(fib)) / attr.FuncInfoRecSize
+			attr.FuncInfoRecSize = btf.FuncInfoSize
+			attr.FuncInfoCnt = uint32(len(fib)) / btf.FuncInfoSize
 			attr.FuncInfo = sys.NewSlicePointer(fib)
 
 			lib, err := marshalLineInfos(layout)


### PR DESCRIPTION
Prompted by https://github.com/cilium/ebpf/pull/567/files#r805999952

Make it so that FuncInfo and LineInfo don't expose the BTF wire format outside of the package, and decode FileName, Line, etc. I used getters to avoid users being able to modify `LineInfo.FileName` and expecting that to show up in BTF.

Somewhat WIP since I need to write better commit descriptions.

cc @dylandreimerink