### PR TITLE
asm,features: unexport jump fixup, fix misc probes and tests

### DIFF
--- a/features/misc.go
+++ b/features/misc.go
@@ -161,10 +161,6 @@ func createMiscProbeAttr(mt miscType) (*sys.ProgLoadAttr, error) {
 		return nil, fmt.Errorf("feature %d not yet implemented", mt)
 	}
 
-	if err := insns.FixupReferences(); err != nil {
-		return nil, err
-	}
-
 	buf := bytes.NewBuffer(make([]byte, 0, insns.Size()))
 	if err := insns.Marshal(buf, internal.NativeEndian); err != nil {
 		return nil, err

--- a/features/misc_test.go
+++ b/features/misc_test.go
@@ -1,32 +1,31 @@
 package features
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/cilium/ebpf/internal/testutils"
 )
 
 func TestHaveMisc(t *testing.T) {
-	tests := map[miscType]struct {
+	tests := map[string]struct {
+		typ       miscType
 		probe     func() error
 		minKernel string
 	}{
-		largeInsn:    {probe: HaveLargeInstructions, minKernel: "5.1"},
-		boundedLoops: {probe: HaveBoundedLoops, minKernel: "5.2"},
-		v2ISA:        {probe: HaveV2ISA, minKernel: "4.13"},
-		v3ISA:        {probe: HaveV3ISA, minKernel: "5.0"},
+		"large instructions": {typ: largeInsn, probe: HaveLargeInstructions, minKernel: "5.2"},
+		"bounded loops":      {typ: boundedLoops, probe: HaveBoundedLoops, minKernel: "5.3"},
+		"v2 ISA":             {typ: v2ISA, probe: HaveV2ISA, minKernel: "4.14"},
+		"v3 ISA":             {typ: v3ISA, probe: HaveV3ISA, minKernel: "5.1"},
 	}
 
 	for misc, test := range tests {
 		test := test
-		probe := fmt.Sprintf("misc-%d", misc)
-		t.Run(probe, func(t *testing.T) {
-			testutils.SkipOnOldKernel(t, test.minKernel, probe)
+		t.Run(misc, func(t *testing.T) {
+			testutils.SkipOnOldKernel(t, test.minKernel, misc)
 
 			if err := test.probe(); err != nil {
 				t.Fatalf("Feature %s isn't supported even though kernel is at least %s: %v",
-					probe, test.minKernel, err)
+					misc, test.minKernel, err)
 			}
 		})
 	}

--- a/internal/feature.go
+++ b/internal/feature.go
@@ -54,11 +54,6 @@ type FeatureTestFn func() error
 //
 // Returns an error wrapping ErrNotSupported if the feature is not supported.
 func FeatureTest(name, version string, fn FeatureTestFn) func() error {
-	v, err := NewVersion(version)
-	if err != nil {
-		return func() error { return err }
-	}
-
 	ft := new(featureTest)
 	return func() error {
 		ft.RLock()
@@ -79,6 +74,11 @@ func FeatureTest(name, version string, fn FeatureTestFn) func() error {
 		err := fn()
 		switch {
 		case errors.Is(err, ErrNotSupported):
+			v, err := NewVersion(version)
+			if err != nil {
+				return err
+			}
+
 			ft.result = &UnsupportedFeatureError{
 				MinimumVersion: v,
 				Name:           name,

--- a/linker.go
+++ b/linker.go
@@ -114,9 +114,10 @@ func marshalLineInfos(layout []reference) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-func fixupJumpsAndCalls(insns asm.Instructions) error {
-	// fixupBPFCalls replaces bpf_probe_read_{kernel,user}[_str] with bpf_probe_read[_str] on older kernels
-	// https://github.com/libbpf/libbpf/blob/master/src/libbpf.c#L6009
+// fixupAndValidate is called by the ELF reader right before marshaling the
+// instruction stream. It performs last-minute adjustments to the program and
+// runs some sanity checks before sending it off to the kernel.
+func fixupAndValidate(insns asm.Instructions) error {
 	iter := insns.Iterate()
 	for iter.Next() {
 		ins := iter.Ins
@@ -125,21 +126,28 @@ func fixupJumpsAndCalls(insns asm.Instructions) error {
 			return fmt.Errorf("instruction %d: map %s: %w", iter.Index, ins.Reference, asm.ErrUnsatisfiedMapReference)
 		}
 
-		if !ins.IsBuiltinCall() {
-			continue
-		}
-
-		switch asm.BuiltinFunc(ins.Constant) {
-		case asm.FnProbeReadKernel, asm.FnProbeReadUser:
-			if err := haveProbeReadKernel(); err != nil {
-				ins.Constant = int64(asm.FnProbeRead)
-			}
-		case asm.FnProbeReadKernelStr, asm.FnProbeReadUserStr:
-			if err := haveProbeReadKernel(); err != nil {
-				ins.Constant = int64(asm.FnProbeReadStr)
-			}
-		}
+		fixupProbeReadKernel(ins)
 	}
 
 	return nil
+}
+
+// fixupProbeReadKernel replaces calls to bpf_probe_read_{kernel,user}(_str)
+// with bpf_probe_read(_str) on kernels that don't support it yet.
+func fixupProbeReadKernel(ins *asm.Instruction) {
+	if !ins.IsBuiltinCall() {
+		return
+	}
+
+	// Kernel supports bpf_probe_read_kernel, nothing to do.
+	if haveProbeReadKernel() == nil {
+		return
+	}
+
+	switch asm.BuiltinFunc(ins.Constant) {
+	case asm.FnProbeReadKernel, asm.FnProbeReadUser:
+		ins.Constant = int64(asm.FnProbeRead)
+	case asm.FnProbeReadKernelStr, asm.FnProbeReadUserStr:
+		ins.Constant = int64(asm.FnProbeReadStr)
+	}
 }

--- a/linker.go
+++ b/linker.go
@@ -115,18 +115,20 @@ func marshalLineInfos(layout []reference) ([]byte, error) {
 }
 
 func fixupJumpsAndCalls(insns asm.Instructions) error {
-	if err := insns.FixupReferences(); err != nil {
-		return err
-	}
-
 	// fixupBPFCalls replaces bpf_probe_read_{kernel,user}[_str] with bpf_probe_read[_str] on older kernels
 	// https://github.com/libbpf/libbpf/blob/master/src/libbpf.c#L6009
 	iter := insns.Iterate()
 	for iter.Next() {
 		ins := iter.Ins
+
+		if ins.IsLoadFromMap() && ins.MapPtr() == -1 {
+			return fmt.Errorf("instruction %d: map %s: %w", iter.Index, ins.Reference, asm.ErrUnsatisfiedMapReference)
+		}
+
 		if !ins.IsBuiltinCall() {
 			continue
 		}
+
 		switch asm.BuiltinFunc(ins.Constant) {
 		case asm.FnProbeReadKernel, asm.FnProbeReadUser:
 			if err := haveProbeReadKernel(); err != nil {

--- a/prog.go
+++ b/prog.go
@@ -330,7 +330,7 @@ func newProgramWithOptions(spec *ProgramSpec, opts ProgramOptions, handles *hand
 		return nil, fmt.Errorf("CO-RE fixup: %w", err)
 	}
 
-	if err := fixupJumpsAndCalls(insns); err != nil {
+	if err := fixupAndValidate(insns); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
See commit messages.

The ISA probes didn't match the bpftool ones and the test skips were all off by one kernel release.