### PR TITLE
collection: Rename CollectionSpec.BTF to .Types, copy in Copy()

### DIFF
--- a/cmd/bpf2go/output.go
+++ b/cmd/bpf2go/output.go
@@ -255,7 +255,7 @@ func output(args outputArgs) error {
 	}
 
 	// Collect any types which we've been asked for explicitly.
-	cTypes, err := collectCTypes(spec.BTF, args.cTypes)
+	cTypes, err := collectCTypes(spec.Types, args.cTypes)
 	if err != nil {
 		return err
 	}

--- a/collection.go
+++ b/collection.go
@@ -27,8 +27,8 @@ type CollectionSpec struct {
 	Maps     map[string]*MapSpec
 	Programs map[string]*ProgramSpec
 
-	// The BTF used by maps and programs.
-	BTF *btf.Spec
+	// Types holds type information about Maps and Programs.
+	Types *btf.Spec
 
 	// ByteOrder specifies whether the ELF was compiled for
 	// big-endian or little-endian architectures.
@@ -45,7 +45,7 @@ func (cs *CollectionSpec) Copy() *CollectionSpec {
 		Maps:      make(map[string]*MapSpec, len(cs.Maps)),
 		Programs:  make(map[string]*ProgramSpec, len(cs.Programs)),
 		ByteOrder: cs.ByteOrder,
-		BTF:       cs.BTF.Copy(),
+		Types:     cs.Types.Copy(),
 	}
 
 	for name, spec := range cs.Maps {
@@ -413,7 +413,7 @@ func (cl *collectionLoader) loadMap(mapName string) (*Map, error) {
 		return nil, fmt.Errorf("missing map %s", mapName)
 	}
 
-	if mapSpec.BTF != nil && cl.coll.BTF != mapSpec.BTF.Spec {
+	if mapSpec.BTF != nil && cl.coll.Types != mapSpec.BTF.Spec {
 		return nil, fmt.Errorf("map %s: BTF doesn't match collection", mapName)
 	}
 
@@ -442,7 +442,7 @@ func (cl *collectionLoader) loadProgram(progName string) (*Program, error) {
 		return nil, fmt.Errorf("cannot load program %s: program type is unspecified", progName)
 	}
 
-	if progSpec.BTF != nil && cl.coll.BTF != progSpec.BTF.Spec() {
+	if progSpec.BTF != nil && cl.coll.Types != progSpec.BTF.Spec() {
 		return nil, fmt.Errorf("program %s: BTF doesn't match collection", progName)
 	}
 

--- a/collection.go
+++ b/collection.go
@@ -45,6 +45,7 @@ func (cs *CollectionSpec) Copy() *CollectionSpec {
 		Maps:      make(map[string]*MapSpec, len(cs.Maps)),
 		Programs:  make(map[string]*ProgramSpec, len(cs.Programs)),
 		ByteOrder: cs.ByteOrder,
+		BTF:       cs.BTF.Copy(),
 	}
 
 	for name, spec := range cs.Maps {

--- a/collection_test.go
+++ b/collection_test.go
@@ -67,7 +67,7 @@ func TestCollectionSpecCopy(t *testing.T) {
 				License: "MIT",
 			},
 		},
-		BTF: &btf.Spec{},
+		Types: &btf.Spec{},
 	}
 	cpy := cs.Copy()
 
@@ -83,8 +83,8 @@ func TestCollectionSpecCopy(t *testing.T) {
 		t.Error("Copy returned same Programs")
 	}
 
-	if cpy.BTF == cs.BTF {
-		t.Error("Copy returned same BTF")
+	if cpy.Types == cs.Types {
+		t.Error("Copy returned same Types")
 	}
 }
 

--- a/collection_test.go
+++ b/collection_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/cilium/ebpf/asm"
+	"github.com/cilium/ebpf/internal/btf"
 	"github.com/cilium/ebpf/internal/testutils"
 )
 
@@ -66,6 +67,7 @@ func TestCollectionSpecCopy(t *testing.T) {
 				License: "MIT",
 			},
 		},
+		BTF: &btf.Spec{},
 	}
 	cpy := cs.Copy()
 
@@ -79,6 +81,10 @@ func TestCollectionSpecCopy(t *testing.T) {
 
 	if cpy.Programs["test"] == cs.Programs["test"] {
 		t.Error("Copy returned same Programs")
+	}
+
+	if cpy.BTF == cs.BTF {
+		t.Error("Copy returned same BTF")
 	}
 }
 

--- a/elf_reader_test.go
+++ b/elf_reader_test.go
@@ -143,7 +143,7 @@ func TestLoadCollectionSpec(t *testing.T) {
 			return false
 		}),
 		cmpopts.IgnoreTypes(new(btf.Map), new(btf.Program)),
-		cmpopts.IgnoreFields(CollectionSpec{}, "ByteOrder", "BTF"),
+		cmpopts.IgnoreFields(CollectionSpec{}, "ByteOrder", "Types"),
 		cmpopts.IgnoreFields(ProgramSpec{}, "Instructions", "ByteOrder"),
 		cmpopts.IgnoreUnexported(ProgramSpec{}),
 		cmpopts.IgnoreMapEntries(func(key string, _ *MapSpec) bool {


### PR DESCRIPTION
In preparation of renaming the btf.Spec type itself down the line, once .BTF.ext data has been lifted into per-insn metadata, cement the interface that will be used to query the CollectionSpec for its type information.

A CollectionSpec now provides Maps, Programs and Types.

---

Also fix CollectionSpec.Copy() not copying Types.