### PR TITLE
collection: don't copy btf.Spec in CollectionSpec.Copy()

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -28,6 +28,7 @@ type CollectionSpec struct {
 	Programs map[string]*ProgramSpec
 
 	// Types holds type information about Maps and Programs.
+	// Modifications to Types are currently undefined behaviour.
 	Types *btf.Spec
 
 	// ByteOrder specifies whether the ELF was compiled for
@@ -45,7 +46,7 @@ func (cs *CollectionSpec) Copy() *CollectionSpec {
 		Maps:      make(map[string]*MapSpec, len(cs.Maps)),
 		Programs:  make(map[string]*ProgramSpec, len(cs.Programs)),
 		ByteOrder: cs.ByteOrder,
-		Types:     cs.Types.Copy(),
+		Types:     cs.Types,
 	}
 
 	for name, spec := range cs.Maps {

--- a/collection_test.go
+++ b/collection_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/cilium/ebpf/asm"
+	"github.com/cilium/ebpf/internal"
 	"github.com/cilium/ebpf/internal/btf"
 	"github.com/cilium/ebpf/internal/testutils"
 )
@@ -83,8 +84,32 @@ func TestCollectionSpecCopy(t *testing.T) {
 		t.Error("Copy returned same Programs")
 	}
 
-	if cpy.Types == cs.Types {
-		t.Error("Copy returned same Types")
+	if cpy.Types != cs.Types {
+		t.Error("Copy returned different Types")
+	}
+}
+
+func TestCollectionSpecLoadCopy(t *testing.T) {
+	file := fmt.Sprintf("testdata/loader-%s.elf", internal.ClangEndian)
+	spec, err := LoadCollectionSpec(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	spec2 := spec.Copy()
+
+	var objs struct {
+		Prog *Program `ebpf:"xdp_prog"`
+	}
+
+	err = spec.LoadAndAssign(&objs, nil)
+	testutils.SkipIfNotSupported(t, err)
+	if err != nil {
+		t.Fatal("Loading original spec:", err)
+	}
+
+	if err := spec2.LoadAndAssign(&objs, nil); err != nil {
+		t.Fatal("Loading copied spec:", err)
 	}
 }
 


### PR DESCRIPTION
Copying btf.Spec requires updating Map/Program.BTF.(S,s)pec, which gets complicated due to btf.Map/Program being pointers.

Instead of implementing a full deep-copy, avoid copying btf.Spec for now, since it's considered read-only. Since we're planning to get rid of btf.Program/Map anyway, this would not be worth the investment.

Add a test that loads both a copy and an original CollectionSpec.