### PR TITLE
features: add LinuxVersionCode function to obtain LINUX_VERSION_CODE

### DIFF
--- a/features/version.go
+++ b/features/version.go
@@ -1,0 +1,18 @@
+package features
+
+import "github.com/cilium/ebpf/internal"
+
+// LinuxVersionCode returns the version of the currently running kernel
+// as defined in the LINUX_VERSION_CODE compile-time macro. It is represented
+// in the format described by the KERNEL_VERSION macro from linux/version.h.
+//
+// Do not use the version to make assumptions about the presence of certain
+// kernel features, always prefer feature probes in this package. Some
+// distributions backport or disable eBPF features.
+func LinuxVersionCode() (uint32, error) {
+	v, err := internal.KernelVersion()
+	if err != nil {
+		return 0, err
+	}
+	return v.Kernel(), nil
+}


### PR DESCRIPTION
In order to allow userspace to determine the value used for LINUX_VERSION_CODE at compile time, expose the constant here.

This is useful when building eBPF objects at runtime.

Supersedes #570