### PR TITLE
btf: rename 'Core' to 'CORE'

### DIFF
--- a/internal/btf/btf.go
+++ b/internal/btf/btf.go
@@ -46,7 +46,7 @@ type Spec struct {
 	// Data from .BTF.ext. indexed by function name.
 	funcInfos map[string]FuncInfo
 	lineInfos map[string]LineInfos
-	coreRelos map[string]CoreRelos
+	coreRelos map[string]CORERelos
 
 	byteOrder binary.ByteOrder
 }
@@ -190,13 +190,13 @@ func loadSpecFromELF(file *internal.SafeELFFile) (*Spec, error) {
 	return spec, nil
 }
 
-// splitExtInfos takes FuncInfos, LineInfos and CoreRelos indexed by section and
+// splitExtInfos takes FuncInfos, LineInfos and CORERelos indexed by section and
 // transforms them to be indexed by function. Retrieves function names from
 // the BTF spec.
 func (spec *Spec) splitExtInfos(info *extInfo) error {
 	ofi := make(map[string]FuncInfo)
 	oli := make(map[string]LineInfos)
-	ocr := make(map[string]CoreRelos)
+	ocr := make(map[string]CORERelos)
 
 	for secName, secFuncInfos := range info.funcInfos {
 		// Collect functions from each section and organize them by name.
@@ -835,7 +835,7 @@ type Program struct {
 	spec      *Spec
 	FuncInfo  FuncInfo
 	LineInfos LineInfos
-	CoreRelos CoreRelos
+	CORERelos CORERelos
 }
 
 // Spec returns the BTF spec of this program.
@@ -846,7 +846,7 @@ func (p *Program) Spec() *Spec {
 // CORERelocate returns the changes required to adjust the program to the target.
 //
 // Passing a nil target will relocate against the running kernel.
-func CORERelocate(local, target *Spec, relos CoreRelos) (COREFixups, error) {
+func CORERelocate(local, target *Spec, relos CORERelos) (COREFixups, error) {
 	if len(relos) == 0 {
 		return nil, nil
 	}

--- a/internal/btf/core.go
+++ b/internal/btf/core.go
@@ -191,13 +191,13 @@ func (k COREKind) checksForExistence() bool {
 	return k == reloEnumvalExists || k == reloTypeExists || k == reloFieldExists
 }
 
-func coreRelocate(local, target *Spec, relos CoreRelos) (COREFixups, error) {
+func coreRelocate(local, target *Spec, relos CORERelos) (COREFixups, error) {
 	if local.byteOrder != target.byteOrder {
 		return nil, fmt.Errorf("can't relocate %s against %s", local.byteOrder, target.byteOrder)
 	}
 
 	var ids []TypeID
-	relosByID := make(map[TypeID]CoreRelos)
+	relosByID := make(map[TypeID]CORERelos)
 	result := make(COREFixups, len(relos))
 	for _, relo := range relos {
 		if relo.kind == reloTypeIDLocal {
@@ -262,7 +262,7 @@ var errImpossibleRelocation = errors.New("impossible relocation")
 //
 // The best target is determined by scoring: the less poisoning we have to do
 // the better the target is.
-func coreCalculateFixups(local Type, targets []Type, relos CoreRelos) ([]COREFixup, error) {
+func coreCalculateFixups(local Type, targets []Type, relos CORERelos) ([]COREFixup, error) {
 	localID := local.ID()
 	local, err := copyType(local, skipQualifiersAndTypedefs)
 	if err != nil {
@@ -326,7 +326,7 @@ func coreCalculateFixups(local Type, targets []Type, relos CoreRelos) ([]COREFix
 
 // coreCalculateFixup calculates the fixup for a single local type, target type
 // and relocation.
-func coreCalculateFixup(local Type, localID TypeID, target Type, targetID TypeID, relo CoreRelo) (COREFixup, error) {
+func coreCalculateFixup(local Type, localID TypeID, target Type, targetID TypeID, relo CORERelocation) (COREFixup, error) {
 	fixup := func(local, target uint32) (COREFixup, error) {
 		return COREFixup{relo.kind, local, target, false}, nil
 	}
@@ -462,7 +462,7 @@ func coreCalculateFixup(local Type, localID TypeID, target Type, targetID TypeID
  */
 type coreAccessor []int
 
-func parseCoreAccessor(accessor string) (coreAccessor, error) {
+func parseCOREAccessor(accessor string) (coreAccessor, error) {
 	if accessor == "" {
 		return nil, fmt.Errorf("empty accessor")
 	}

--- a/internal/btf/core_reloc_test.go
+++ b/internal/btf/core_reloc_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/cilium/ebpf/internal/testutils"
 )
 
-func TestCoreRelocationLoad(t *testing.T) {
+func TestCORERelocationLoad(t *testing.T) {
 	testutils.Files(t, testutils.Glob(t, "testdata/relocs-*.elf"), func(t *testing.T, file string) {
 		fh, err := os.Open(file)
 		if err != nil {
@@ -67,7 +67,7 @@ func TestCoreRelocationLoad(t *testing.T) {
 	})
 }
 
-func TestCoreRelocationRead(t *testing.T) {
+func TestCORERelocationRead(t *testing.T) {
 	testutils.Files(t, testutils.Glob(t, "testdata/relocs_read-*.elf"), func(t *testing.T, file string) {
 		fh, err := os.Open(file)
 		if err != nil {

--- a/internal/btf/core_test.go
+++ b/internal/btf/core_test.go
@@ -12,7 +12,7 @@ import (
 	qt "github.com/frankban/quicktest"
 )
 
-func TestCoreAreTypesCompatible(t *testing.T) {
+func TestCOREAreTypesCompatible(t *testing.T) {
 	tests := []struct {
 		a, b       Type
 		compatible bool
@@ -83,7 +83,7 @@ func TestCoreAreTypesCompatible(t *testing.T) {
 	}
 }
 
-func TestCoreAreMembersCompatible(t *testing.T) {
+func TestCOREAreMembersCompatible(t *testing.T) {
 	tests := []struct {
 		a, b       Type
 		compatible bool
@@ -141,13 +141,13 @@ func TestCoreAreMembersCompatible(t *testing.T) {
 	}
 }
 
-func TestCoreAccessor(t *testing.T) {
+func TestCOREAccessor(t *testing.T) {
 	for _, valid := range []string{
 		"0",
 		"1:0",
 		"1:0:3:34:10:1",
 	} {
-		_, err := parseCoreAccessor(valid)
+		_, err := parseCOREAccessor(valid)
 		if err != nil {
 			t.Errorf("Parse %q: %s", valid, err)
 		}
@@ -161,14 +161,14 @@ func TestCoreAccessor(t *testing.T) {
 		":12",
 		"4294967296",
 	} {
-		_, err := parseCoreAccessor(invalid)
+		_, err := parseCOREAccessor(invalid)
 		if err == nil {
 			t.Errorf("Accepted invalid accessor %q", invalid)
 		}
 	}
 }
 
-func TestCoreFindEnumValue(t *testing.T) {
+func TestCOREFindEnumValue(t *testing.T) {
 	a := &Enum{Values: []EnumValue{{"foo", 23}, {"bar", 42}}}
 	b := &Enum{Values: []EnumValue{
 		{"foo___flavour", 0},
@@ -226,7 +226,7 @@ func TestCoreFindEnumValue(t *testing.T) {
 	}
 }
 
-func TestCoreFindField(t *testing.T) {
+func TestCOREFindField(t *testing.T) {
 	ptr := &Pointer{}
 	u16 := &Int{Size: 2}
 	u32 := &Int{Size: 4}
@@ -436,7 +436,7 @@ func TestCoreFindField(t *testing.T) {
 		},
 	}
 
-	checkCoreField := func(t *testing.T, got, want coreField) {
+	checkCOREField := func(t *testing.T, got, want coreField) {
 		t.Helper()
 		qt.Check(t, got.Type, qt.Equals, want.Type, qt.Commentf("type should match"))
 		qt.Check(t, got.offset, qt.Equals, want.offset, qt.Commentf("offset should match"))
@@ -446,13 +446,13 @@ func TestCoreFindField(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			localField, targetField, err := coreFindField(test.local, test.acc, test.target)
 			qt.Assert(t, err, qt.IsNil)
-			checkCoreField(t, localField, test.localField)
-			checkCoreField(t, targetField, test.targetField)
+			checkCOREField(t, localField, test.localField)
+			checkCOREField(t, targetField, test.targetField)
 		})
 	}
 }
 
-func TestCoreFindFieldCyclical(t *testing.T) {
+func TestCOREFindFieldCyclical(t *testing.T) {
 	members := []Member{{Name: "foo", Type: &Pointer{}}}
 
 	cyclicStruct := &Struct{}
@@ -483,7 +483,7 @@ func TestCoreFindFieldCyclical(t *testing.T) {
 	}
 }
 
-func TestCoreRelocation(t *testing.T) {
+func TestCORERelocation(t *testing.T) {
 	testutils.Files(t, testutils.Glob(t, "testdata/*.elf"), func(t *testing.T, file string) {
 		rd, err := os.Open(file)
 		if err != nil {
@@ -509,7 +509,7 @@ func TestCoreRelocation(t *testing.T) {
 					t.Fatal("Retrieve program:", err)
 				}
 
-				relos, err := CORERelocate(prog.Spec(), spec, prog.CoreRelos)
+				relos, err := CORERelocate(prog.Spec(), spec, prog.CORERelos)
 				if want := errs[name]; want != nil {
 					if !errors.Is(err, want) {
 						t.Fatal("Expected", want, "got", err)
@@ -533,7 +533,7 @@ func TestCoreRelocation(t *testing.T) {
 	})
 }
 
-func TestCoreCopyWithoutQualifiers(t *testing.T) {
+func TestCORECopyWithoutQualifiers(t *testing.T) {
 	qualifiers := []struct {
 		name string
 		fn   func(Type) Type

--- a/linker.go
+++ b/linker.go
@@ -81,19 +81,19 @@ func findReferences(progs map[string]*ProgramSpec) error {
 	return nil
 }
 
-// collectCoreRelos returns a list of CO-RE relocations of the layout's progs
+// collectCORERelos returns a list of CO-RE relocations of the layout's progs
 // in order.
-func collectCoreRelos(layout []reference) btf.CoreRelos {
 	if len(layout) == 0 {
 		return nil
 	}
 
-	var relos btf.CoreRelos
+func collectCORERelos(layout []reference) btf.CORERelos {
+	var relos btf.CORERelos
 	for _, sym := range layout {
 		if sym.spec.BTF == nil {
 			continue
 		}
-		relos = append(relos, sym.spec.BTF.CoreRelos.Offset(uint32(sym.offset))...)
+		relos = append(relos, sym.spec.BTF.CORERelos.Offset(uint32(sym.offset))...)
 	}
 
 	return relos

--- a/linker.go
+++ b/linker.go
@@ -83,20 +83,16 @@ func findReferences(progs map[string]*ProgramSpec) error {
 
 // collectCORERelos returns a list of CO-RE relocations of the layout's progs
 // in order.
-	if len(layout) == 0 {
-		return nil
-	}
-
-func collectCORERelos(layout []reference) btf.CORERelos {
+func collectCORERelos(layout []reference) (btf.CORERelos, error) {
 	var relos btf.CORERelos
 	for _, sym := range layout {
 		if sym.spec.BTF == nil {
-			continue
+			return nil, fmt.Errorf("program %s: missing BTF", sym.spec.Name)
 		}
 		relos = append(relos, sym.spec.BTF.CORERelos.Offset(uint32(sym.offset))...)
 	}
 
-	return relos
+	return relos, nil
 }
 
 // marshalFuncInfos returns the BTF func infos of all progs in order.

--- a/prog.go
+++ b/prog.go
@@ -293,7 +293,10 @@ func newProgramWithOptions(spec *ProgramSpec, opts ProgramOptions, handles *hand
 	var btfDisabled bool
 	var core btf.COREFixups
 	if spec.BTF != nil {
-		relos := collectCORERelos(layout)
+		relos, err := collectCORERelos(layout)
+		if err != nil {
+			return nil, fmt.Errorf("collecting CO-RE relocations: %w", err)
+		}
 		core, err = btf.CORERelocate(spec.BTF.Spec(), targetBTF, relos)
 		if err != nil {
 			return nil, fmt.Errorf("generating CO-RE fixups: %w", err)

--- a/prog.go
+++ b/prog.go
@@ -293,10 +293,10 @@ func newProgramWithOptions(spec *ProgramSpec, opts ProgramOptions, handles *hand
 	var btfDisabled bool
 	var core btf.COREFixups
 	if spec.BTF != nil {
-		relos := collectCoreRelos(layout)
+		relos := collectCORERelos(layout)
 		core, err = btf.CORERelocate(spec.BTF.Spec(), targetBTF, relos)
 		if err != nil {
-			return nil, fmt.Errorf("CO-RE relocations: %w", err)
+			return nil, fmt.Errorf("generating CO-RE fixups: %w", err)
 		}
 
 		handle, err := handles.btfHandle(spec.BTF.Spec())
@@ -328,7 +328,7 @@ func newProgramWithOptions(spec *ProgramSpec, opts ProgramOptions, handles *hand
 
 	insns, err := core.Apply(spec.Instructions)
 	if err != nil {
-		return nil, fmt.Errorf("CO-RE fixup: %w", err)
+		return nil, fmt.Errorf("applying CO-RE fixups: %w", err)
 	}
 
 	if err := fixupAndValidate(insns); err != nil {


### PR DESCRIPTION
CO-RE/CORE is an acronym, consistently name it that way.

Missing program BTF should not be silently ignored in `collectCORERelos()`, so make it return error.