### PR TITLE
asm: add Instruction Source metadata

### DIFF
--- a/asm/instruction_test.go
+++ b/asm/instruction_test.go
@@ -180,9 +180,10 @@ func TestInstructionsRewriteMapPtr(t *testing.T) {
 // You can use format flags to change the way an eBPF
 // program is stringified.
 func ExampleInstructions_Format() {
+
 	insns := Instructions{
-		FnMapLookupElem.Call().WithSymbol("my_func"),
-		LoadImm(R0, 42, DWord),
+		FnMapLookupElem.Call().WithSymbol("my_func").WithSource(Comment("bpf_map_lookup_elem()")),
+		LoadImm(R0, 42, DWord).WithSource(Comment("abc = 42")),
 		Return(),
 	}
 
@@ -200,25 +201,33 @@ func ExampleInstructions_Format() {
 
 	// Output: Default format:
 	// my_func:
+	//	 ; bpf_map_lookup_elem()
 	// 	0: Call FnMapLookupElem
+	//	 ; abc = 42
 	// 	1: LdImmDW dst: r0 imm: 42
 	// 	3: Exit
 	//
 	// Don't indent instructions:
 	// my_func:
+	//  ; bpf_map_lookup_elem()
 	// 0: Call FnMapLookupElem
+	//  ; abc = 42
 	// 1: LdImmDW dst: r0 imm: 42
 	// 3: Exit
 	//
 	// Indent using spaces:
 	// my_func:
+	//   ; bpf_map_lookup_elem()
 	//  0: Call FnMapLookupElem
+	//   ; abc = 42
 	//  1: LdImmDW dst: r0 imm: 42
 	//  3: Exit
 	//
 	// Control symbol indentation:
 	// 		my_func:
+	//	 ; bpf_map_lookup_elem()
 	// 	0: Call FnMapLookupElem
+	//	 ; abc = 42
 	// 	1: LdImmDW dst: r0 imm: 42
 	// 	3: Exit
 }


### PR DESCRIPTION
This commit adds Source metadata to Instruction, which is data about the origin of a series of Instructions.

A Source can be any fmt.Stringer. The ELF reader will associate corresponding btf.LineInfo objects with the Instruction.

Instructions.Format will now print the source information in-line with the Instruction on which it is set. This results in instructions being annotated with original source code when loaded from an ELF file, or custom annotations if custom Stringers are assigned using the Instruction.WithSource.

---

Leaving this here as work in progress because the LineInfo unmarshaler should be reverted to operate per section instead of per function. lineInfos are encoded per section, so it's a bit unnecessary to split during unmarshaling and join for instruction tagging.