### PR TITLE
Remove extra allocations from perf.Reader.Read()

### DIFF
--- a/internal/endian.go
+++ b/internal/endian.go
@@ -1,3 +1,6 @@
+//go:build !arm64 && !amd64
+// +build !arm64,!amd64
+
 package internal
 
 import (

--- a/internal/endian_le.go
+++ b/internal/endian_le.go
@@ -1,0 +1,10 @@
+//go:build amd64 || arm64
+// +build amd64 arm64
+
+package internal
+
+import "encoding/binary"
+
+var NativeEndian binary.ByteOrder = binary.LittleEndian
+
+const ClangEndian = "el"

--- a/perf/ring.go
+++ b/perf/ring.go
@@ -10,8 +10,16 @@ import (
 	"sync/atomic"
 	"unsafe"
 
+	"github.com/cilium/ebpf/internal"
 	"github.com/cilium/ebpf/internal/unix"
 )
+
+type ringReaderSeeker interface {
+	io.Reader
+	readUint32() (uint32, error)
+	readUint64() (uint64, error)
+	seek(int) error
+}
 
 // perfEventRing is a page of metadata followed by
 // a variable number of pages which form a ring buffer.
@@ -136,9 +144,20 @@ func (rr *ringReader) writeTail() {
 }
 
 func (rr *ringReader) Read(p []byte) (int, error) {
-	start := int(rr.tail & rr.mask)
+	start, end := rr.getBounds(len(p))
+	n := copy(p, rr.ring[start:end])
+	rr.tail += uint64(n)
 
-	n := len(p)
+	if rr.tail == rr.head {
+		return n, io.EOF
+	}
+
+	return n, nil
+}
+
+func (rr *ringReader) getBounds(len int) (start, end int) {
+	n := len
+	start = int(rr.tail & rr.mask)
 	// Truncate if the read wraps in the ring buffer
 	if remainder := cap(rr.ring) - start; n > remainder {
 		n = remainder
@@ -148,13 +167,37 @@ func (rr *ringReader) Read(p []byte) (int, error) {
 	if remainder := int(rr.head - rr.tail); n > remainder {
 		n = remainder
 	}
+	end = start + n
+	return
+}
 
-	copy(p, rr.ring[start:start+n])
-	rr.tail += uint64(n)
-
-	if rr.tail == rr.head {
-		return n, io.EOF
+func (rr *ringReader) readUint32() (uint32, error) {
+	n := 4
+	start, end := rr.getBounds(n)
+	if end-start < n {
+		return 0, io.EOF
 	}
+	num := internal.NativeEndian.Uint32(rr.ring[start:end])
+	rr.tail += uint64(n)
+	return num, nil
+}
 
-	return n, nil
+func (rr *ringReader) readUint64() (uint64, error) {
+	n := 8
+	start, end := rr.getBounds(n)
+	if end-start < n {
+		return 0, io.EOF
+	}
+	num := internal.NativeEndian.Uint64(rr.ring[start:end])
+	rr.tail += uint64(n)
+	return num, nil
+}
+
+func (rr *ringReader) seek(offset int) error {
+	start, end := rr.getBounds(offset)
+	rr.tail += uint64(end - start)
+	if rr.tail == rr.head {
+		return io.EOF
+	}
+	return nil
 }


### PR DESCRIPTION
Before:
```
goos: linux
goarch: arm64
pkg: github.com/cilium/ebpf/perf
BenchmarkReader
BenchmarkReader-4   	  287356	      3732 ns/op	     409 B/op	       6 allocs/op
BenchmarkReader-4   	  305671	      3701 ns/op	     409 B/op	       6 allocs/op
BenchmarkReader-4   	  305148	      3669 ns/op	     409 B/op	       6 allocs/op
BenchmarkReader-4   	  306469	      3675 ns/op	     409 B/op	       6 allocs/op
BenchmarkReader-4   	  295496	      3691 ns/op	     409 B/op	       6 allocs/op
BenchmarkReader-4   	  297704	      3710 ns/op	     410 B/op	       6 allocs/op
BenchmarkReader-4   	  302049	      3667 ns/op	     410 B/op	       6 allocs/op
BenchmarkReader-4   	  299085	      3680 ns/op	     409 B/op	       6 allocs/op
BenchmarkReader-4   	  305419	      3673 ns/op	     409 B/op	       6 allocs/op
BenchmarkReader-4   	  305707	      3691 ns/op	     409 B/op	       6 allocs/op
PASS
ok  	github.com/cilium/ebpf/perf	11.532s
```

After:
```
goos: linux
goarch: arm64
pkg: github.com/cilium/ebpf/perf
BenchmarkReader
BenchmarkReader-4   	  318324	      3476 ns/op	     384 B/op	       2 allocs/op
BenchmarkReader-4   	  330291	      3492 ns/op	     384 B/op	       2 allocs/op
BenchmarkReader-4   	  325369	      3509 ns/op	     384 B/op	       2 allocs/op
BenchmarkReader-4   	  325884	      3508 ns/op	     384 B/op	       2 allocs/op
BenchmarkReader-4   	  327452	      3497 ns/op	     384 B/op	       2 allocs/op
BenchmarkReader-4   	  326408	      3599 ns/op	     384 B/op	       2 allocs/op
BenchmarkReader-4   	  320997	      3507 ns/op	     384 B/op	       2 allocs/op
BenchmarkReader-4   	  320274	      3512 ns/op	     384 B/op	       2 allocs/op
BenchmarkReader-4   	  318555	      3506 ns/op	     384 B/op	       2 allocs/op
BenchmarkReader-4   	  329978	      3499 ns/op	     384 B/op	       2 allocs/op
PASS
ok  	github.com/cilium/ebpf/perf	11.788s
```

The remaining 2 allocs are:
1. The creation of the raw sample slice
2. The output slice from `program.Test`