### PR TITLE
btf: reduce unnecessary copies when parsing BTF

### DIFF
--- a/internal/btf/btf_test.go
+++ b/internal/btf/btf_test.go
@@ -161,6 +161,7 @@ func TestTypeByName(t *testing.T) {
 
 func BenchmarkParseVmlinux(b *testing.B) {
 	rd := readVMLinux(b)
+	b.ReportAllocs()
 	b.ResetTimer()
 
 	for n := 0; n < b.N; n++ {

--- a/internal/io.go
+++ b/internal/io.go
@@ -18,7 +18,7 @@ import (
 // end up being read completely anyway.
 //
 // Use instead of the r.Seek() + io.LimitReader() pattern.
-func NewBufferedSectionReader(ra io.ReaderAt, off, n int64) io.Reader {
+func NewBufferedSectionReader(ra io.ReaderAt, off, n int64) *bufio.Reader {
 	// Clamp the size of the buffer to one page to avoid slurping large parts
 	// of a file into memory. bufio.NewReader uses a hardcoded default buffer
 	// of 4096. Allow arches with larger pages to allocate more, but don't


### PR DESCRIPTION
We currently read all BTF into memory before starting decoding. This is wasteful,
especially for the large-ish string table. Be a bit more clever to remove intermediate
copies.

    name            old time/op    new time/op    delta
    ParseVmlinux-4     107ms ± 7%      77ms ±13%  -27.98%  (p=0.029 n=4+4)

    name            old alloc/op   new alloc/op   delta
    ParseVmlinux-4     119MB ± 0%      93MB ± 0%  -22.20%  (p=0.029 n=4+4)

    name            old allocs/op  new allocs/op  delta
    ParseVmlinux-4      786k ± 0%      786k ± 0%   -0.01%  (p=0.029 n=4+4)