### PR TITLE
link/kprobe: improve test cases for kprobe+offset feature

### DIFF
--- a/link/kprobe.go
+++ b/link/kprobe.go
@@ -161,7 +161,7 @@ func kprobe(symbol string, prog *ebpf.Program, opts *KprobeOptions, ret bool) (*
 
 	args := probeArgs{
 		pid:    perfAllThreads,
-		symbol: platformPrefix(symbol),
+		symbol: symbol,
 		ret:    ret,
 	}
 
@@ -173,7 +173,7 @@ func kprobe(symbol string, prog *ebpf.Program, opts *KprobeOptions, ret bool) (*
 	// Use kprobe PMU if the kernel has it available.
 	tp, err := pmuKprobe(args)
 	if errors.Is(err, os.ErrNotExist) {
-		args.symbol = symbol
+		args.symbol = platformPrefix(symbol)
 		tp, err = pmuKprobe(args)
 	}
 	if err == nil {
@@ -184,10 +184,10 @@ func kprobe(symbol string, prog *ebpf.Program, opts *KprobeOptions, ret bool) (*
 	}
 
 	// Use tracefs if kprobe PMU is missing.
-	args.symbol = platformPrefix(symbol)
+	args.symbol = symbol
 	tp, err = tracefsKprobe(args)
 	if errors.Is(err, os.ErrNotExist) {
-		args.symbol = symbol
+		args.symbol = platformPrefix(symbol)
 		tp, err = tracefsKprobe(args)
 	}
 	if err != nil {

--- a/link/kprobe_test.go
+++ b/link/kprobe_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"syscall"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
@@ -429,28 +430,71 @@ func TestKprobeToken(t *testing.T) {
 	}
 }
 
-// Test Kprobe with Offset
 func TestKprobeOffset(t *testing.T) {
+	// skip test on 4.4 and 4.9 as the offsets are different
+	// even if the function implementation hasn't changed:
+	//
+	// ffffffff81690670 <inet6_release>:
+	// ffffffff81690670:	e8 eb c0 15 00       	call   ffffffff817ec760 <__fentry__>
+	// ffffffff81690675:	55                   	push   %rbp
+	// ffffffff81690676:	48 89 e5             	mov    %rsp,%rbp
+	// ffffffff81690679:	41 55                	push   %r13
+	// ffffffff8169067b:	41 54                	push   %r12
+	// snip
+	testutils.SkipOnOldKernel(t, "4.10", "n/a")
+
 	tests := []struct {
+		name   string
 		offset uint64
-		ok     bool
+		err    error
 	}{
-		{0, true},
-		{math.MaxUint64, false},
+		// cat /boot/System.map-$(uname -r) |rg inet6_release
+		// ffffffff81b97c10 T inet6_release
+		//
+		// ./extract-vmlinux /boot/vmlinuz-$(uname -r) > /tmp/vmlinux
+		//
+		// objdump -D /tmp/vmlinux |rg ffffffff81b97c
+		// ffffffff81b97c10:	e8 4b fc 4c ff       	call   0xffffffff81067860
+		// ffffffff81b97c15:	41 54                	push   %r12
+		// ffffffff81b97c17:	55                   	push   %rbp
+		// ffffffff81b97c18:	4c 8b 67 18          	mov    0x18(%rdi),%r12
+		// snip
+		// ffffffff81b97c27:	e8 c4 ae 03 00       	call   0xffffffff81bd2af0
+		// snip
+		// ffffffff81b97c47:	c3                   	ret
+		{"valid offset", 0x5, nil},
+		{"valid offset", 0x7, nil},
+		// ipv6_sock_mc_close()
+		{"valid offset", 0x17, nil},
+		{"bad insn boundary", 0x4, syscall.EILSEQ},
+		{"bad insn boundary", 0x6, syscall.EILSEQ},
+		{"bad probe address", math.MaxUint64, os.ErrNotExist},
 	}
 
 	prog := mustLoadProgram(t, ebpf.Kprobe, 0, "")
-	for i, tt := range tests {
-		t.Run(fmt.Sprint(i), func(t *testing.T) {
-			k, err := Kprobe(ksym, prog, &KprobeOptions{Offset: tt.offset})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			k, err := Kprobe("inet6_release", prog, &KprobeOptions{Offset: tt.offset})
+			if tt.err != nil {
+				if !errors.Is(err, tt.err) {
+					// -EILSEQ is returned only since 5.2.
+					// https://github.com/torvalds/linux/commit/ab105a4fb89496c71c5a0f3222347c506c30feb0
+					if errors.Is(tt.err, syscall.EILSEQ) && errors.Is(err, os.ErrNotExist) {
+						return
+					}
+					// tracefs returns -ERANGE instead of os.ErrNotExist.
+					if errors.Is(tt.err, os.ErrNotExist) && errors.Is(err, syscall.ERANGE) {
+						return
+					}
+					t.Errorf("expected err '%v', got '%v'", tt.err, err)
+				}
+				return
+			}
 
-			ok := err == nil
-			if tt.ok != ok {
-				t.Errorf("Expected symbol+offset load %v', got '%v'", tt.ok, ok)
+			if err != nil {
+				t.Fatalf("unexpected err: '%v'", err)
 			}
-			if ok {
-				k.Close()
-			}
+			k.Close()
 		})
 	}
 }

--- a/link/perf_event.go
+++ b/link/perf_event.go
@@ -211,19 +211,9 @@ func attachPerfEvent(pe *perfEvent, prog *ebpf.Program) (Link, error) {
 	}
 
 	if err := haveBPFLinkPerfEvent(); err == nil {
-		lnk, err := attachPerfEventLink(pe, prog)
-		if err != nil {
-			return nil, err
-		}
-		return lnk, nil
+		return attachPerfEventLink(pe, prog)
 	}
-
-	lnk, err := attachPerfEventIoctl(pe, prog)
-	if err != nil {
-		return nil, err
-	}
-
-	return lnk, nil
+	return attachPerfEventIoctl(pe, prog)
 }
 
 func attachPerfEventIoctl(pe *perfEvent, prog *ebpf.Program) (*perfEventIoctl, error) {


### PR DESCRIPTION
Some polishing:

- kprobe: load provided symbol first and then fallback to platform specific syscall symbols

the vast majority of traceable functions are not syscalls, swapping the syms will remove the "fallback overhead" for most cases
```
wc -l /sys/kernel/debug/tracing/available_filter_functions
70291

cat /sys/kernel/debug/tracing/available_filter_functions |rg __x64_ |wc -l
424
```

- kprobe: properly test the offset feature

I tried to add a "positive" test for a fairly stable symbol (hasn't changed since 2.x): `inet6_release`.
The compiled vmlinux would still report different offsets for older kernels, but seems to be stable from 4.14 to 5.16. If this will become something that should be maintained with newer kernel version, we can remove the positive cases and leave the "bad insn boundary" ones
