### PR TITLE
fix incorrect usage of elf.File.Close

### DIFF
--- a/elf_reader.go
+++ b/elf_reader.go
@@ -49,7 +49,6 @@ func LoadCollectionSpecFromReader(rd io.ReaderAt) (*CollectionSpec, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer f.Close()
 
 	var (
 		licenseSection *elf.Section

--- a/internal/btf/btf.go
+++ b/internal/btf/btf.go
@@ -90,7 +90,6 @@ func LoadSpecFromReader(rd io.ReaderAt) (*Spec, error) {
 
 		return nil, err
 	}
-	defer file.Close()
 
 	return loadSpecFromELF(file)
 }
@@ -390,11 +389,11 @@ func findVMLinux() (*internal.SafeELFFile, error) {
 	}
 
 	for _, loc := range locations {
-		fh, err := os.Open(fmt.Sprintf(loc, release))
-		if err != nil {
+		file, err := internal.OpenSafeELFFile(fmt.Sprintf(loc, release))
+		if errors.Is(err, os.ErrNotExist) {
 			continue
 		}
-		return internal.NewSafeELFFile(fh)
+		return file, err
 	}
 
 	return nil, fmt.Errorf("no BTF found for kernel version %s: %w", release, internal.ErrNotSupported)

--- a/internal/btf/btf_test.go
+++ b/internal/btf/btf_test.go
@@ -193,6 +193,7 @@ func TestFindVMLinux(t *testing.T) {
 	if err != nil {
 		t.Fatal("Can't find vmlinux:", err)
 	}
+	defer file.Close()
 
 	spec, err := loadSpecFromELF(file)
 	if err != nil {

--- a/internal/elf.go
+++ b/internal/elf.go
@@ -35,6 +35,29 @@ func NewSafeELFFile(r io.ReaderAt) (safe *SafeELFFile, err error) {
 	return &SafeELFFile{file}, nil
 }
 
+// OpenSafeELFFile reads an ELF from a file.
+//
+// It works like NewSafeELFFile, with the exception that safe.Close will
+// close the underlying file.
+func OpenSafeELFFile(path string) (safe *SafeELFFile, err error) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			return
+		}
+
+		safe = nil
+		err = fmt.Errorf("reading ELF file panicked: %s", r)
+	}()
+
+	file, err := elf.Open(path)
+	if err != nil {
+		return nil, err
+	}
+
+	return &SafeELFFile{file}, nil
+}
+
 // Symbols is the safe version of elf.File.Symbols.
 func (se *SafeELFFile) Symbols() (syms []elf.Symbol, err error) {
 	defer func() {


### PR DESCRIPTION
elf.File.Close has a strange API:

    Close closes the File. If the File was created using NewFile
    directly instead of Open, Close has no effect.

We inconsistently call elf.File.Close across the code base, but since
we always use NewFile whether we call close or not doesn't have an
effect. This is a problem in findVMLinux, as it relies
on elf.File.Close to do cleanup. Introduce a wrapper for elf.File.Open
so that Close works, and remove ineffectual calls to Close.