### PR TITLE
Makefile: add internal/sys to generate target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,7 @@ generate: export BPF_CLANG := $(CLANG)
 generate: export BPF_CFLAGS := $(CFLAGS)
 generate:
 	go generate ./cmd/bpf2go/test
+	go generate ./internal/sys
 	cd examples/ && go generate ./...
 
 testdata/loader-%-el.elf: testdata/loader.c

--- a/internal/sys/doc.go
+++ b/internal/sys/doc.go
@@ -1,4 +1,6 @@
 // Package sys contains bindings for the BPF syscall.
 package sys
 
+// Regenerate types.go by invoking go generate in the current directory.
+
 //go:generate go run github.com/cilium/ebpf/internal/cmd/gentypes ../btf/testdata/vmlinux-btf.gz


### PR DESCRIPTION
Also regenerate syscall wrappers when generating code. This makes sure that CI
reproduces the checked in code 1:1.