### PR TITLE
Memory improvements to `loadRawSpec`

### DIFF
--- a/internal/btf/btf.go
+++ b/internal/btf/btf.go
@@ -462,7 +462,7 @@ func parseBTF(btf io.ReaderAt, bo binary.ByteOrder) ([]rawType, stringTable, err
 	}
 
 	buf.Reset(io.NewSectionReader(btf, header.typeStart(), int64(header.TypeLen)))
-	rawTypes, err := readTypes(buf, bo)
+	rawTypes, err := readTypes(buf, bo, header.TypeLen)
 	if err != nil {
 		return nil, nil, fmt.Errorf("can't read types: %w", err)
 	}

--- a/internal/btf/btf_types.go
+++ b/internal/btf/btf_types.go
@@ -226,11 +226,14 @@ type btfParam struct {
 	Type    TypeID
 }
 
-func readTypes(r io.Reader, bo binary.ByteOrder) ([]rawType, error) {
-	var (
-		header btfType
-		types  []rawType
-	)
+func readTypes(r io.Reader, bo binary.ByteOrder, typeLen uint32) ([]rawType, error) {
+	var header btfType
+	// because of the interleaving between types and struct members it is difficult to
+	// precompute the numbers of raw types this will parse
+	// this "guess" is a good first estimation
+	sizeOfbtfType := uintptr(binary.Size(btfType{}))
+	tyMaxCount := uintptr(typeLen) / sizeOfbtfType / 2
+	types := make([]rawType, 0, tyMaxCount)
 
 	for id := TypeID(1); ; id++ {
 		if err := binary.Read(r, bo, &header); err == io.EOF {

--- a/internal/btf/types.go
+++ b/internal/btf/types.go
@@ -776,20 +776,47 @@ func (dq *typeDeque) all() []*Type {
 	return types
 }
 
+// countFixups takes a list of raw btf types and returns the count of fixups that
+// will be required when building the graph of Types.
+func countFixups(rawTypes []rawType) int {
+	fixupCount := 0
+	for _, raw := range rawTypes {
+		switch raw.Kind() {
+		case kindStruct, kindUnion:
+			members := raw.data.([]btfMember)
+			fixupCount += len(members)
+
+		case kindFuncProto:
+			rawparams := raw.data.([]btfParam)
+			fixupCount += len(rawparams) + 1
+
+		case kindDatasec:
+			btfVars := raw.data.([]btfVarSecinfo)
+			fixupCount += len(btfVars)
+
+		default:
+			fixupCount++
+		}
+	}
+	return fixupCount
+}
+
 // inflateRawTypes takes a list of raw btf types linked via type IDs, and turns
 // it into a graph of Types connected via pointers.
 //
 // Returns a map of named types (so, where NameOff is non-zero) and a slice of types
 // indexed by TypeID. Since BTF ignores compilation units, multiple types may share
 // the same name. A Type may form a cyclic graph by pointing at itself.
-func inflateRawTypes(rawTypes []rawType, rawStrings stringTable) (types []Type, namedTypes map[essentialName][]Type, err error) {
+func inflateRawTypes(rawTypes []rawType, rawStrings stringTable) ([]Type, map[essentialName][]Type, error) {
 	type fixupDef struct {
 		id           TypeID
 		expectedKind btfKind
 		typ          *Type
 	}
 
-	var fixups []fixupDef
+	fixupsCount := countFixups(rawTypes)
+	fixups := make([]fixupDef, 0, fixupsCount)
+
 	fixup := func(id TypeID, expectedKind btfKind, typ *Type) {
 		fixups = append(fixups, fixupDef{id, expectedKind, typ})
 	}
@@ -819,9 +846,9 @@ func inflateRawTypes(rawTypes []rawType, rawStrings stringTable) (types []Type, 
 		return members, nil
 	}
 
-	types = make([]Type, 0, len(rawTypes))
+	types := make([]Type, 0, len(rawTypes)+1)
 	types = append(types, (*Void)(nil))
-	namedTypes = make(map[essentialName][]Type)
+	namedTypes := make(map[essentialName][]Type)
 
 	for i, raw := range rawTypes {
 		var (


### PR DESCRIPTION
This PR contains memory usage (and small cpu) improvements to `lawRawSpec` through:
- precomputing the amount of required fixups when building the type graph
- guess-timating the amount of types when reading the btf types reducing the amount of buffer reallocation

Benchmark:
```
>>> sudo go test -run=XXX -bench=BenchmarkParseVmlinux ./internal/btf
```

Before (master branch):
```
goos: linux
goarch: amd64
pkg: github.com/cilium/ebpf/internal/btf
cpu: Intel(R) Core(TM) i7-1068NG7 CPU @ 2.30GHz
BenchmarkParseVmlinux-4   	       9	 118640220 ns/op	96579569 B/op	  786353 allocs/op
PASS
ok  	github.com/cilium/ebpf/internal/btf	2.049s
```

After (updated after review):
```
goos: linux
goarch: amd64
pkg: github.com/cilium/ebpf/internal/btf
cpu: Intel(R) Core(TM) i7-1068NG7 CPU @ 2.30GHz
BenchmarkParseVmlinux-4   	      14	  76856666 ns/op	53361862 B/op	  574838 allocs/op
PASS
ok  	github.com/cilium/ebpf/internal/btf	2.001s
```

Happy to discuss future paths of improvements