### PR TITLE
internal: make ErrorWithLog slightly more efficient

### DIFF
--- a/internal/btf/btf.go
+++ b/internal/btf/btf.go
@@ -783,6 +783,7 @@ func NewHandle(spec *Spec) (*Handle, error) {
 		attr.BtfLogSize = uint32(len(logBuf))
 		attr.BtfLogLevel = 1
 		_, logErr := sys.BtfLoad(attr)
+		// NB: The syscall will never return ENOSPC as of 5.18-rc4.
 		return nil, internal.ErrorWithLog(err, logBuf, logErr)
 	}
 

--- a/internal/errors.go
+++ b/internal/errors.go
@@ -1,9 +1,9 @@
 package internal
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/cilium/ebpf/internal/unix"
 )
@@ -14,7 +14,7 @@ import (
 // logErr should be the error returned by the syscall that generated
 // the log. It is used to check for truncation of the output.
 func ErrorWithLog(err error, log []byte, logErr error) error {
-	logStr := strings.Trim(unix.ByteSliceToString(log), "\t\r\n ")
+	logStr := unix.ByteSliceToString(bytes.Trim(log, "\t\r\n "))
 	if errors.Is(logErr, unix.ENOSPC) {
 		logStr += " (truncated...)"
 	}


### PR DESCRIPTION
Trim the log before converting it into a string will save an allocation.
Also document that BPF_LOAD_BTF never returns ENOSPC.