### PR TITLE
collection: Add ReplaceMaps to CollectionOptions

### DIFF
--- a/map.go
+++ b/map.go
@@ -24,7 +24,7 @@ var (
 	ErrKeyNotExist      = errors.New("key does not exist")
 	ErrKeyExist         = errors.New("key already exists")
 	ErrIterationAborted = errors.New("iteration aborted")
-	ErrMapIncompatible  = errors.New("map's spec is incompatible with pinned map")
+	ErrMapIncompatible  = errors.New("map spec is incompatible with existing map")
 )
 
 // MapOptions control loading a map into the kernel.


### PR DESCRIPTION
```
    collection: Add MapReplacements to CollectionOptions
    
    Add a new way to replace references to specific maps when creating a
    new collection by introducing a MapReplacements field to the
    CollectionOptions struct.
    
    The goal of this functionality is the same provided by RewriteMaps(),
    but this new approach plays nicely with bpf2go as https://github.com/cilium/ebpf/issues/517
    is fixed.
```

Fixes https://github.com/cilium/ebpf/issues/517