### PR TITLE
Hard code endianness

### DIFF
--- a/internal/endian.go
+++ b/internal/endian.go
@@ -1,3 +1,6 @@
+//go:build !386 && !amd64 && !amd64p32 && !arm && !arm64 && !mipsle && !mips64le && !mips64p32le && !ppc64le && !riscv64 && !armbe && !arm64be && !mips && !mips64 && !mips64p32 && !ppc64 && !s390 && !s390x && !sparc && !sparc64
+// +build !386,!amd64,!amd64p32,!arm,!arm64,!mipsle,!mips64le,!mips64p32le,!ppc64le,!riscv64,!armbe,!arm64be,!mips,!mips64,!mips64p32,!ppc64,!s390,!s390x,!sparc,!sparc64
+
 package internal
 
 import (
@@ -9,7 +12,7 @@ import (
 // depending on the host's endianness.
 var NativeEndian binary.ByteOrder
 
-// Clang is set to either "el" or "eb" depending on the host's endianness.
+// ClangEndian is set to either "el" or "eb" depending on the host's endianness.
 var ClangEndian string
 
 func init() {

--- a/internal/endian_be.go
+++ b/internal/endian_be.go
@@ -1,0 +1,13 @@
+//go:build armbe || arm64be || mips || mips64 || mips64p32 || ppc64 || s390 || s390x || sparc || sparc64
+// +build armbe arm64be mips mips64 mips64p32 ppc64 s390 s390x sparc sparc64
+
+package internal
+
+import "encoding/binary"
+
+// NativeEndian is set to either binary.BigEndian or binary.LittleEndian,
+// depending on the host's endianness.
+var NativeEndian binary.ByteOrder = binary.BigEndian
+
+// ClangEndian is set to either "el" or "eb" depending on the host's endianness.
+const ClangEndian = "eb"

--- a/internal/endian_le.go
+++ b/internal/endian_le.go
@@ -1,0 +1,13 @@
+//go:build 386 || amd64 || amd64p32 || arm || arm64 || mipsle || mips64le || mips64p32le || ppc64le || riscv64
+// +build 386 amd64 amd64p32 arm arm64 mipsle mips64le mips64p32le ppc64le riscv64
+
+package internal
+
+import "encoding/binary"
+
+// NativeEndian is set to either binary.BigEndian or binary.LittleEndian,
+// depending on the host's endianness.
+var NativeEndian binary.ByteOrder = binary.LittleEndian
+
+// ClangEndian is set to either "el" or "eb" depending on the host's endianness.
+const ClangEndian = "el"


### PR DESCRIPTION
This results in a reduction of the instructions necessary for endian-related operations. The wall clock time difference for a single call is miniscule (picoseconds).

An example, with the `ByteOrder.Uint32` function:
Runtime instructions: https://godbolt.org/z/7vW1Pfnso
Buildtime instructions: https://godbolt.org/z/baxW1Wb7W

The function call on `amd64` changes from:
```
MOVQ    "".NativeEndian(SB), CX
MOVQ    "".NativeEndian+8(SB), DX
MOVQ    64(CX), CX
MOVQ    AX, BX
MOVL    $4, DI
MOVQ    DX, AX
MOVQ    CX, DX
MOVQ    DI, CX
CALL    DX
```
to
```
XCHGL   AX, AX
```

The difference on `arm64` is equivalent, but uses different specific instructions.