### PR TITLE
Deprecate CollectionSpec.RewriteMaps()

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -19,13 +19,15 @@ type CollectionOptions struct {
 	Maps     MapOptions
 	Programs ProgramOptions
 
-	// MapReplacements defines a set of maps that will be used
-	// instead of creating new ones when loading the object. The
-	// maps' specs should be compatible and there must exist a map
-	// in CollectionSpec.Maps for each map in MapReplacements.
-	// MapReplacements are cloned before being used in the
-	// Collection, so the user can Close() them if not needed
-	// anymore.
+	// MapReplacements takes a set of Maps that will be used instead of
+	// creating new ones when loading the CollectionSpec.
+	//
+	// For each given Map, there must be a corresponding MapSpec in
+	// CollectionSpec.Maps, and its type, key/value size, max entries and flags
+	// must match the values of the MapSpec.
+	//
+	// The given Maps are Clone()d before being used in the Collection, so the
+	// caller can Close() them freely when they are no longer needed.
 	MapReplacements map[string]*Map
 }
 

--- a/collection.go
+++ b/collection.go
@@ -75,6 +75,9 @@ func (cs *CollectionSpec) Copy() *CollectionSpec {
 // when calling NewCollection. Any named maps are removed from CollectionSpec.Maps.
 //
 // Returns an error if a named map isn't used in at least one program.
+//
+// Deprecated: Pass CollectionOptions.MapReplacements when loading the Collection
+// instead.
 func (cs *CollectionSpec) RewriteMaps(maps map[string]*Map) error {
 	for symbol, m := range maps {
 		// have we seen a program that uses this symbol / map


### PR DESCRIPTION
Some follow-ups to https://github.com/cilium/ebpf/pull/646.

Adds a deprecation notice to RewriteMaps().
Moves the Map(Spec) compatibility check out of the lazy-loading path.

cc @mauriciovasquezbernal 