### PR TITLE
syscalls: omit AttachType field in haveProgAttach

### DIFF
--- a/link/syscalls.go
+++ b/link/syscalls.go
@@ -27,9 +27,8 @@ const (
 
 var haveProgAttach = internal.FeatureTest("BPF_PROG_ATTACH", "4.10", func() error {
 	prog, err := ebpf.NewProgram(&ebpf.ProgramSpec{
-		Type:       ebpf.CGroupSKB,
-		AttachType: ebpf.AttachCGroupInetIngress,
-		License:    "MIT",
+		Type:    ebpf.CGroupSKB,
+		License: "MIT",
 		Instructions: asm.Instructions{
 			asm.Mov.Imm(asm.R0, 0),
 			asm.Return(),

--- a/prog.go
+++ b/prog.go
@@ -58,7 +58,12 @@ type ProgramSpec struct {
 	Name string
 
 	// Type determines at which hook in the kernel a program will run.
-	Type       ProgramType
+	Type ProgramType
+
+	// AttachType of the program, needed to differentiate allowed context
+	// accesses in some newer program types like CGroupSockAddr.
+	//
+	// Available on kernels 4.17 and later.
 	AttachType AttachType
 
 	// Name of a kernel data structure or function to attach to. Its


### PR DESCRIPTION
Discovered while running the test suite on kernel 4.14.

With the addition BPF_PROG_ATTACH tests in package link, the haveProgAttach feature test was added, gated on 4.10. This helper uses the AttachType field, which sets the bpf_attr expected_attach_type field, available as of 4.17.

There are more issues to address for 4.14, but this patch fixes these tests on kernels between 4.10 and 4.17.

cc @rgo3 