### PR TITLE
Assorted fixes for kernel 4.14

### DIFF
--- a/info.go
+++ b/info.go
@@ -214,7 +214,10 @@ func (pi *ProgramInfo) Runtime() (time.Duration, bool) {
 // inspecting loaded programs for troubleshooting, dumping, etc.
 //
 // For example, map accesses are made to reference their kernel map IDs,
-// not the FDs they had when the program was inserted.
+// not the FDs they had when the program was inserted. Note that before
+// the introduction of bpf_insn_prepare_dump in kernel 4.16, xlated
+// instructions were not sanitized, making the output even less reusable
+// and less likely to round-trip or evaluate to the same program Tag.
 //
 // The first instruction is marked as a symbol using the Program's name.
 //

--- a/link/link_test.go
+++ b/link/link_test.go
@@ -85,7 +85,7 @@ func mustCgroupFixtures(t *testing.T) (*os.File, *ebpf.Program) {
 
 	testutils.SkipIfNotSupported(t, haveProgAttach())
 
-	return testutils.CreateCgroup(t), mustLoadProgram(t, ebpf.CGroupSKB, ebpf.AttachCGroupInetEgress, "")
+	return testutils.CreateCgroup(t), mustLoadProgram(t, ebpf.CGroupSKB, 0, "")
 }
 
 func testLink(t *testing.T, link Link, prog *ebpf.Program) {

--- a/map_test.go
+++ b/map_test.go
@@ -642,7 +642,7 @@ func TestMapLoadPinnedUnpin(t *testing.T) {
 
 func TestMapLoadPinnedWithOptions(t *testing.T) {
 	// Introduced in commit 6e71b04a8224.
-	testutils.SkipOnOldKernel(t, "4.14", "file_flags in BPF_OBJ_GET")
+	testutils.SkipOnOldKernel(t, "4.15", "file_flags in BPF_OBJ_GET")
 
 	array := createArray(t)
 	defer array.Close()

--- a/prog_test.go
+++ b/prog_test.go
@@ -687,17 +687,12 @@ func TestProgramBindMap(t *testing.T) {
 }
 
 func TestProgramInstructions(t *testing.T) {
-	arr := createArray(t)
-	defer arr.Close()
-
 	name := "test_prog"
 	spec := &ProgramSpec{
 		Type: SocketFilter,
 		Name: name,
 		Instructions: asm.Instructions{
 			asm.LoadImm(asm.R0, -1, asm.DWord).WithSymbol(name),
-			asm.LoadMapPtr(asm.R1, arr.FD()),
-			asm.Mov.Imm32(asm.R0, 0),
 			asm.Return(),
 		},
 		License: "MIT",


### PR DESCRIPTION
- Run `TestMapLoadPinnedWithOptions` as of 4.15
- Don't specify AttachType in `mustCgroupFixtures`
- Remove map pointer from `TestProgramInstructions`

Together with #657, this makes tests pass on our 4.14 ci-kernels image. To be enabled later when we move to self-hosted CI runners.