### PR TITLE
btf: move type IDs into Spec

### DIFF
--- a/internal/btf/btf.go
+++ b/internal/btf/btf.go
@@ -43,6 +43,9 @@ type Spec struct {
 	// Includes all struct flavors and types with the same name.
 	namedTypes map[essentialName][]Type
 
+	// Type IDs indexed by type.
+	typeIDs map[Type]TypeID
+
 	byteOrder binary.ByteOrder
 }
 
@@ -199,18 +202,45 @@ func loadRawSpec(btf io.ReaderAt, bo binary.ByteOrder, sectionSizes map[string]u
 		return nil, err
 	}
 
-	types, typesByName, err := inflateRawTypes(rawTypes, rawStrings)
+	types, err := inflateRawTypes(rawTypes, rawStrings)
 	if err != nil {
 		return nil, err
 	}
 
+	typeIDs, typesByName := indexTypes(types)
+
 	return &Spec{
 		rawTypes:   rawTypes,
 		namedTypes: typesByName,
+		typeIDs:    typeIDs,
 		types:      types,
 		strings:    rawStrings,
 		byteOrder:  bo,
 	}, nil
+}
+
+func indexTypes(types []Type) (map[Type]TypeID, map[essentialName][]Type) {
+	namedTypes := 0
+	for _, typ := range types {
+		if typ.TypeName() != "" {
+			// Do a pre-pass to figure out how big types by name has to be.
+			// Most types have unique names, so it's OK to ignore essentialName
+			// here.
+			namedTypes++
+		}
+	}
+
+	typeIDs := make(map[Type]TypeID, len(types))
+	typesByName := make(map[essentialName][]Type, namedTypes)
+
+	for i, typ := range types {
+		if name := newEssentialName(typ.TypeName()); name != "" {
+			typesByName[name] = append(typesByName[name], typ)
+		}
+		typeIDs[typ] = TypeID(i)
+	}
+
+	return typeIDs, typesByName
 }
 
 var kernelBTF struct {
@@ -413,20 +443,15 @@ func fixupDatasec(rawTypes []rawType, rawStrings *stringTable, sectionSizes map[
 func (s *Spec) Copy() *Spec {
 	types := copyTypes(s.types, nil)
 
-	namedTypes := make(map[essentialName][]Type)
-	for _, typ := range types {
-		if name := typ.TypeName(); name != "" {
-			en := newEssentialName(name)
-			namedTypes[en] = append(namedTypes[en], typ)
-		}
-	}
+	typeIDs, typesByName := indexTypes(types)
 
 	// NB: Other parts of spec are not copied since they are immutable.
 	return &Spec{
 		s.rawTypes,
 		s.strings,
 		types,
-		namedTypes,
+		typesByName,
+		typeIDs,
 		s.byteOrder,
 	}
 }
@@ -505,6 +530,18 @@ func (sw sliceWriter) Write(p []byte) (int, error) {
 // does not exist in the Spec.
 func (s *Spec) TypeByID(id TypeID) (Type, error) {
 	return s.types.ByID(id)
+}
+
+// TypeID returns the ID for a given Type.
+//
+// Returns an error wrapping ErrNoFound if the type isn't part of the Spec.
+func (s *Spec) TypeID(typ Type) (TypeID, error) {
+	id, ok := s.typeIDs[typ]
+	if !ok {
+		return 0, fmt.Errorf("no ID for given type: %w", ErrNotFound)
+	}
+
+	return id, nil
 }
 
 // AnyTypesByName returns a list of BTF Types with the given name.

--- a/link/tracing.go
+++ b/link/tracing.go
@@ -61,7 +61,10 @@ func AttachFreplace(targetProg *ebpf.Program, name string, prog *ebpf.Program) (
 		}
 
 		target = targetProg.FD()
-		typeID = function.ID()
+		typeID, err = btfHandle.Spec().TypeID(function)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	link, err := AttachRawLink(RawLinkOptions{

--- a/map.go
+++ b/map.go
@@ -407,9 +407,19 @@ func (spec *MapSpec) createMap(inner *sys.FD, opts MapOptions, handles *handleCa
 		}
 
 		if handle != nil {
+			keyTypeID, err := spec.BTF.TypeID(spec.Key)
+			if err != nil {
+				return nil, err
+			}
+
+			valueTypeID, err := spec.BTF.TypeID(spec.Value)
+			if err != nil {
+				return nil, err
+			}
+
 			attr.BtfFd = uint32(handle.FD())
-			attr.BtfKeyTypeId = uint32(spec.Key.ID())
-			attr.BtfValueTypeId = uint32(spec.Value.ID())
+			attr.BtfKeyTypeId = uint32(keyTypeID)
+			attr.BtfValueTypeId = uint32(valueTypeID)
 		}
 	}
 


### PR DESCRIPTION
The ID of a type is really its index in the list of types passed to the kernel
when loading BTF. As such, it's incorrect for a Type to have an ID. The ID only
exists for []Type. Remove ID() from the Type interface, and instead provide a
function to look up an ID from a Spec. This function requires a map[Type]TypeID
to avoid a linear scan of the potentially large Spec.types. It seems like removing
the type ID from types themselves does make up for the increase however.

    name            old time/op    new time/op    delta
    ParseVmlinux-4    58.6ms ± 1%    61.7ms ± 1%  +5.40%  (p=0.029 n=4+4)

    name            old alloc/op   new alloc/op   delta
    ParseVmlinux-4    45.2MB ± 0%    44.2MB ± 0%  -2.20%  (p=0.029 n=4+4)

    name            old allocs/op  new allocs/op  delta
    ParseVmlinux-4      721k ± 0%      718k ± 0%  -0.32%  (p=0.029 n=4+4)

Fixes #643