### PR TITLE
btf: allow users to obtain COREFixups

### DIFF
--- a/internal/btf/core_test.go
+++ b/internal/btf/core_test.go
@@ -548,7 +548,7 @@ func TestCORERelocation(t *testing.T) {
 					relos = append(relos, reloInfo.relo)
 				}
 
-				fixups, err := coreRelocate(spec, spec, relos)
+				fixups, err := CORERelocate(spec, spec, relos)
 				if want := errs[name]; want != nil {
 					if !errors.Is(err, want) {
 						t.Fatal("Expected", want, "got", err)

--- a/internal/btf/ext_info.go
+++ b/internal/btf/ext_info.go
@@ -136,7 +136,7 @@ func MarshalExtInfos(insns asm.Instructions) (funcInfos, lineInfos []byte, _ err
 	iter := insns.Iterate()
 	var fiBuf, liBuf bytes.Buffer
 	for iter.Next() {
-		if fn, ok := iter.Ins.Metadata.Get(funcInfoMeta{}).(*Func); ok {
+		if fn := FuncMetadata(iter.Ins); fn != nil {
 			fi := &funcInfo{
 				fn:     fn,
 				offset: iter.Offset,
@@ -604,6 +604,11 @@ type CORERelocation struct {
 	typ      Type
 	accessor coreAccessor
 	kind     coreKind
+}
+
+func CORERelocationMetadata(ins *asm.Instruction) *CORERelocation {
+	relo, _ := ins.Metadata.Get(coreRelocationMeta{}).(*CORERelocation)
+	return relo
 }
 
 type coreRelocationInfo struct {

--- a/internal/btf/types.go
+++ b/internal/btf/types.go
@@ -6,6 +6,8 @@ import (
 	"math"
 	"reflect"
 	"strings"
+
+	"github.com/cilium/ebpf/asm"
 )
 
 const maxTypeDepth = 32
@@ -434,6 +436,11 @@ type Func struct {
 	Name    string
 	Type    Type
 	Linkage FuncLinkage
+}
+
+func FuncMetadata(ins *asm.Instruction) *Func {
+	fn, _ := ins.Metadata.Get(funcInfoMeta{}).(*Func)
+	return fn
 }
 
 func (f *Func) Format(fs fmt.State, verb rune) {

--- a/prog.go
+++ b/prog.go
@@ -255,7 +255,7 @@ func newProgramWithOptions(spec *ProgramSpec, opts ProgramOptions, handles *hand
 
 	var btfDisabled bool
 	if spec.BTF != nil {
-		if err := btf.CORERelocate(insns, spec.BTF, targetBTF); err != nil {
+		if err := applyRelocations(insns, spec.BTF, targetBTF); err != nil {
 			return nil, fmt.Errorf("apply CO-RE relocations: %w", err)
 		}
 


### PR DESCRIPTION
It's currently not possible to obtain COREFixups since coreRelocate
is not exported. The relocation process is already opaque to users,
and this makes it worse. To fix this we export coreRelocate and move
the bit that collects CORERelocation into ebpf proper.