### PR TITLE
perf, ringbuf: add ReadBuffer mehods

### DIFF
--- a/perf/reader_test.go
+++ b/perf/reader_test.go
@@ -294,7 +294,7 @@ func TestReadRecord(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = readRecord(&buf, 0)
+	_, err = readRecord(&buf, 0, make([]byte, perfEventHeaderSize), nil)
 	if !IsUnknownEvent(err) {
 		t.Error("readRecord should return unknown event error, got", err)
 	}
@@ -401,7 +401,11 @@ func BenchmarkReader(b *testing.B) {
 
 	b.ResetTimer()
 	b.ReportAllocs()
+
+	var sampleBuf []byte
 	for i := 0; i < b.N; i++ {
+		// NB: Submitting samples into the perf event ring dominates
+		// the benchmark time unfortunately.
 		ret, _, err := prog.Test(buf)
 		if err != nil {
 			b.Fatal(err)
@@ -409,9 +413,12 @@ func BenchmarkReader(b *testing.B) {
 			b.Fatal("Expected 0 as return value, got", errno)
 		}
 
-		if _, err = rd.Read(); err != nil {
+		record, err := rd.ReadBuffer(sampleBuf)
+		if err != nil {
 			b.Fatal(err)
 		}
+
+		sampleBuf = record.RawSample
 	}
 }
 
@@ -467,4 +474,43 @@ func ExampleReader() {
 
 	// Data is padded with 0 for alignment
 	fmt.Println("Sample:", record.RawSample)
+
+	// Output: Sample: [1 2 3 4 4 0 0 0 0 0 0 0]
+}
+
+// ReadBuffer allows reducing memory allocations.
+func ExampleReader_ReadBuffer() {
+	prog, events := bpfPerfEventOutputProgram()
+	defer prog.Close()
+	defer events.Close()
+
+	rd, err := NewReader(events, 4096)
+	if err != nil {
+		panic(err)
+	}
+	defer rd.Close()
+
+	for i := 0; i < 2; i++ {
+		// Write out two samples
+		ret, _, err := prog.Test(make([]byte, 14))
+		if err != nil || ret != 0 {
+			panic("Can't write sample")
+		}
+	}
+
+	buf := make([]byte, 128)
+	for i := 0; i < 2; i++ {
+		record, err := rd.ReadBuffer(buf)
+		if err != nil {
+			panic(err)
+		}
+
+		fmt.Println("Sample:", record.RawSample[:5])
+
+		// Re-use the (possibly larger) buffer for the next call to ReadBuffer.
+		buf = record.RawSample
+	}
+
+	// Output: Sample: [1 2 3 4 4]
+	// Sample: [1 2 3 4 4]
 }

--- a/ringbuf/reader_test.go
+++ b/ringbuf/reader_test.go
@@ -224,9 +224,6 @@ func BenchmarkReader(b *testing.B) {
 		},
 	}
 
-	b.ResetTimer()
-	b.ReportAllocs()
-
 	for _, bm := range readerBenchmarks {
 		b.Run(bm.name, func(b *testing.B) {
 			prog, events := mustOutputSamplesProg(b, bm.flags, 80)
@@ -237,8 +234,13 @@ func BenchmarkReader(b *testing.B) {
 			}
 			defer rd.Close()
 
+			buf := make([]byte, 14)
+
+			b.ResetTimer()
+			b.ReportAllocs()
+
 			for i := 0; i < b.N; i++ {
-				ret, _, err := prog.Benchmark(make([]byte, 14), 1, nil)
+				ret, _, err := prog.Test(buf)
 				if err != nil {
 					b.Fatal(err)
 				} else if errno := syscall.Errno(-int32(ret)); errno != 0 {

--- a/ringbuf/reader_test.go
+++ b/ringbuf/reader_test.go
@@ -239,6 +239,7 @@ func BenchmarkReader(b *testing.B) {
 			b.ResetTimer()
 			b.ReportAllocs()
 
+			var sampleBuf []byte
 			for i := 0; i < b.N; i++ {
 				ret, _, err := prog.Test(buf)
 				if err != nil {
@@ -246,10 +247,13 @@ func BenchmarkReader(b *testing.B) {
 				} else if errno := syscall.Errno(-int32(ret)); errno != 0 {
 					b.Fatal("Expected 0 as return value, got", errno)
 				}
-				_, err = rd.Read()
+
+				record, err := rd.ReadBuffer(sampleBuf)
 				if err != nil {
 					b.Fatal("Can't read samples:", err)
 				}
+
+				sampleBuf = record.RawSample
 			}
 		})
 	}


### PR DESCRIPTION
perf: add Reader.ReadBuffer

    Allow reading from a Reader without allocations, once a steady state
    has been reached.

        name      old time/op    new time/op    delta
        Reader-4    8.98µs ± 2%    8.91µs ± 3%     ~     (p=0.686 n=4+4)

        name      old alloc/op   new alloc/op   delta
        Reader-4      424B ± 0%      288B ± 0%  -32.08%  (p=0.029 n=4+4)

        name      old allocs/op  new allocs/op  delta
        Reader-4      8.00 ± 0%      1.00 ± 0%  -87.50%  (p=0.029 n=4+4)

ringbuf: fix BenchmarkReader

    Move calls to ResetTimer and ReportAllocs and avoid allocating a
    temporary buffer.

ringbuf: add ReadBuffer method

    Add a ReadBuffer method to ringbuf.Reader, analogous to perf.Reader.

        name                                   old time/op    new time/op    delta
        Reader/normal_epoll_with_timeout_-1-4    8.58µs ± 3%    9.07µs ± 4%     ~     (p=0.057 n=4+4)

        name                                   old alloc/op   new alloc/op   delta
        Reader/normal_epoll_with_timeout_-1-4      384B ± 0%      288B ± 0%  -25.00%  (p=0.029 n=4+4)

        name                                   old allocs/op  new allocs/op  delta
        Reader/normal_epoll_with_timeout_-1-4      4.00 ± 0%      1.00 ± 0%  -75.00%  (p=0.029 n=4+4)