### PR TITLE
ringbuf: reduce allocations and syscalls

### DIFF
--- a/ringbuf/reader.go
+++ b/ringbuf/reader.go
@@ -66,7 +66,7 @@ func readRecord(rd *ringbufEventRing, rec *Record, buf []byte) error {
 		// the next sample in the ring is not committed yet so we
 		// exit without storing the reader/consumer position
 		// and start again from the same position.
-		return fmt.Errorf("%w", errBusy)
+		return errBusy
 	}
 
 	/* read up to 8 byte alignment */
@@ -81,7 +81,7 @@ func readRecord(rd *ringbufEventRing, rec *Record, buf []byte) error {
 		rd.skipRead(dataLenAligned)
 		rd.storeConsumer()
 
-		return fmt.Errorf("%w", errDiscard)
+		return errDiscard
 	}
 
 	if cap(rec.RawSample) < int(dataLenAligned) {
@@ -193,7 +193,7 @@ func (r *Reader) ReadInto(rec *Record) error {
 		}
 
 		err = readRecord(r.ring, rec, r.header)
-		if errors.Is(err, errBusy) || errors.Is(err, errDiscard) {
+		if err == errBusy || err == errDiscard {
 			continue
 		}
 

--- a/ringbuf/reader_test.go
+++ b/ringbuf/reader_test.go
@@ -167,10 +167,19 @@ func mustOutputSamplesProg(tb testing.TB, flags int32, sampleSizes ...int) (*ebp
 	return prog, events
 }
 
-func TestRingbufReaderClose(t *testing.T) {
+func TestReaderBlocking(t *testing.T) {
 	testutils.SkipOnOldKernel(t, "5.8", "BPF ring buffer")
 
-	_, events := mustOutputSamplesProg(t, 0, 5)
+	prog, events := mustOutputSamplesProg(t, 0, 5)
+	ret, _, err := prog.Test(make([]byte, 14))
+	testutils.SkipIfNotSupported(t, err)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if errno := syscall.Errno(-int32(ret)); errno != 0 {
+		t.Fatal("Expected 0 as return value, got", errno)
+	}
 
 	rd, err := NewReader(events)
 	if err != nil {
@@ -178,15 +187,23 @@ func TestRingbufReaderClose(t *testing.T) {
 	}
 	defer rd.Close()
 
-	errs := make(chan error, 1)
-	waiting := make(chan struct{})
+	errs := make(chan error)
 	go func() {
-		close(waiting)
-		_, err := rd.Read()
-		errs <- err
+		for {
+			_, err := rd.Read()
+			errs <- err
+		}
 	}()
 
-	<-waiting
+	if err := <-errs; err != nil {
+		t.Fatal("Can't read first sample", err)
+	}
+
+	select {
+	case err := <-errs:
+		t.Fatal("Read returns error instead of blocking:", err)
+	case <-time.After(100 * time.Millisecond):
+	}
 
 	// Close should interrupt blocking Read
 	if err := rd.Close(); err != nil {


### PR DESCRIPTION
ringbuf: reduce allocations on the discard and busy paths

    There is no need to wrap internal sentinel errors, since they are
    never returned to the user. Not wrapping saves us some allocations.

ringbuf: reduce the number of epoll_wait calls

    We don't have to call back into epoll_wait until we've read the
    full contents of the ring buffer. This reduces the number of syscalls
    made during busy periods.