### PR TITLE
CI: Test against kernel 5.18

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -42,7 +42,7 @@ blocks:
         - name: TMPDIR
           value: /tmp
         - name: CI_MAX_KERNEL_VERSION
-          value: "5.15"
+          value: "5.18"
       jobs:
       - name: Build and Lint
         commands:
@@ -61,10 +61,10 @@ blocks:
         commands:
           - sem-version go 1.17
           - go test -v ./cmd/bpf2go -run TestRun
-          - timeout -s KILL 600s ./run-tests.sh 5.10
+          - timeout -s KILL 600s ./run-tests.sh $CI_MAX_KERNEL_VERSION
       - name: Run unit tests
         matrix:
           - env_var: KERNEL_VERSION
-            values: ["5.15", "5.10", "5.4", "4.19", "4.14", "4.9"]
+            values: ["5.18", "5.15", "5.10", "5.4", "4.19", "4.14", "4.9"]
         commands:
           - timeout -s KILL 600s ./run-tests.sh $KERNEL_VERSION

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ have questions regarding the library.
 
 ## Packages
 
-This library includes the following packages: 
+This library includes the following packages:
 
 * [asm](https://pkg.go.dev/github.com/cilium/ebpf/asm) contains a basic
   assembler, allowing you to write eBPF assembly instructions directly
@@ -38,7 +38,7 @@ This library includes the following packages:
 * [cmd/bpf2go](https://pkg.go.dev/github.com/cilium/ebpf/cmd/bpf2go) allows
   compiling and embedding eBPF programs written in C within Go code. As well as
   compiling the C code, it auto-generates Go code for loading and manipulating
-  the eBPF program and map objects. 
+  the eBPF program and map objects.
 * [link](https://pkg.go.dev/github.com/cilium/ebpf/link) allows attaching eBPF
   to various hooks
 * [perf](https://pkg.go.dev/github.com/cilium/ebpf/perf) allows reading from a

--- a/elf_reader_test.go
+++ b/elf_reader_test.go
@@ -692,6 +692,9 @@ func TestLibBPFCompat(t *testing.T) {
 		case "bloom_filter_map.o", "bloom_filter_map.linked3.o",
 			"bloom_filter_bench.o", "bloom_filter_bench.linked3.o":
 			t.Skip("Skipping due to missing MapExtra field in MapSpec")
+		case "btf_type_tag.o", "btf_type_tag.linked3.o", "test_btf_decl_tag.o",
+			"test_btf_decl_tag.linked3.o":
+			t.Skip("Skipping due to missing support for BTF_KIND_TYPE_TAG and BTF_KIND_DECL_TAG")
 		}
 
 		t.Parallel()

--- a/elf_reader_test.go
+++ b/elf_reader_test.go
@@ -689,6 +689,9 @@ func TestLibBPFCompat(t *testing.T) {
 			t.Skip("Skipping since .text contains 'subprog' twice")
 		case "linked_maps.linked3.o", "linked_funcs.linked3.o":
 			t.Skip("Skipping since weak relocations are not supported")
+		case "bloom_filter_map.o", "bloom_filter_map.linked3.o",
+			"bloom_filter_bench.o", "bloom_filter_bench.linked3.o":
+			t.Skip("Skipping due to missing MapExtra field in MapSpec")
 		}
 
 		t.Parallel()

--- a/elf_reader_test.go
+++ b/elf_reader_test.go
@@ -695,6 +695,8 @@ func TestLibBPFCompat(t *testing.T) {
 		case "btf_type_tag.o", "btf_type_tag.linked3.o", "test_btf_decl_tag.o",
 			"test_btf_decl_tag.linked3.o":
 			t.Skip("Skipping due to missing support for BTF_KIND_TYPE_TAG and BTF_KIND_DECL_TAG")
+		case "netif_receive_skb.linked3.o":
+			t.Skip("Skipping due to possible bug in upstream CO-RE generation")
 		}
 
 		t.Parallel()


### PR DESCRIPTION
After https://github.com/cilium/ci-kernels/pull/24, now test the library against kernel 5.17.

@lmb @joamaki There's one remaining failing selftest:

```
--- FAIL: TestLibBPFCompat (0.01s)
    --- FAIL: TestLibBPFCompat/netif_receive_skb.linked3.o (0.01s)
        elf_reader_test.go:665: Error during loading: program trace_netif_receive_skb: apply CO-RE relocations: apply fixup target_type_id=67->16253: invalid immediate 73, expected 67 (fixup: target_type_id=67->16253)
```

Could this be a bug on our side? Nothing was changed to `netif_receive_skb.c` in over a year, so not sure why this broke now.

fyi @rgo3 

---

- [ ] Enable commented helper tests from https://github.com/cilium/ebpf/pull/375.