### PR TITLE
Export `LoadKernelSpecUncached` function to load kernel spec

### DIFF
--- a/btf/btf.go
+++ b/btf/btf.go
@@ -273,14 +273,14 @@ func LoadKernelSpec() (*Spec, error) {
 	}
 
 	var err error
-	kernelBTF.Spec, err = loadKernelSpec()
+	kernelBTF.Spec, err = LoadKernelSpecUncached()
 	return kernelBTF.Spec, err
 }
 
-// loadKernelSpec attempts to load the raw vmlinux BTF blob at
+// LoadKernelSpecUncached attempts to load the raw vmlinux BTF blob at
 // /sys/kernel/btf/vmlinux and falls back to scanning the file system
 // for vmlinux ELFs.
-func loadKernelSpec() (*Spec, error) {
+func LoadKernelSpecUncached() (*Spec, error) {
 	fh, err := os.Open("/sys/kernel/btf/vmlinux")
 	if err == nil {
 		defer fh.Close()

--- a/btf/btf_test.go
+++ b/btf/btf_test.go
@@ -182,7 +182,7 @@ func BenchmarkParseVmlinux(b *testing.B) {
 }
 
 func TestParseCurrentKernelBTF(t *testing.T) {
-	spec, err := loadKernelSpec()
+	spec, err := LoadKernelSpecUncached()
 	testutils.SkipIfNotSupported(t, err)
 	if err != nil {
 		t.Fatal("Can't load BTF:", err)


### PR DESCRIPTION
With https://github.com/cilium/ebpf/pull/665 being merged, we can expect users that would use `cilium/ebpf` only for the BTF parsing/exploration facilities. For some of them the cache used by `LoadKernelSpec` might not be desirable, for example if they only want to load the BTF at one point of time and be done with it.

This PR exports the inner function that load the kernel spec.

As a side note: I'm not a huge fan of the name `LoadKernelSpecUncached` but I can't find a better one. Happy to update this PR with another name if desired (maybe `LoadKernelSpecRaw` or `LoadKernelSpecWithoutCache` ?)