### PR TITLE
features: add HaveMapFlag API

### DIFF
--- a/features/map.go
+++ b/features/map.go
@@ -13,6 +13,7 @@ import (
 
 func init() {
 	mc.mapTypes = make(map[ebpf.MapType]error)
+	mc.mapFlags = make(map[uint32]error)
 }
 
 var (
@@ -22,6 +23,7 @@ var (
 type mapCache struct {
 	sync.Mutex
 	mapTypes map[ebpf.MapType]error
+	mapFlags map[uint32]error
 }
 
 func createMapTypeAttr(mt ebpf.MapType) *sys.MapCreateAttr {
@@ -120,29 +122,8 @@ func haveMapType(mt ebpf.MapType) error {
 		fd.Close()
 	}
 
-	switch {
-	// For nested and storage map types we accept EBADF as indicator that these maps are supported
-	case errors.Is(err, unix.EBADF):
-		if isMapOfMaps(mt) || isStorageMap(mt) {
-			err = nil
-		}
-
-	// ENOTSUPP means the map type is at least known to the kernel.
-	case errors.Is(err, sys.ENOTSUPP):
-		if mt == ebpf.StructOpsMap {
-			err = nil
-		}
-
-	// EINVAL occurs when attempting to create a map with an unknown type.
-	// E2BIG occurs when MapCreateAttr contains non-zero bytes past the end
-	// of the struct known by the running kernel, meaning the kernel is too old
-	// to support the given map type.
-	case errors.Is(err, unix.EINVAL), errors.Is(err, unix.E2BIG):
-		err = ebpf.ErrNotSupported
-	}
-
+	err = convertProbeError(mt, err)
 	mc.mapTypes[mt] = err
-
 	return err
 }
 
@@ -159,6 +140,84 @@ func isStorageMap(mt ebpf.MapType) bool {
 	case ebpf.SkStorage, ebpf.InodeStorage, ebpf.TaskStorage:
 		return true
 	}
-
 	return false
+}
+
+// HaveMapFlag probes the running kernel for the availability of the specified map flag.
+//
+// See the package documentation for the meaning of the error return value.
+func HaveMapFlag(flag uint32) (err error) {
+	defer func() {
+		// This closure modifies a named return variable.
+		err = wrapProbeErrors(err)
+	}()
+
+	return haveMapFlag(flag)
+}
+
+func haveMapFlag(flag uint32) error {
+	mc.Lock()
+	defer mc.Unlock()
+	err, ok := mc.mapFlags[flag]
+	if ok {
+		return err
+	}
+
+	attr, err := createMapFlagTypeAttr(flag)
+	if err != nil {
+		return err
+	}
+
+	fd, err := sys.MapCreate(attr)
+	if err == nil {
+		fd.Close()
+	}
+
+	err = convertProbeError(ebpf.MapType(attr.MapType), err)
+	mc.mapFlags[flag] = err
+	return err
+}
+
+func createMapFlagTypeAttr(flag uint32) (*sys.MapCreateAttr, error) {
+	a := &sys.MapCreateAttr{
+		KeySize:    4,
+		ValueSize:  4,
+		MaxEntries: 1,
+		MapFlags:   flag,
+	}
+
+	switch flag {
+	case unix.BPF_F_MMAPABLE, unix.BPF_F_INNER_MAP, unix.BPF_F_RDONLY_PROG, unix.BPF_F_WRONLY_PROG:
+		a.MapType = sys.MapType(ebpf.Array)
+		return a, nil
+	case unix.BPF_F_NO_PREALLOC:
+		a.MapType = sys.MapType(ebpf.Hash)
+		return a, nil
+	}
+
+	return nil, ebpf.ErrNotSupported
+}
+
+func convertProbeError(mt ebpf.MapType, err error) error {
+	switch {
+	// For nested and storage map types we accept EBADF as indicator that these maps are supported
+	case errors.Is(err, unix.EBADF):
+		if isMapOfMaps(mt) || isStorageMap(mt) {
+			return nil
+		}
+
+	// ENOTSUPP means the map type is at least known to the kernel.
+	case errors.Is(err, sys.ENOTSUPP):
+		if mt == ebpf.StructOpsMap {
+			return nil
+		}
+
+	// EINVAL occurs when attempting to create a map with an unknown type.
+	// E2BIG occurs when MapCreateAttr contains non-zero bytes past the end
+	// of the struct known by the running kernel, meaning the kernel is too old
+	// to support the given map type.
+	case errors.Is(err, unix.EINVAL), errors.Is(err, unix.E2BIG):
+		return ebpf.ErrNotSupported
+	}
+	return err
 }

--- a/features/map.go
+++ b/features/map.go
@@ -122,8 +122,29 @@ func haveMapType(mt ebpf.MapType) error {
 		fd.Close()
 	}
 
-	err = convertProbeError(mt, err)
+	switch {
+	// For nested and storage map types we accept EBADF as indicator that these maps are supported
+	case errors.Is(err, unix.EBADF):
+		if isMapOfMaps(mt) || isStorageMap(mt) {
+			err = nil
+		}
+
+	// ENOTSUPP means the map type is at least known to the kernel.
+	case errors.Is(err, sys.ENOTSUPP):
+		if mt == ebpf.StructOpsMap {
+			err = nil
+		}
+
+	// EINVAL occurs when attempting to create a map with an unknown type.
+	// E2BIG occurs when MapCreateAttr contains non-zero bytes past the end
+	// of the struct known by the running kernel, meaning the kernel is too old
+	// to support the given map type.
+	case errors.Is(err, unix.EINVAL), errors.Is(err, unix.E2BIG):
+		err = ebpf.ErrNotSupported
+	}
+
 	mc.mapTypes[mt] = err
+
 	return err
 }
 
@@ -173,8 +194,13 @@ func haveMapFlag(flag uint32) error {
 		fd.Close()
 	}
 
-	err = convertProbeError(ebpf.MapType(attr.MapType), err)
+	// EINVAL occurs when attempting to create a map with an unknown type or an unknown flag.
+	if errors.Is(err, unix.EINVAL) {
+		err = ebpf.ErrNotSupported
+	}
+
 	mc.mapFlags[flag] = err
+
 	return err
 }
 
@@ -196,28 +222,4 @@ func createMapFlagTypeAttr(flag uint32) (*sys.MapCreateAttr, error) {
 	}
 
 	return nil, ebpf.ErrNotSupported
-}
-
-func convertProbeError(mt ebpf.MapType, err error) error {
-	switch {
-	// For nested and storage map types we accept EBADF as indicator that these maps are supported
-	case errors.Is(err, unix.EBADF):
-		if isMapOfMaps(mt) || isStorageMap(mt) {
-			return nil
-		}
-
-	// ENOTSUPP means the map type is at least known to the kernel.
-	case errors.Is(err, sys.ENOTSUPP):
-		if mt == ebpf.StructOpsMap {
-			return nil
-		}
-
-	// EINVAL occurs when attempting to create a map with an unknown type.
-	// E2BIG occurs when MapCreateAttr contains non-zero bytes past the end
-	// of the struct known by the running kernel, meaning the kernel is too old
-	// to support the given map type.
-	case errors.Is(err, unix.EINVAL), errors.Is(err, unix.E2BIG):
-		return ebpf.ErrNotSupported
-	}
-	return err
 }

--- a/features/map.go
+++ b/features/map.go
@@ -212,6 +212,11 @@ func createMapFlagTypeAttr(flag uint32) (*sys.MapCreateAttr, error) {
 		MapFlags:   flag,
 	}
 
+	// For now, we do not check if the map type is supported because we only support
+	// probing for flags defined on arrays and hashs that are always supported.
+	// In the future, if we allow probing on flags defined on newer types, checking for map type
+	// support will be required.
+
 	switch flag {
 	case unix.BPF_F_MMAPABLE, unix.BPF_F_INNER_MAP, unix.BPF_F_RDONLY_PROG, unix.BPF_F_WRONLY_PROG:
 		a.MapType = sys.MapType(ebpf.Array)

--- a/features/map.go
+++ b/features/map.go
@@ -221,5 +221,5 @@ func createMapFlagTypeAttr(flag uint32) (*sys.MapCreateAttr, error) {
 		return a, nil
 	}
 
-	return nil, ebpf.ErrNotSupported
+	return nil, errors.New("probe not implemented")
 }

--- a/features/map_test.go
+++ b/features/map_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/internal/testutils"
+	"github.com/cilium/ebpf/internal/unix"
 )
 
 var mapTypeMinVersion = map[ebpf.MapType]string{
@@ -61,9 +62,38 @@ func TestHaveMapType(t *testing.T) {
 				t.Fatalf("Map type %s isn't supported even though kernel is at least %s: %v", mt.String(), minVersion, err)
 			}
 		})
+	}
+}
 
+type haveMapFlagsTestEntry struct {
+	flags            uint32
+	minKernelVersion string
+	description      string
+}
+
+func TestHaveMapFlag(t *testing.T) {
+	mapFlagTestEntries := []haveMapFlagsTestEntry{
+		{unix.BPF_F_RDONLY_PROG, "5.2", "read_only_array_map"},
+		{unix.BPF_F_WRONLY_PROG, "5.2", "write_only_array_map"},
+		{unix.BPF_F_MMAPABLE, "5.5", "mmapable_array_map"},
+		{unix.BPF_F_INNER_MAP, "5.10", "inner_map_array_map"},
+		{unix.BPF_F_NO_PREALLOC, "4.6", "no_prealloc_hash_map"},
 	}
 
+	for _, entry := range mapFlagTestEntries {
+		t.Run(entry.description, func(t *testing.T) {
+			err := HaveMapFlag(entry.flags)
+			if testutils.IsKernelLessThan(t, entry.minKernelVersion) {
+				if err == nil {
+					t.Fatalf("Map flag %d is supported on this kernel even though kernel is less than %s", entry.flags, entry.minKernelVersion)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("Map flag %d isn't supported even though kernel is at least %s: %v", entry.flags, entry.minKernelVersion, err)
+				}
+			}
+		})
+	}
 }
 
 func TestHaveMapTypeUnsupported(t *testing.T) {

--- a/internal/testutils/feature.go
+++ b/internal/testutils/feature.go
@@ -65,6 +65,14 @@ func checkKernelVersion(tb testing.TB, ufe *internal.UnsupportedFeatureError) {
 func SkipOnOldKernel(tb testing.TB, minVersion, feature string) {
 	tb.Helper()
 
+	if IsKernelLessThan(tb, minVersion) {
+		tb.Skipf("Test requires at least kernel %s (due to missing %s)", minVersion, feature)
+	}
+}
+
+func IsKernelLessThan(tb testing.TB, minVersion string) bool {
+	tb.Helper()
+
 	minv, err := internal.NewVersion(minVersion)
 	if err != nil {
 		tb.Fatalf("Invalid version %s: %s", minVersion, err)
@@ -81,7 +89,5 @@ func SkipOnOldKernel(tb testing.TB, minVersion, feature string) {
 		}
 	}
 
-	if MustKernelVersion().Less(minv) {
-		tb.Skipf("Test requires at least kernel %s (due to missing %s)", minv, feature)
-	}
+	return MustKernelVersion().Less(minv)
 }

--- a/internal/unix/types_other.go
+++ b/internal/unix/types_other.go
@@ -27,14 +27,14 @@ const (
 	EACCES = syscall.Errno(0)
 	EILSEQ = syscall.Errno(0)
 
-	BPF_F_NO_PREALLOC        = 0
+	BPF_F_NO_PREALLOC        = 1 << 0
 	BPF_F_NUMA_NODE          = 0
 	BPF_F_RDONLY             = 0
 	BPF_F_WRONLY             = 0
-	BPF_F_RDONLY_PROG        = 0
-	BPF_F_WRONLY_PROG        = 0
+	BPF_F_RDONLY_PROG        = 1 << 7
+	BPF_F_WRONLY_PROG        = 1 << 8
 	BPF_F_SLEEPABLE          = 0
-	BPF_F_MMAPABLE           = 0
+	BPF_F_MMAPABLE           = 1 << 10
 	BPF_F_INNER_MAP          = 0
 	BPF_OBJ_NAME_LEN         = 0x10
 	BPF_TAG_SIZE             = 0x8


### PR DESCRIPTION
`HaveMapFlag(flag uint32) error` would allow a user to probe running kernel for support for map flags.
The main target of this would be to probe for availability of mmapable array maps.

This PR could also be replaced by just exporting https://github.com/cilium/ebpf/blob/314c7732ecc76e7587edf487d1048fbc165983e3/syscalls.go#L91