### PR TITLE
btf: report correct method in TestTypeByName fatal message

### DIFF
--- a/btf/btf_test.go
+++ b/btf/btf_test.go
@@ -112,7 +112,7 @@ func TestTypeByName(t *testing.T) {
 		t.Run(fmt.Sprintf("%T", typ), func(t *testing.T) {
 			// spec.TypeByName MUST fail if typ is a nil btf.Type.
 			if err := spec.TypeByName("iphdr", typ); err == nil {
-				t.Fatalf("FindType does not fail with type %T", typ)
+				t.Fatalf("TypeByName does not fail with type %T", typ)
 			}
 		})
 	}


### PR DESCRIPTION
FindType was renamed to TypeByName in commit 9b2180471cfe ("btf: rename
FindType to TypeByName, add AnyTypesByName and TypeByID methods").
Adjust the fatal message in TestTypeByName accordingly.