### PR TITLE
btf: don't cache kernel BTF in LoadKernelSpec

### DIFF
--- a/btf/btf_test.go
+++ b/btf/btf_test.go
@@ -182,7 +182,7 @@ func BenchmarkParseVmlinux(b *testing.B) {
 }
 
 func TestParseCurrentKernelBTF(t *testing.T) {
-	spec, err := loadKernelSpec()
+	spec, err := LoadKernelSpec()
 	testutils.SkipIfNotSupported(t, err)
 	if err != nil {
 		t.Fatal("Can't load BTF:", err)

--- a/prog.go
+++ b/prog.go
@@ -801,17 +801,12 @@ func findTargetInKernel(spec *btf.Spec, name string, progType ProgramType, attac
 		return 0, errUnrecognizedAttachType
 	}
 
-	var (
-		target btf.Type
-		err    error
-	)
-	if spec == nil {
-		spec, err = btf.LoadKernelSpec()
-		if err != nil {
-			return 0, fmt.Errorf("load kernel spec: %w", err)
-		}
+	spec, err := maybeLoadKernelBTF(spec)
+	if err != nil {
+		return 0, fmt.Errorf("load kernel spec: %w", err)
 	}
 
+	var target btf.Type
 	if isBTFTypeFunc {
 		var targetFunc *btf.Func
 		err = spec.TypeByName(typeName, &targetFunc)


### PR DESCRIPTION
Some users of package btf might not want cache a parsed vmlinux to
avoid paying the memory cost associated with it, but this isn't possible
at the moment. Move the caching of vmlinux BTF into package ebpf.