### PR TITLE
btf: Add getter for Spec.namedTypes

### DIFF
--- a/btf/btf.go
+++ b/btf/btf.go
@@ -655,6 +655,11 @@ func (s *Spec) TypeByName(name string, typ interface{}) error {
 	return nil
 }
 
+// GetNamedTypes returns a reference to named types.
+func (s *Spec) GetNamedTypes() map[essentialName][]Type {
+	return s.namedTypes
+}
+
 // Handle is a reference to BTF loaded into the kernel.
 type Handle struct {
 	spec *Spec


### PR DESCRIPTION
This commit adds the `(*Spec).GetNamedTypes()` getter.

One consumer of such an API is "pwru" \[1\] which needs to iterate over
all types of a given spec.

\[1\]: https://github.com/cilium/pwru

---

I didn't bother making the `essentialName` type public, as my consumer doesn't need to access the returned map by a key (it iterates over it with the `range` operator).