### PR TITLE
btf: Add spec types iterator

### DIFF
--- a/btf/btf.go
+++ b/btf/btf.go
@@ -655,6 +655,31 @@ func (s *Spec) TypeByName(name string, typ interface{}) error {
 	return nil
 }
 
+// TypesIterator iterates over types of a given spec.
+type TypesIterator struct {
+	spec *Spec
+	// The index of the last visited type in the spec.
+	Index int
+	// The last visited type in the spec.
+	Type Type
+}
+
+// NewTypesIterator returns the types iterator.
+func (s *Spec) NewTypesIterator() *TypesIterator {
+	return &TypesIterator{spec: s, Index: 0}
+}
+
+// Next returns true as longs as there are any remaining types.
+func (iter *TypesIterator) Next() bool {
+	if len(iter.spec.types) <= iter.Index {
+		return false
+	}
+
+	iter.Type = iter.spec.types[iter.Index]
+	iter.Index++
+	return true
+}
+
 // Handle is a reference to BTF loaded into the kernel.
 type Handle struct {
 	spec *Spec

--- a/btf/btf_test.go
+++ b/btf/btf_test.go
@@ -342,3 +342,38 @@ func ExampleSpec_TypeByName() {
 	// We've found struct foo
 	fmt.Println(foo.Name)
 }
+
+func TestTypesIterator(t *testing.T) {
+	spec, err := LoadSpecFromReader(readVMLinux(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(spec.types) < 1 {
+		t.Fatal("Not enough types")
+	}
+
+	// Assertion that 'iphdr' type exists within the spec
+	_, err = spec.AnyTypeByName("iphdr")
+	if err != nil {
+		t.Fatalf("Failed to find 'iphdr' type by name: %s", err)
+	}
+
+	found := false
+	count := 0
+
+	iter := spec.NewTypesIterator()
+	for iter.Next() {
+		if !found && iter.Type.TypeName() == "iphdr" {
+			found = true
+		}
+		count += 1
+	}
+
+	if l := len(spec.types); l != count {
+		t.Fatalf("Failed to iterate over all types (%d vs %d)", l, count)
+	}
+	if !found {
+		t.Fatal("Cannot find 'iphdr' type")
+	}
+}


### PR DESCRIPTION
This commit introduces the `TypesIterator` which is used to iterate over all types of a given spec.

One notable user is "pwru" \[1\] which needs to iterate over all vmlinux BTF types to find functions which accept SKB as a param.

The iterator is very similar to the existing `InstructionIterator`, as both export the `Next()` method and set the values and indices in the public fields.

\[1\]: https://github.com/cilium/pwru