### PR TITLE
program: remove references from ProgramSpec

### DIFF
--- a/asm/instruction.go
+++ b/asm/instruction.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"sort"
 	"strings"
 
 	"github.com/cilium/ebpf/internal/sys"
@@ -568,9 +569,8 @@ func (insns Instructions) SymbolOffsets() (map[string]int, error) {
 
 // FunctionReferences returns a set of symbol names these Instructions make
 // bpf-to-bpf calls to.
-func (insns Instructions) FunctionReferences() map[string]bool {
-	calls := make(map[string]bool)
-
+func (insns Instructions) FunctionReferences() []string {
+	calls := make(map[string]struct{})
 	for _, ins := range insns {
 		if ins.Constant != -1 {
 			// BPF-to-BPF calls have -1 constants.
@@ -585,10 +585,16 @@ func (insns Instructions) FunctionReferences() map[string]bool {
 			continue
 		}
 
-		calls[ins.Reference()] = true
+		calls[ins.Reference()] = struct{}{}
 	}
 
-	return calls
+	result := make([]string, 0, len(calls))
+	for call := range calls {
+		result = append(result, call)
+	}
+
+	sort.Strings(result)
+	return result
 }
 
 // ReferenceOffsets returns the set of references and their offset in

--- a/elf_reader.go
+++ b/elf_reader.go
@@ -283,6 +283,7 @@ func (ec *elfCode) loadProgramSections() (map[string]*ProgramSpec, error) {
 	progs := make(map[string]*ProgramSpec)
 
 	// Generate a ProgramSpec for each function found in each program section.
+	var export []string
 	for _, sec := range ec.sections {
 		if sec.kind != programSection {
 			continue
@@ -319,13 +320,14 @@ func (ec *elfCode) loadProgramSections() (map[string]*ProgramSpec, error) {
 				return nil, fmt.Errorf("duplicate program name %s", name)
 			}
 			progs[name] = spec
+
+			if spec.SectionName != ".text" {
+				export = append(export, name)
+			}
 		}
 	}
 
-	// Populate each prog's references with pointers to all of its callees.
-	if err := populateReferences(progs); err != nil {
-		return nil, fmt.Errorf("populating references: %w", err)
-	}
+	linkPrograms(progs, export)
 
 	// Hide programs (e.g. library functions) that were not explicitly emitted
 	// to an ELF section. These could be exposed in a separate CollectionSpec

--- a/linker.go
+++ b/linker.go
@@ -51,68 +51,9 @@ func splitSymbols(insns asm.Instructions) (map[string]asm.Instructions, error) {
 // Each function is denoted by an ELF symbol and the compiler takes care of
 // register setup before each jump instruction.
 
-// populateReferences populates all of progs' Instructions and references
-// with their full dependency chains including transient dependencies.
-func populateReferences(progs map[string]*ProgramSpec) error {
-	type props struct {
-		insns asm.Instructions
-		refs  map[string]*ProgramSpec
-	}
-
-	out := make(map[string]props)
-
-	// Resolve and store direct references between all progs.
-	if err := findReferences(progs); err != nil {
-		return fmt.Errorf("finding references: %w", err)
-	}
-
-	// Flatten all progs' instruction streams.
-	for name, prog := range progs {
-		insns, refs := prog.flatten(nil)
-
-		prop := props{
-			insns: insns,
-			refs:  refs,
-		}
-
-		out[name] = prop
-	}
-
-	// Replace all progs' instructions and references
-	for name, props := range out {
-		progs[name].Instructions = props.insns
-		progs[name].references = props.refs
-	}
-
-	return nil
-}
-
-// findReferences finds bpf-to-bpf calls between progs and populates each
-// prog's references field with its direct neighbours.
-func findReferences(progs map[string]*ProgramSpec) error {
-	// Check all ProgramSpecs in the collection against each other.
-	for _, prog := range progs {
-		prog.references = make(map[string]*ProgramSpec)
-
-		// Look up call targets in progs and store pointers to their corresponding
-		// ProgramSpecs as direct references.
-		for refname := range prog.Instructions.FunctionReferences() {
-			ref := progs[refname]
-			// Call targets are allowed to be missing from an ELF. This occurs when
-			// a program calls into a forward function declaration that is left
-			// unimplemented. This is caught at load time during fixups.
-			if ref != nil {
-				prog.references[refname] = ref
-			}
-		}
-	}
-
-	return nil
-}
-
-// hasReferences returns true if insns contains one or more bpf2bpf
+// hasFunctionReferences returns true if insns contains one or more bpf2bpf
 // function references.
-func hasReferences(insns asm.Instructions) bool {
+func hasFunctionReferences(insns asm.Instructions) bool {
 	for _, i := range insns {
 		if i.IsFunctionReference() {
 			return true
@@ -160,6 +101,68 @@ func applyRelocations(insns asm.Instructions, local, target *btf.Spec) error {
 	}
 
 	return nil
+}
+
+// linkPrograms resolves bpf-to-bpf calls for a set of programs.
+//
+// Links all programs in names by modifying their ProgramSpec in progs.
+func linkPrograms(progs map[string]*ProgramSpec, names []string) {
+	// Pre-calculate all function references.
+	refs := make(map[*ProgramSpec][]string)
+	for _, prog := range progs {
+		refs[prog] = prog.Instructions.FunctionReferences()
+	}
+
+	// Create a flattened instruction stream, but don't modify progs yet to
+	// avoid linking multiple times.
+	flattened := make([]asm.Instructions, 0, len(names))
+	for _, name := range names {
+		flattened = append(flattened, flattenInstructions(name, progs, refs))
+	}
+
+	// Finally, assign the flattened instructions.
+	for i, name := range names {
+		progs[name].Instructions = flattened[i]
+	}
+}
+
+// flattenInstructions resolves bpf-to-bpf calls for a single program.
+//
+// Flattens the instructions of prog by concatenating the instructions of all
+// direct and indirect dependencies.
+//
+// progs contains all referenceable programs, while refs contain the direct
+// dependencies of each program.
+func flattenInstructions(name string, progs map[string]*ProgramSpec, refs map[*ProgramSpec][]string) asm.Instructions {
+	prog := progs[name]
+
+	pending := make([]string, len(refs[prog]))
+	copy(pending, refs[prog])
+
+	insns := make(asm.Instructions, len(prog.Instructions))
+	copy(insns, prog.Instructions)
+
+	linked := make(map[string]bool)
+	for len(pending) > 0 {
+		var ref string
+		ref, pending = pending[0], pending[1:]
+
+		if linked[ref] {
+			continue
+		}
+
+		progRef := progs[ref]
+		if progRef == nil {
+			// TODO: Is this legitimate?
+			continue
+		}
+
+		insns = append(insns, progRef.Instructions...)
+		pending = append(pending, refs[progRef]...)
+		linked[ref] = true
+	}
+
+	return insns
 }
 
 // fixupAndValidate is called by the ELF reader right before marshaling the

--- a/linker_test.go
+++ b/linker_test.go
@@ -38,9 +38,7 @@ func TestFindReferences(t *testing.T) {
 		},
 	}
 
-	if err := populateReferences(progs); err != nil {
-		t.Fatal(err)
-	}
+	linkPrograms(progs, []string{"entrypoint"})
 
 	prog, err := NewProgram(progs["entrypoint"])
 	testutils.SkipIfNotSupported(t, err)

--- a/prog_test.go
+++ b/prog_test.go
@@ -15,7 +15,6 @@ import (
 	"time"
 
 	qt "github.com/frankban/quicktest"
-	"github.com/google/go-cmp/cmp"
 
 	"github.com/cilium/ebpf/asm"
 	"github.com/cilium/ebpf/btf"
@@ -88,40 +87,6 @@ func TestProgramRun(t *testing.T) {
 
 	if !bytes.Equal(out[:len(pat)], pat) {
 		t.Errorf("Expected %v, got %v", pat, out)
-	}
-}
-
-func TestProgramSpecFlattenOrder(t *testing.T) {
-	prog_a := ProgramSpec{Name: "prog_a"}
-	prog_b := ProgramSpec{Name: "prog_b"}
-	prog_c := ProgramSpec{
-		Name: "prog_c",
-		references: map[string]*ProgramSpec{
-			"prog_a": &prog_a,
-			"prog_b": &prog_b,
-		},
-	}
-
-	spec := ProgramSpec{
-		references: map[string]*ProgramSpec{
-			// Depend on prog_a since it's a mutual dependency of prog_c.
-			"prog_a": &prog_a,
-			// Omit prog_b to ensure indirect dependencies get pulled in.
-			"prog_c": &prog_c,
-		},
-	}
-
-	// Run the flatten operation twice to make sure both yield the same output.
-	ins1, refs1 := spec.flatten(nil)
-	ins2, refs2 := spec.flatten(nil)
-
-	opts := cmp.AllowUnexported(spec)
-	if diff := cmp.Diff(ins1, ins2, opts); diff != "" {
-		t.Fatal(diff)
-	}
-
-	if diff := cmp.Diff(refs1, refs2, opts); diff != "" {
-		t.Fatal(diff)
 	}
 }
 


### PR DESCRIPTION
Now that we don't need ProgramSpec.layout anymore to reconstruct
CO-RE relocations we can remove ProgramSpec.references. At the
same time we can simplify the linking logic.