### PR TITLE
Add `RelativeOffset` field to `UprobeOptions` struct

### DIFF
--- a/link/link_test.go
+++ b/link/link_test.go
@@ -197,6 +197,8 @@ func mustLoadProgram(tb testing.TB, typ ebpf.ProgramType, attachType ebpf.Attach
 		License:    license,
 		Instructions: asm.Instructions{
 			asm.Mov.Imm(asm.R0, 0),
+			asm.Mov.Imm(asm.R1, 1),
+			asm.Mov.Imm(asm.R2, 2),
 			asm.Return(),
 		},
 	})

--- a/link/link_test.go
+++ b/link/link_test.go
@@ -197,8 +197,6 @@ func mustLoadProgram(tb testing.TB, typ ebpf.ProgramType, attachType ebpf.Attach
 		License:    license,
 		Instructions: asm.Instructions{
 			asm.Mov.Imm(asm.R0, 0),
-			asm.Mov.Imm(asm.R1, 1),
-			asm.Mov.Imm(asm.R2, 2),
 			asm.Return(),
 		},
 	})

--- a/link/uprobe.go
+++ b/link/uprobe.go
@@ -49,7 +49,7 @@ type Executable struct {
 // UprobeOptions defines additional parameters that will be used
 // when loading Uprobes.
 type UprobeOptions struct {
-	// Symbol offset (absolute). Must be provided in case of external symbols (shared libs).
+	// Symbol offset. Must be provided in case of external symbols (shared libs).
 	// If set, overrides the offset eventually parsed from the executable.
 	Offset uint64
 	// The offset relative to given symbol. Useful when tracing an arbitrary point

--- a/link/uprobe.go
+++ b/link/uprobe.go
@@ -262,11 +262,12 @@ func (ex *Executable) uprobe(symbol string, prog *ebpf.Program, opts *UprobeOpti
 
 	offset := opts.Offset
 	if offset == 0 {
+		offset = opts.RelativeOffset
 		off, err := ex.offset(symbol)
 		if err != nil {
 			return nil, err
 		}
-		offset = off
+		offset += off
 	}
 
 	pid := opts.PID
@@ -283,7 +284,7 @@ func (ex *Executable) uprobe(symbol string, prog *ebpf.Program, opts *UprobeOpti
 	args := probeArgs{
 		symbol:       symbol,
 		path:         ex.path,
-		offset:       offset + opts.RelativeOffset,
+		offset:       offset,
 		pid:          pid,
 		refCtrOffset: opts.RefCtrOffset,
 		ret:          ret,

--- a/link/uprobe.go
+++ b/link/uprobe.go
@@ -262,12 +262,11 @@ func (ex *Executable) uprobe(symbol string, prog *ebpf.Program, opts *UprobeOpti
 
 	offset := opts.Offset
 	if offset == 0 {
-		offset = opts.RelativeOffset
 		off, err := ex.offset(symbol)
 		if err != nil {
 			return nil, err
 		}
-		offset += off
+		offset = off
 	}
 
 	pid := opts.PID
@@ -284,7 +283,7 @@ func (ex *Executable) uprobe(symbol string, prog *ebpf.Program, opts *UprobeOpti
 	args := probeArgs{
 		symbol:       symbol,
 		path:         ex.path,
-		offset:       offset,
+		offset:       offset + opts.RelativeOffset,
 		pid:          pid,
 		refCtrOffset: opts.RefCtrOffset,
 		ret:          ret,

--- a/link/uprobe_test.go
+++ b/link/uprobe_test.go
@@ -69,28 +69,11 @@ func TestUprobeExtWithOpts(t *testing.T) {
 
 	// This Uprobe is broken and will not work because the offset is not
 	// correct. This is expected since the offset is provided by the user.
-	up1, err := bashEx.Uprobe("open", prog, &UprobeOptions{Offset: 0x1})
+	up, err := bashEx.Uprobe("open", prog, &UprobeOptions{Offset: 0x1})
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer up1.Close()
-
-	// Set RelativeOffset field. Can't verify the offset calculated inside uprobe
-	// but ProgramSpec in mustLoadProgram has enough number of instructions.
-	up2, err := bashEx.Uprobe("open", prog, &UprobeOptions{RelativeOffset: 0x2})
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer up2.Close()
-
-	// Set Offset and RelativeOffsets fields together.
-	// Can't verify the offset calculated inside uprobe
-	// but ProgramSpec in mustLoadProgram has enough number of instructions.
-	up3, err := bashEx.Uprobe("open", prog, &UprobeOptions{Offset: 0x1, RelativeOffset: 0x2})
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer up3.Close()
+	defer up.Close()
 }
 
 func TestUprobeWithPID(t *testing.T) {

--- a/link/uprobe_test.go
+++ b/link/uprobe_test.go
@@ -42,6 +42,42 @@ func TestExecutable(t *testing.T) {
 	}
 }
 
+func TestOffsetWithOpts(t *testing.T) {
+	c := qt.New(t)
+
+	_ = mustLoadProgram(t, ebpf.Kprobe, 0, "")
+
+	offset, err := bashEx.offsetWithOpts(bashSym, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.Assert(offset, qt.Equals, uint64(0x2ebd0))
+
+	offset, err = bashEx.offsetWithOpts(bashSym, &UprobeOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.Assert(offset, qt.Equals, uint64(0x2ebd0))
+
+	offset, err = bashEx.offsetWithOpts(bashSym, &UprobeOptions{Offset: 0x1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.Assert(offset, qt.Equals, uint64(0x1))
+
+	offset, err = bashEx.offsetWithOpts(bashSym, &UprobeOptions{RelativeOffset: 0x2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.Assert(offset, qt.Equals, uint64(0x2ebd2))
+
+	offset, err = bashEx.offsetWithOpts(bashSym, &UprobeOptions{Offset: 0x1, RelativeOffset: 0x2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.Assert(offset, qt.Equals, uint64(0x1))
+}
+
 func TestUprobe(t *testing.T) {
 	c := qt.New(t)
 

--- a/link/uprobe_test.go
+++ b/link/uprobe_test.go
@@ -47,17 +47,22 @@ func TestOffsetWithOpts(t *testing.T) {
 
 	_ = mustLoadProgram(t, ebpf.Kprobe, 0, "")
 
+	symbolOffset, err := bashEx.offset(bashSym)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	offset, err := bashEx.offsetWithOpts(bashSym, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	c.Assert(offset, qt.Equals, uint64(0x2ebd0))
+	c.Assert(offset, qt.Equals, uint64(symbolOffset))
 
 	offset, err = bashEx.offsetWithOpts(bashSym, &UprobeOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
-	c.Assert(offset, qt.Equals, uint64(0x2ebd0))
+	c.Assert(offset, qt.Equals, uint64(symbolOffset))
 
 	offset, err = bashEx.offsetWithOpts(bashSym, &UprobeOptions{Offset: 0x1})
 	if err != nil {
@@ -69,7 +74,7 @@ func TestOffsetWithOpts(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	c.Assert(offset, qt.Equals, uint64(0x2ebd2))
+	c.Assert(offset, qt.Equals, uint64(symbolOffset+0x2))
 
 	offset, err = bashEx.offsetWithOpts(bashSym, &UprobeOptions{Offset: 0x1, RelativeOffset: 0x2})
 	if err != nil {

--- a/link/uprobe_test.go
+++ b/link/uprobe_test.go
@@ -31,56 +31,42 @@ func TestExecutable(t *testing.T) {
 		t.Fatalf("create executable: unexpected path '%s'", bashEx.path)
 	}
 
-	_, err = bashEx.offset(bashSym)
+	_, err = bashEx.offset(bashSym, &UprobeOptions{})
 	if err != nil {
 		t.Fatalf("find offset: %v", err)
 	}
 
-	_, err = bashEx.offset("bogus")
+	_, err = bashEx.offset("bogus", &UprobeOptions{})
 	if err == nil {
 		t.Fatal("find symbol: expected error")
 	}
 }
 
-func TestOffsetWithOpts(t *testing.T) {
+func TestExecutableOffset(t *testing.T) {
 	c := qt.New(t)
 
-	_ = mustLoadProgram(t, ebpf.Kprobe, 0, "")
-
-	symbolOffset, err := bashEx.offset(bashSym)
+	symbolOffset, err := bashEx.offset(bashSym, &UprobeOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	offset, err := bashEx.offsetWithOpts(bashSym, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	c.Assert(offset, qt.Equals, uint64(symbolOffset))
-
-	offset, err = bashEx.offsetWithOpts(bashSym, &UprobeOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	c.Assert(offset, qt.Equals, uint64(symbolOffset))
-
-	offset, err = bashEx.offsetWithOpts(bashSym, &UprobeOptions{Offset: 0x1})
+	offset, err := bashEx.offset(bashSym, &UprobeOptions{Offset: 0x1})
 	if err != nil {
 		t.Fatal(err)
 	}
 	c.Assert(offset, qt.Equals, uint64(0x1))
 
-	offset, err = bashEx.offsetWithOpts(bashSym, &UprobeOptions{RelativeOffset: 0x2})
+	offset, err = bashEx.offset(bashSym, &UprobeOptions{RelativeOffset: 0x2})
 	if err != nil {
 		t.Fatal(err)
 	}
-	c.Assert(offset, qt.Equals, uint64(symbolOffset+0x2))
+	c.Assert(offset, qt.Equals, symbolOffset+0x2)
 
-	offset, err = bashEx.offsetWithOpts(bashSym, &UprobeOptions{Offset: 0x1, RelativeOffset: 0x2})
+	offset, err = bashEx.offset(bashSym, &UprobeOptions{Offset: 0x1, RelativeOffset: 0x2})
 	if err != nil {
 		t.Fatal(err)
 	}
-	c.Assert(offset, qt.Equals, uint64(0x1))
+	c.Assert(offset, qt.Equals, uint64(0x1+0x2))
 }
 
 func TestUprobe(t *testing.T) {
@@ -157,7 +143,7 @@ func TestUprobeCreatePMU(t *testing.T) {
 	c := qt.New(t)
 
 	// Fetch the offset from the /bin/bash Executable already defined.
-	off, err := bashEx.offset(bashSym)
+	off, err := bashEx.offset(bashSym, &UprobeOptions{})
 	c.Assert(err, qt.IsNil)
 
 	// Prepare probe args.
@@ -189,7 +175,7 @@ func TestUprobePMUUnavailable(t *testing.T) {
 	c := qt.New(t)
 
 	// Fetch the offset from the /bin/bash Executable already defined.
-	off, err := bashEx.offset(bashSym)
+	off, err := bashEx.offset(bashSym, &UprobeOptions{})
 	c.Assert(err, qt.IsNil)
 
 	// Prepare probe args.
@@ -215,7 +201,7 @@ func TestUprobeTraceFS(t *testing.T) {
 	c := qt.New(t)
 
 	// Fetch the offset from the /bin/bash Executable already defined.
-	off, err := bashEx.offset(bashSym)
+	off, err := bashEx.offset(bashSym, &UprobeOptions{})
 	c.Assert(err, qt.IsNil)
 
 	// Prepare probe args.
@@ -264,7 +250,7 @@ func TestUprobeCreateTraceFS(t *testing.T) {
 	c := qt.New(t)
 
 	// Fetch the offset from the /bin/bash Executable already defined.
-	off, err := bashEx.offset(bashSym)
+	off, err := bashEx.offset(bashSym, &UprobeOptions{})
 	c.Assert(err, qt.IsNil)
 
 	// Sanitize the symbol in order to be used in tracefs API.

--- a/link/uprobe_test.go
+++ b/link/uprobe_test.go
@@ -69,11 +69,28 @@ func TestUprobeExtWithOpts(t *testing.T) {
 
 	// This Uprobe is broken and will not work because the offset is not
 	// correct. This is expected since the offset is provided by the user.
-	up, err := bashEx.Uprobe("open", prog, &UprobeOptions{Offset: 0x1})
+	up1, err := bashEx.Uprobe("open", prog, &UprobeOptions{Offset: 0x1})
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer up.Close()
+	defer up1.Close()
+
+	// Set RelativeOffset field. Can't verify the offset calculated inside uprobe
+	// but ProgramSpec in mustLoadProgram has enough number of instructions.
+	up2, err := bashEx.Uprobe("open", prog, &UprobeOptions{RelativeOffset: 0x2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer up2.Close()
+
+	// Set Offset and RelativeOffsets fields together.
+	// Can't verify the offset calculated inside uprobe
+	// but ProgramSpec in mustLoadProgram has enough number of instructions.
+	up3, err := bashEx.Uprobe("open", prog, &UprobeOptions{Offset: 0x1, RelativeOffset: 0x2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer up3.Close()
 }
 
 func TestUprobeWithPID(t *testing.T) {


### PR DESCRIPTION
Alternative to https://github.com/cilium/ebpf/pull/683

This PR, for a [bpftrace](https://github.com/iovisor/bpftrace) program like below:

```
#!/usr/bin/env bpftrace

uprobe:./main:"main.probeMe"+42
{
    printf("rax: %d\n", reg("ax"));
}
```

enables probing without the need of recalculating the offset of `main.probeMe` (which is already calculated and stored inside [`offsets` field](https://github.com/cilium/ebpf/blob/951bb28908d23e50fca063a2d51098ca028352bf/link/uprobe.go#L46)), adding `0x2a` and setting `Offset` field to the resulting value:

```go
up, err := ex.Uprobe("main.probeMe", objs.ExampleUprobe, &link.UprobeOptions{RelativeOffset: 0x2a})
if err != nil {
	log.Fatalf("creating uprobe: %s", err)
}
defer up.Close()
```

The PR also improves some of the comments because it's hard to understand at first glance that with the block below, the `Offset` field nullifies the offset that's calculated from the given symbol and the `Offset` is actually an **absolute offset** instead of a relative one:

https://github.com/cilium/ebpf/blob/951bb28908d23e50fca063a2d51098ca028352bf/link/uprobe.go#L255-L262