### PR TITLE
Export the `Offset` method of `Executable`

### DIFF
--- a/link/uprobe.go
+++ b/link/uprobe.go
@@ -157,7 +157,7 @@ func (ex *Executable) load(f *internal.SafeELFFile) error {
 	return nil
 }
 
-func (ex *Executable) offset(symbol string) (uint64, error) {
+func (ex *Executable) Offset(symbol string) (uint64, error) {
 	if off, ok := ex.offsets[symbol]; ok {
 		// Symbols with location 0 from section undef are shared library calls and
 		// are relocated before the binary is executed. Dynamic linking is not
@@ -254,7 +254,7 @@ func (ex *Executable) uprobe(symbol string, prog *ebpf.Program, opts *UprobeOpti
 
 	offset := opts.Offset
 	if offset == 0 {
-		off, err := ex.offset(symbol)
+		off, err := ex.Offset(symbol)
 		if err != nil {
 			return nil, err
 		}

--- a/link/uprobe_test.go
+++ b/link/uprobe_test.go
@@ -31,12 +31,12 @@ func TestExecutable(t *testing.T) {
 		t.Fatalf("create executable: unexpected path '%s'", bashEx.path)
 	}
 
-	_, err = bashEx.offset(bashSym)
+	_, err = bashEx.Offset(bashSym)
 	if err != nil {
 		t.Fatalf("find offset: %v", err)
 	}
 
-	_, err = bashEx.offset("bogus")
+	_, err = bashEx.Offset("bogus")
 	if err == nil {
 		t.Fatal("find symbol: expected error")
 	}
@@ -116,7 +116,7 @@ func TestUprobeCreatePMU(t *testing.T) {
 	c := qt.New(t)
 
 	// Fetch the offset from the /bin/bash Executable already defined.
-	off, err := bashEx.offset(bashSym)
+	off, err := bashEx.Offset(bashSym)
 	c.Assert(err, qt.IsNil)
 
 	// Prepare probe args.
@@ -148,7 +148,7 @@ func TestUprobePMUUnavailable(t *testing.T) {
 	c := qt.New(t)
 
 	// Fetch the offset from the /bin/bash Executable already defined.
-	off, err := bashEx.offset(bashSym)
+	off, err := bashEx.Offset(bashSym)
 	c.Assert(err, qt.IsNil)
 
 	// Prepare probe args.
@@ -174,7 +174,7 @@ func TestUprobeTraceFS(t *testing.T) {
 	c := qt.New(t)
 
 	// Fetch the offset from the /bin/bash Executable already defined.
-	off, err := bashEx.offset(bashSym)
+	off, err := bashEx.Offset(bashSym)
 	c.Assert(err, qt.IsNil)
 
 	// Prepare probe args.
@@ -223,7 +223,7 @@ func TestUprobeCreateTraceFS(t *testing.T) {
 	c := qt.New(t)
 
 	// Fetch the offset from the /bin/bash Executable already defined.
-	off, err := bashEx.offset(bashSym)
+	off, err := bashEx.Offset(bashSym)
 	c.Assert(err, qt.IsNil)
 
 	// Sanitize the symbol in order to be used in tracefs API.


### PR DESCRIPTION
Alternative to https://github.com/cilium/ebpf/pull/682

This PR, for a [bpftrace](https://github.com/iovisor/bpftrace) program like below:

```
#!/usr/bin/env bpftrace

uprobe:./main:"main.probeMe"+42
{
    printf("rax: %d\n", reg("ax"));
}
```

enables probing without the need of recalculating the offset of `main.probeMe` (which is already calculated and stored inside [`offsets` field](https://github.com/cilium/ebpf/blob/951bb28908d23e50fca063a2d51098ca028352bf/link/uprobe.go#L46)):

```go
symbol := "main.probeMe"
offset, err := ex.Offset(readSymbol)
if err != nil {
	log.Fatalf("error getting offset: %s", err)
}
offset += 0x2a
up, err := ex.Uprobe(symbol, objs.ExampleUprobe, &link.UprobeOptions{Offset: offset})
if err != nil {
	log.Fatalf("creating uprobe: %s", err)
}
defer up.Close()
```