### PR TITLE
Remove deprecated API deprecated in v0.8.0

### DIFF
--- a/link/cgroup.go
+++ b/link/cgroup.go
@@ -56,18 +56,6 @@ func AttachCgroup(opts CgroupOptions) (Link, error) {
 	return cg, nil
 }
 
-// LoadPinnedCgroup loads a pinned cgroup from a bpffs.
-//
-// Deprecated: use LoadPinnedLink instead.
-func LoadPinnedCgroup(fileName string, opts *ebpf.LoadPinOptions) (Link, error) {
-	link, err := LoadPinnedRawLink(fileName, CgroupType, opts)
-	if err != nil {
-		return nil, err
-	}
-
-	return &linkCgroup{*link}, nil
-}
-
 type progAttachCgroup struct {
 	cgroup     *os.File
 	current    *ebpf.Program

--- a/link/iter.go
+++ b/link/iter.go
@@ -58,18 +58,6 @@ func AttachIter(opts IterOptions) (*Iter, error) {
 	return &Iter{RawLink{fd, ""}}, err
 }
 
-// LoadPinnedIter loads a pinned iterator from a bpffs.
-//
-// Deprecated: use LoadPinnedLink instead.
-func LoadPinnedIter(fileName string, opts *ebpf.LoadPinOptions) (*Iter, error) {
-	link, err := LoadPinnedRawLink(fileName, IterType, opts)
-	if err != nil {
-		return nil, err
-	}
-
-	return &Iter{*link}, err
-}
-
 // Iter represents an attached bpf_iter.
 type Iter struct {
 	RawLink

--- a/link/link.go
+++ b/link/link.go
@@ -107,11 +107,6 @@ type Info struct {
 	extra   interface{}
 }
 
-// RawLinkInfo contains information on a raw link.
-//
-// Deprecated: use Info instead.
-type RawLinkInfo = Info
-
 type TracingInfo sys.TracingLinkInfo
 type CgroupInfo sys.CgroupLinkInfo
 type NetNsInfo sys.NetNsLinkInfo

--- a/link/link.go
+++ b/link/link.go
@@ -188,36 +188,6 @@ func AttachRawLink(opts RawLinkOptions) (*RawLink, error) {
 	return &RawLink{fd, ""}, nil
 }
 
-// LoadPinnedRawLink loads a persisted link from a bpffs.
-//
-// Returns an error if the pinned link type doesn't match linkType. Pass
-// UnspecifiedType to disable this behaviour.
-//
-// Deprecated: use LoadPinnedLink instead.
-func LoadPinnedRawLink(fileName string, linkType Type, opts *ebpf.LoadPinOptions) (*RawLink, error) {
-	link, err := loadPinnedRawLink(fileName, opts)
-	if err != nil {
-		return nil, err
-	}
-
-	if linkType == UnspecifiedType {
-		return link, nil
-	}
-
-	info, err := link.Info()
-	if err != nil {
-		link.Close()
-		return nil, fmt.Errorf("get pinned link info: %w", err)
-	}
-
-	if info.Type != linkType {
-		link.Close()
-		return nil, fmt.Errorf("link type %v doesn't match %v", info.Type, linkType)
-	}
-
-	return link, nil
-}
-
 func loadPinnedRawLink(fileName string, opts *ebpf.LoadPinOptions) (*RawLink, error) {
 	fd, err := sys.ObjGet(&sys.ObjGetAttr{
 		Pathname:  sys.NewStringPointer(fileName),

--- a/link/netns.go
+++ b/link/netns.go
@@ -34,15 +34,3 @@ func AttachNetNs(ns int, prog *ebpf.Program) (*NetNsLink, error) {
 
 	return &NetNsLink{*link}, nil
 }
-
-// LoadPinnedNetNs loads a network namespace link from bpffs.
-//
-// Deprecated: use LoadPinnedLink instead.
-func LoadPinnedNetNs(fileName string, opts *ebpf.LoadPinOptions) (*NetNsLink, error) {
-	link, err := LoadPinnedRawLink(fileName, NetNsType, opts)
-	if err != nil {
-		return nil, err
-	}
-
-	return &NetNsLink{*link}, nil
-}

--- a/link/tracing.go
+++ b/link/tracing.go
@@ -80,18 +80,6 @@ func AttachFreplace(targetProg *ebpf.Program, name string, prog *ebpf.Program) (
 	return &tracing{*link}, nil
 }
 
-// LoadPinnedFreplace loads a pinned iterator from a bpffs.
-//
-// Deprecated: use LoadPinnedLink instead.
-func LoadPinnedFreplace(fileName string, opts *ebpf.LoadPinOptions) (Link, error) {
-	link, err := LoadPinnedRawLink(fileName, TracingType, opts)
-	if err != nil {
-		return nil, err
-	}
-
-	return &tracing{*link}, err
-}
-
 type TracingOptions struct {
 	// Program must be of type Tracing with attach type
 	// AttachTraceFEntry/AttachTraceFExit/AttachModifyReturn or

--- a/map.go
+++ b/map.go
@@ -1418,14 +1418,3 @@ func NewMapFromID(id MapID) (*Map, error) {
 
 	return newMapFromFD(fd)
 }
-
-// ID returns the systemwide unique ID of the map.
-//
-// Deprecated: use MapInfo.ID() instead.
-func (m *Map) ID() (MapID, error) {
-	var info sys.MapInfo
-	if err := sys.ObjInfo(m.fd, &info); err != nil {
-		return MapID(0), err
-	}
-	return MapID(info.Id), nil
-}

--- a/map_test.go
+++ b/map_test.go
@@ -1635,7 +1635,7 @@ func TestMapGetNextID(t *testing.T) {
 	for {
 		last := next
 		if next, err = MapGetNextID(last); err != nil {
-			if !errors.Is(err, ErrNotExist) {
+			if !errors.Is(err, os.ErrNotExist) {
 				t.Fatal("Expected ErrNotExist, got:", err)
 			}
 			break
@@ -1665,7 +1665,7 @@ func TestNewMapFromID(t *testing.T) {
 
 	// As there can be multiple maps, we use max(uint32) as MapID to trigger an expected error.
 	_, err = NewMapFromID(MapID(math.MaxUint32))
-	if !errors.Is(err, ErrNotExist) {
+	if !errors.Is(err, os.ErrNotExist) {
 		t.Fatal("Expected ErrNotExist, got:", err)
 	}
 }

--- a/map_test.go
+++ b/map_test.go
@@ -1647,21 +1647,24 @@ func TestMapGetNextID(t *testing.T) {
 }
 
 func TestNewMapFromID(t *testing.T) {
-	testutils.SkipOnOldKernel(t, "4.13", "bpf_map_get_fd_by_id")
-
 	hash := createHash()
 	defer hash.Close()
-	var next MapID
-	var err error
 
-	next, err = hash.ID()
+	info, err := hash.Info()
 	if err != nil {
-		t.Fatal("Could not get ID of map:", err)
+		t.Fatal("Couldn't get map info:", err)
 	}
 
-	if _, err = NewMapFromID(next); err != nil {
-		t.Fatalf("Can't get map for ID %d: %v", uint32(next), err)
+	id, ok := info.ID()
+	if !ok {
+		t.Skip("Map ID not supported")
 	}
+
+	hash2, err := NewMapFromID(id)
+	if err != nil {
+		t.Fatalf("Can't get map for ID %d: %v", id, err)
+	}
+	hash2.Close()
 
 	// As there can be multiple maps, we use max(uint32) as MapID to trigger an expected error.
 	_, err = NewMapFromID(MapID(math.MaxUint32))

--- a/prog.go
+++ b/prog.go
@@ -650,45 +650,6 @@ func marshalProgram(p *Program, length int) ([]byte, error) {
 	return buf, nil
 }
 
-// Attach a Program.
-//
-// Deprecated: use link.RawAttachProgram instead.
-func (p *Program) Attach(fd int, typ AttachType, flags AttachFlags) error {
-	if fd < 0 {
-		return errors.New("invalid fd")
-	}
-
-	attr := sys.ProgAttachAttr{
-		TargetFd:    uint32(fd),
-		AttachBpfFd: p.fd.Uint(),
-		AttachType:  uint32(typ),
-		AttachFlags: uint32(flags),
-	}
-
-	return sys.ProgAttach(&attr)
-}
-
-// Detach a Program.
-//
-// Deprecated: use link.RawDetachProgram instead.
-func (p *Program) Detach(fd int, typ AttachType, flags AttachFlags) error {
-	if fd < 0 {
-		return errors.New("invalid fd")
-	}
-
-	if flags != 0 {
-		return errors.New("flags must be zero")
-	}
-
-	attr := sys.ProgAttachAttr{
-		TargetFd:    uint32(fd),
-		AttachBpfFd: p.fd.Uint(),
-		AttachType:  uint32(typ),
-	}
-
-	return sys.ProgAttach(&attr)
-}
-
 // LoadPinnedProgram loads a Program from a BPF file.
 //
 // Requires at least Linux 4.11.

--- a/prog.go
+++ b/prog.go
@@ -734,17 +734,6 @@ func ProgramGetNextID(startID ProgramID) (ProgramID, error) {
 	return ProgramID(attr.NextId), sys.ProgGetNextId(attr)
 }
 
-// ID returns the systemwide unique ID of the program.
-//
-// Deprecated: use ProgramInfo.ID() instead.
-func (p *Program) ID() (ProgramID, error) {
-	var info sys.ProgInfo
-	if err := sys.ObjInfo(p.fd, &info); err != nil {
-		return ProgramID(0), err
-	}
-	return ProgramID(info.Id), nil
-}
-
 // BindMap binds map to the program and is only released once program is released.
 //
 // This may be used in cases where metadata should be associated with the program

--- a/prog_test.go
+++ b/prog_test.go
@@ -491,7 +491,7 @@ func TestProgramGetNextID(t *testing.T) {
 	last := ProgramID(0)
 	for {
 		next, err := ProgramGetNextID(last)
-		if errors.Is(err, ErrNotExist) {
+		if errors.Is(err, os.ErrNotExist) {
 			if last == 0 {
 				t.Fatal("Got ErrNotExist on the first iteration")
 			}
@@ -525,7 +525,7 @@ func TestNewProgramFromID(t *testing.T) {
 
 	// As there can be multiple programs, we use max(uint32) as ProgramID to trigger an expected error.
 	_, err = NewProgramFromID(ProgramID(math.MaxUint32))
-	if !errors.Is(err, ErrNotExist) {
+	if !errors.Is(err, os.ErrNotExist) {
 		t.Fatal("Expected ErrNotExist, got:", err)
 	}
 }

--- a/prog_test.go
+++ b/prog_test.go
@@ -508,20 +508,23 @@ func TestProgramGetNextID(t *testing.T) {
 }
 
 func TestNewProgramFromID(t *testing.T) {
-	testutils.SkipOnOldKernel(t, "4.13", "bpf_prog_get_fd_by_id")
-
 	prog := mustSocketFilter(t)
 
-	var next ProgramID
-
-	next, err := prog.ID()
+	info, err := prog.Info()
 	if err != nil {
-		t.Fatal("Could not get ID of program:", err)
+		t.Fatal("Could not get program info:", err)
 	}
 
-	if _, err = NewProgramFromID(next); err != nil {
-		t.Fatalf("Can't get FD for program ID %d: %v", uint32(next), err)
+	id, ok := info.ID()
+	if !ok {
+		t.Skip("Program ID not supported")
 	}
+
+	prog2, err := NewProgramFromID(id)
+	if err != nil {
+		t.Fatalf("Can't get FD for program ID %d: %v", id, err)
+	}
+	prog2.Close()
 
 	// As there can be multiple programs, we use max(uint32) as ProgramID to trigger an expected error.
 	_, err = NewProgramFromID(ProgramID(math.MaxUint32))

--- a/syscalls.go
+++ b/syscalls.go
@@ -4,18 +4,12 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"os"
 
 	"github.com/cilium/ebpf/asm"
 	"github.com/cilium/ebpf/internal"
 	"github.com/cilium/ebpf/internal/sys"
 	"github.com/cilium/ebpf/internal/unix"
 )
-
-// ErrNotExist is returned when loading a non-existing map or program.
-//
-// Deprecated: use os.ErrNotExist instead.
-var ErrNotExist = os.ErrNotExist
 
 // invalidBPFObjNameChar returns true if char may not appear in
 // a BPF object name.


### PR DESCRIPTION
Remove API that was marked deprecated when we tagged v0.8.0. Generated by checking out the tag and then running:

```
$ rg -F '// Deprecated: '
syscalls.go
17:// Deprecated: use os.ErrNotExist instead.

prog.go
707:// Deprecated: use link.RawAttachProgram instead.
725:// Deprecated: use link.RawDetachProgram instead.
791:// Deprecated: use ProgramInfo.ID() instead.

link/netns.go
40:// Deprecated: use LoadPinnedLink instead.

link/cgroup.go
61:// Deprecated: use LoadPinnedLink instead.

link/iter.go
63:// Deprecated: use LoadPinnedLink instead.

link/tracing.go
82:// Deprecated: use LoadPinnedLink instead.

map.go
1440:// Deprecated: use MapInfo.ID() instead.

link/link.go
112:// Deprecated: use Info instead.
196:// Deprecated: use LoadPinnedLink instead.
```