### PR TITLE
prog: Allow empty data for prog.Test and prog.Run

### DIFF
--- a/internal/sys/types.go
+++ b/internal/sys/types.go
@@ -538,6 +538,21 @@ type ProgInfo struct {
 	_                    [4]byte
 }
 
+type SkLookup struct {
+	Cookie         uint64
+	Family         uint32
+	Protocol       uint32
+	RemoteIp4      [4]uint8
+	RemoteIp6      [16]uint8
+	RemotePort     uint16
+	_              [2]byte
+	LocalIp4       [4]uint8
+	LocalIp6       [16]uint8
+	LocalPort      uint32
+	IngressIfindex uint32
+	_              [4]byte
+}
+
 type XdpMd struct {
 	Data           uint32
 	DataEnd        uint32

--- a/prog.go
+++ b/prog.go
@@ -488,7 +488,10 @@ func (p *Program) Test(in []byte) (uint32, []byte, error) {
 	// size will be. Hence we allocate an output buffer which we hope will always be large
 	// enough, and panic if the kernel wrote past the end of the allocation.
 	// See https://patchwork.ozlabs.org/cover/1006822/
-	out := make([]byte, len(in)+outputPad)
+	var out []byte
+	if len(in) > 0 {
+		out = make([]byte, len(in)+outputPad)
+	}
 
 	opts := RunOptions{
 		Data:    in,
@@ -589,10 +592,6 @@ var haveProgTestRun = internal.FeatureTest("BPF_PROG_TEST_RUN", "4.12", func() e
 })
 
 func (p *Program) testRun(opts *RunOptions) (uint32, time.Duration, error) {
-	if len(opts.Data) == 0 {
-		return 0, 0, fmt.Errorf("missing input")
-	}
-
 	if uint(len(opts.Data)) > math.MaxUint32 {
 		return 0, 0, fmt.Errorf("input is too long")
 	}

--- a/prog_test.go
+++ b/prog_test.go
@@ -136,6 +136,43 @@ func TestProgramRunWithOptions(t *testing.T) {
 	}
 }
 
+func TestProgramRunEmptyData(t *testing.T) {
+	testutils.SkipOnOldKernel(t, "5.13", "sk_lookup BPF_PROG_RUN")
+
+	ins := asm.Instructions{
+		// Return SK_DROP
+		asm.LoadImm(asm.R0, 0, asm.DWord),
+		asm.Return(),
+	}
+
+	prog, err := NewProgram(&ProgramSpec{
+		Name:         "test",
+		Type:         SkLookup,
+		AttachType:   AttachSkLookup,
+		Instructions: ins,
+		License:      "MIT",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer prog.Close()
+
+	opts := RunOptions{
+		Context: sys.SkLookup{
+			Family: syscall.AF_INET,
+		},
+	}
+	ret, err := prog.Run(&opts)
+	testutils.SkipIfNotSupported(t, err)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if ret != 0 {
+		t.Error("Expected return value to be 0, got", ret)
+	}
+}
+
 func TestProgramBenchmark(t *testing.T) {
 	prog := mustSocketFilter(t)
 


### PR DESCRIPTION
Certain prog types (SK_LOOKUP, RAW_TRACEPOINT and
RAW_TRACEPOINT_WRITABLE) require that data_in is NULL. The previous
check prevented 0 length data_in.

Fix by removing check.

Followup from #647.