### PR TITLE
btf: add Array.Index

### DIFF
--- a/btf/core_test.go
+++ b/btf/core_test.go
@@ -27,8 +27,8 @@ func TestCOREAreTypesCompatible(t *testing.T) {
 		{&Int{Name: "a", Size: 2}, &Int{Name: "b", Size: 4}, true},
 		{&Pointer{Target: &Void{}}, &Pointer{Target: &Void{}}, true},
 		{&Pointer{Target: &Void{}}, &Void{}, false},
-		{&Array{Type: &Void{}}, &Array{Type: &Void{}}, true},
-		{&Array{Type: &Int{}}, &Array{Type: &Void{}}, false},
+		{&Array{Index: &Void{}, Type: &Void{}}, &Array{Index: &Void{}, Type: &Void{}}, true},
+		{&Array{Index: &Void{}, Type: &Int{}}, &Array{Index: &Void{}, Type: &Void{}}, false},
 		{&FuncProto{Return: &Int{}}, &FuncProto{Return: &Void{}}, false},
 		{
 			&FuncProto{Return: &Void{}, Params: []FuncParam{{Name: "a", Type: &Void{}}}},


### PR DESCRIPTION
The kernel refuses to load an array type without an index type, so probably
btf.rst is outdated.