### PR TITLE
map: suggest incorrect MaxEntries on EINVAL

### DIFF
--- a/map.go
+++ b/map.go
@@ -456,6 +456,9 @@ func (spec *MapSpec) createMap(inner *sys.FD, opts MapOptions, handles *handleCa
 		if !spec.hasBTF() {
 			return nil, fmt.Errorf("map create without BTF: %w", err)
 		}
+		if errors.Is(err, unix.EINVAL) && attr.MaxEntries == 0 {
+			return nil, fmt.Errorf("map create: %w (MaxEntries may be incorrectly set to zero)", err)
+		}
 		return nil, fmt.Errorf("map create: %w", err)
 	}
 	defer closeOnError(fd)


### PR DESCRIPTION
If a map creation fails and the max entries provided by the spec is
zero, it's likely that it's because of that zero value.
Help the user by suggesting that MaxEntries may be incorrectly set to
zero.

Signed-off-by: Mark Pashmfouroush <mark@isovalent.com>