### PR TITLE
run-tests: fix shebang to find bash more reliably

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Test the current package under a different kernel.
 # Requires virtme and qemu to be installed.
 # Examples:
@@ -61,7 +61,7 @@ if [[ "${1:-}" = "--exec-vm" ]]; then
     if [[ -e "${output}/status" ]]; then
       break
     fi
-    
+
     if [[ -v CI ]]; then
       echo "Retrying test run due to qemu crash"
       continue


### PR DESCRIPTION
Not all systems have bash located at /bin/bash.
A better way to run bash with shebang is with:
`#!/usr/bin/env bash`

Signed-off-by: Mark Pashmfouroush <mark@isovalent.com>