### PR TITLE
Revert ".semaphore - workaround to update ca-certificates before apt-get update"

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -24,7 +24,6 @@ blocks:
         commands:
           - sudo sh -c 'swapoff -a && fallocate -l 2G /swapfile && chmod 0600 /swapfile && mkswap /swapfile && swapon /swapfile'
           - checkout
-          - curl -sSfL http://security.ubuntu.com/ubuntu/pool/main/c/ca-certificates/ca-certificates_20210119~20.04.2_all.deb -o /tmp/ca-certificates.deb && sudo dpkg -i /tmp/ca-certificates.deb
           - sudo mkdir -p /usr/local/golang/1.18 && curl -fL "https://go.dev/dl/go1.18.linux-amd64.tar.gz" | sudo tar -xz -C /usr/local/golang/1.18
           - sem-version go 1.18
           - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.45.0


### PR DESCRIPTION
This reverts commit 41f3f37fcc9c78455921445e7cb9e2cc3ac80afa.

We're now able to run apt-get without manually pulling CA certificates, and the
package we're trying to install has been removed.