### PR TITLE
btf: simplify loadRawSpec

### DIFF
--- a/btf/btf_test.go
+++ b/btf/btf_test.go
@@ -175,7 +175,7 @@ func BenchmarkParseVmlinux(b *testing.B) {
 			b.Fatal(err)
 		}
 
-		if _, err := loadRawSpec(rd, binary.LittleEndian, nil, nil); err != nil {
+		if _, err := loadRawSpec(rd, binary.LittleEndian); err != nil {
 			b.Fatal("Can't load BTF:", err)
 		}
 	}

--- a/btf/fuzz_test.go
+++ b/btf/fuzz_test.go
@@ -29,7 +29,7 @@ func FuzzSpec(f *testing.F) {
 			t.Skip("data is too short")
 		}
 
-		spec, err := loadRawSpec(bytes.NewReader(data), internal.NativeEndian, nil, nil)
+		spec, err := loadRawSpec(bytes.NewReader(data), internal.NativeEndian)
 		if err != nil {
 			if spec != nil {
 				t.Fatal("spec is not nil")

--- a/btf/info.go
+++ b/btf/info.go
@@ -37,7 +37,7 @@ func newInfoFromFd(fd *sys.FD) (*info, error) {
 		return nil, err
 	}
 
-	spec, err := loadRawSpec(bytes.NewReader(btfBuffer), internal.NativeEndian, nil, nil)
+	spec, err := loadRawSpec(bytes.NewReader(btfBuffer), internal.NativeEndian)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
We currently call fixupDatasec from within loadRawSpec, but only
the call site in loadSpecFromELF actually requires the call to be
present. Move the call into loadSpecFromELF, which allows dropping
two arguments from loadRawSpec.