### PR TITLE
CI: load bpf_testmod in VM

### DIFF
--- a/btf/handle_test.go
+++ b/btf/handle_test.go
@@ -3,33 +3,13 @@ package btf_test
 import (
 	"testing"
 
-	"github.com/cilium/ebpf"
-	"github.com/cilium/ebpf/asm"
 	"github.com/cilium/ebpf/btf"
 	"github.com/cilium/ebpf/internal/testutils"
 )
 
-func init() {
-	// We need to call into the verifier at least once to ensure that
-	// vmlinux BTF has been loaded for TestNewHandleFromID.
-	// If there is a call to BPF_BTF_LOAD before BPF_PROG_LOAD then the BTF_LOAD
-	// gets ID 1, and vmlinux ID 2.
-	// Invoke BPF_PROG_LOAD in init() to guarantee that vmlinux has ID 1.
-	prog, err := ebpf.NewProgram(&ebpf.ProgramSpec{
-		Type:    ebpf.SocketFilter,
-		License: "MIT",
-		Instructions: asm.Instructions{
-			asm.Mov.Imm(asm.R0, 0),
-			asm.Return(),
-		},
-	})
-	if err != nil {
-		panic(err)
-	}
-	prog.Close()
-}
-
 func TestNewHandleFromID(t *testing.T) {
+	// vmlinux is not guaranteed to be at ID 1, but it's highly likely, since
+	// module loading causes vmlinux to be parsed.
 	const vmlinux = btf.ID(1)
 
 	// See https://github.com/torvalds/linux/commit/5329722057d41aebc31e391907a501feaa42f7d9

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -83,6 +83,10 @@ elif [[ "${1:-}" = "--exec-test" ]]; then
     export KERNEL_SELFTESTS="/run/input/bpf"
   fi
 
+  if [[ -f "/run/input/bpf/bpf_testmod/bpf_testmod.ko" ]]; then
+    insmod "/run/input/bpf/bpf_testmod/bpf_testmod.ko"
+  fi
+
   dmesg --clear
   rc=0
   "$@" || rc=$?


### PR DESCRIPTION
Load the bpf_testmod into the kernel when booting the test VM. This
allows getting rid of the workaround to load vmlinux at BTF ID 1,
since loading a module also loads vmlinux BTF.

Later on we can use this to test split BTF / kmod support.

Updates #705