### PR TITLE
map: Do not chec maxEntries for PerfEventArray map

### DIFF
--- a/map.go
+++ b/map.go
@@ -170,7 +170,8 @@ func (ms *MapSpec) checkCompatibility(m *Map) error {
 	case m.valueSize != ms.ValueSize:
 		return fmt.Errorf("expected value size %v, got %v: %w", ms.ValueSize, m.valueSize, ErrMapIncompatible)
 
-	case m.maxEntries != ms.MaxEntries:
+	case !(ms.Type == PerfEventArray && ms.MaxEntries == 0) &&
+		m.maxEntries != ms.MaxEntries:
 		return fmt.Errorf("expected max entries %v, got %v: %w", ms.MaxEntries, m.maxEntries, ErrMapIncompatible)
 
 	case m.flags != ms.Flags:


### PR DESCRIPTION
When I use perf event map in MapReplacements for ebpf.CollectionOptions,
I'm getting error for maxEntries check.

The perf event map is created with maxEntries initialized to number
of cpus, so we can't check maxEntries before the map is created.

I'm not sure we can postpone the check, but we can surely skip it
for perf event map.

Signed-off-by: Jiri Olsa <jolsa@kernel.org>