### PR TITLE
collection: close all unassigned resources before returning from LoadAndAssign

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -264,14 +264,17 @@ func (cs *CollectionSpec) LoadAndAssign(to interface{}, opts *CollectionOptions)
 	if err != nil {
 		return err
 	}
-	defer loader.cleanup()
+	defer loader.close()
 
 	// Support assigning Programs and Maps, lazy-loading the required objects.
 	assignedMaps := make(map[string]bool)
+	assignedProgs := make(map[string]bool)
+
 	getValue := func(typ reflect.Type, name string) (interface{}, error) {
 		switch typ {
 
 		case reflect.TypeOf((*Program)(nil)):
+			assignedProgs[name] = true
 			return loader.loadProgram(name)
 
 		case reflect.TypeOf((*Map)(nil)):
@@ -311,7 +314,13 @@ func (cs *CollectionSpec) LoadAndAssign(to interface{}, opts *CollectionOptions)
 		}
 	}
 
-	loader.finalize()
+	// Prevent loader.cleanup() from closing assigned Maps and Programs.
+	for m := range assignedMaps {
+		delete(loader.maps, m)
+	}
+	for p := range assignedProgs {
+		delete(loader.programs, p)
+	}
 
 	return nil
 }
@@ -342,7 +351,7 @@ func NewCollectionWithOptions(spec *CollectionSpec, opts CollectionOptions) (*Co
 	if err != nil {
 		return nil, err
 	}
-	defer loader.cleanup()
+	defer loader.close()
 
 	// Create maps first, as their fds need to be linked into programs.
 	for mapName := range spec.Maps {
@@ -367,9 +376,9 @@ func NewCollectionWithOptions(spec *CollectionSpec, opts CollectionOptions) (*Co
 		return nil, err
 	}
 
+	// Prevent loader.cleanup from closing maps and programs.
 	maps, progs := loader.maps, loader.programs
-
-	loader.finalize()
+	loader.maps, loader.programs = nil, nil
 
 	return &Collection{
 		progs,
@@ -441,16 +450,8 @@ func newCollectionLoader(coll *CollectionSpec, opts *CollectionOptions) (*collec
 	}, nil
 }
 
-// finalize should be called when all the collectionLoader's resources
-// have been successfully loaded into the kernel and populated with values.
-func (cl *collectionLoader) finalize() {
-	cl.maps, cl.programs = nil, nil
-}
-
-// cleanup cleans up all resources left over in the collectionLoader.
-// Call finalize() when Map and Program creation/population is successful
-// to prevent them from getting closed.
-func (cl *collectionLoader) cleanup() {
+// close all resources left over in the collectionLoader.
+func (cl *collectionLoader) close() {
 	cl.handles.close()
 	for _, m := range cl.maps {
 		m.Close()

--- a/collection_test.go
+++ b/collection_test.go
@@ -500,6 +500,47 @@ func TestAssignValues(t *testing.T) {
 
 }
 
+func TestIncompleteLoadAndAssign(t *testing.T) {
+	spec := &CollectionSpec{
+		Programs: map[string]*ProgramSpec{
+			"valid": {
+				Type: SocketFilter,
+				Instructions: asm.Instructions{
+					asm.LoadImm(asm.R0, 0, asm.DWord),
+					asm.Return(),
+				},
+				License: "MIT",
+			},
+			"invalid": {
+				Type: SocketFilter,
+				Instructions: asm.Instructions{
+					asm.Return(),
+				},
+				License: "MIT",
+			},
+		},
+	}
+
+	s := struct {
+		// Assignment to Valid should execute and succeed.
+		Valid *Program `ebpf:"valid"`
+		// Assignment to Invalid should fail and cause Valid's fd to be closed.
+		Invalid *Program `ebpf:"invalid"`
+	}{}
+
+	if err := spec.LoadAndAssign(&s, nil); err == nil {
+		t.Fatal("expected error loading invalid ProgramSpec")
+	}
+
+	if fd := s.Valid.FD(); fd != -1 {
+		t.Fatal("expected valid prog to have closed fd -1, got:", fd)
+	}
+
+	if s.Invalid != nil {
+		t.Fatal("expected invalid prog to be nil due to never being assigned")
+	}
+}
+
 func ExampleCollectionSpec_Assign() {
 	spec := &CollectionSpec{
 		Maps: map[string]*MapSpec{


### PR DESCRIPTION
```
    collection: close all unassigned resources before returning from LoadAndAssign

    Before, loader.finalize() would nil out cl.maps and cl.progs before returning
    from LoadAndAssign, leaving the closing of fds up to the garbage collector.
    This is non-deterministic and potentially causes rlimit pressure when loading
    many objects in quick succession. In case the GC is disabled, this leaks fds.

    .rodata is one such common case that often gets lazy-loaded, but rarely
    gets assigned due to the availability of RewriteConstants. This Map's fd would
    then stick around until the Map gets collected.

    This commit replaces cl.finalize() with inline logic in LoadAndAssign and
    NewCollectionWithOptions and renames loader.cleanup() to .close().
```

Fixes: https://github.com/cilium/ebpf/issues/701

cc @alban @mauriciovasquezbernal 