### PR TITLE
Avoid leaking fds in test suite and `NewMapWithOptions()`

### DIFF
--- a/collection_test.go
+++ b/collection_test.go
@@ -106,10 +106,12 @@ func TestCollectionSpecLoadCopy(t *testing.T) {
 	if err != nil {
 		t.Fatal("Loading original spec:", err)
 	}
+	defer objs.Prog.Close()
 
 	if err := spec2.LoadAndAssign(&objs, nil); err != nil {
 		t.Fatal("Loading copied spec:", err)
 	}
+	defer objs.Prog.Close()
 }
 
 func TestCollectionSpecRewriteMaps(t *testing.T) {
@@ -309,6 +311,9 @@ func TestCollectionSpecMapReplacements_SpecMismatch(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	// Map fd is duplicated by MapReplacements, this one can be safely closed.
+	defer newMap.Close()
+
 	coll, err := NewCollectionWithOptions(cs, CollectionOptions{
 		MapReplacements: map[string]*Map{
 			"test-map": newMap,
@@ -365,6 +370,8 @@ func TestCollectionSpec_LoadAndAssign_LazyLoading(t *testing.T) {
 	if err := spec.LoadAndAssign(&objs, nil); err != nil {
 		t.Fatal("Assign loads a map or program that isn't requested in the struct:", err)
 	}
+	defer objs.Prog.Close()
+	defer objs.Map.Close()
 
 	if objs.Prog == nil {
 		t.Error("Program is nil")
@@ -572,6 +579,8 @@ func ExampleCollectionSpec_LoadAndAssign() {
 	if err := spec.LoadAndAssign(&objs, nil); err != nil {
 		panic(err)
 	}
+	defer objs.Program.Close()
+	defer objs.Map.Close()
 
 	fmt.Println(objs.Program.Type())
 	fmt.Println(objs.Map.Type())

--- a/elf_reader_test.go
+++ b/elf_reader_test.go
@@ -480,6 +480,7 @@ func TestTailCall(t *testing.T) {
 			t.Fatal(err)
 		}
 		defer obj.TailMain.Close()
+		defer obj.ProgArray.Close()
 
 		ret, _, err := obj.TailMain.Test(make([]byte, 14))
 		testutils.SkipIfNotSupported(t, err)
@@ -518,6 +519,7 @@ func TestSubprogRelocation(t *testing.T) {
 			t.Fatal(err)
 		}
 		defer obj.Main.Close()
+		defer obj.HashMap.Close()
 
 		ret, _, err := obj.Main.Test(make([]byte, 14))
 		testutils.SkipIfNotSupported(t, err)

--- a/linker_test.go
+++ b/linker_test.go
@@ -45,6 +45,7 @@ func TestFindReferences(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer prog.Close()
 
 	ret, _, err := prog.Test(make([]byte, 14))
 	if err != nil {
@@ -90,6 +91,7 @@ func TestForwardFunctionDeclaration(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		defer prog.Close()
 
 		ret, _, err := prog.Test(make([]byte, 14))
 		if err != nil {

--- a/map.go
+++ b/map.go
@@ -249,8 +249,8 @@ func NewMapWithOptions(spec *MapSpec, opts MapOptions) (*Map, error) {
 		return nil, fmt.Errorf("creating map: %w", err)
 	}
 
-	err = m.finalize(spec)
-	if err != nil {
+	if err := m.finalize(spec); err != nil {
+		m.Close()
 		return nil, fmt.Errorf("populating map: %w", err)
 	}
 
@@ -1039,7 +1039,8 @@ func (m *Map) Iterate() *MapIterator {
 	return newMapIterator(m)
 }
 
-// Close removes a Map
+// Close the Map's underlying file descriptor, which could unload the
+// Map from the kernel if it is not pinned or in use by a loaded Program.
 func (m *Map) Close() error {
 	if m == nil {
 		// This makes it easier to clean up when iterating maps

--- a/map_test.go
+++ b/map_test.go
@@ -293,6 +293,7 @@ func TestBatchMapWithLock(t *testing.T) {
 		if err != nil {
 			t.Fatal("Can't parse ELF:", err)
 		}
+		defer coll.Close()
 
 		type spinLockValue struct {
 			Cnt     uint32
@@ -353,6 +354,7 @@ func TestMapWithLock(t *testing.T) {
 		if err != nil {
 			t.Fatal("Can't parse ELF:", err)
 		}
+		defer coll.Close()
 
 		type spinLockValue struct {
 			Cnt     uint32
@@ -1240,11 +1242,11 @@ func TestIterateMapInMap(t *testing.T) {
 		m       *Map
 		entries = parent.Iterate()
 	)
-	defer m.Close()
 
 	if !entries.Next(&key, &m) {
 		t.Fatal("Iterator encountered error:", entries.Err())
 	}
+	m.Close()
 
 	if key != 1 {
 		t.Error("Iterator didn't skip first entry")

--- a/prog.go
+++ b/prog.go
@@ -442,7 +442,9 @@ func (p *Program) IsPinned() bool {
 	return p.pinnedPath != ""
 }
 
-// Close unloads the program from the kernel.
+// Close the Program's underlying file descriptor, which could unload
+// the program from the kernel if it is not pinned or attached to a
+// kernel hook.
 func (p *Program) Close() error {
 	if p == nil {
 		return nil

--- a/prog_test.go
+++ b/prog_test.go
@@ -472,6 +472,7 @@ func TestProgramMarshaling(t *testing.T) {
 	if err := arr.Lookup(idx, &prog2); err != nil {
 		t.Fatal("Can't unmarshal program:", err)
 	}
+	defer prog2.Close()
 
 	if prog2 == nil {
 		t.Fatal("Unmarshalling set program to nil")


### PR DESCRIPTION
```
Since omitting Map and Program.Close() is generally considered an error,
clean up all cases in the test suite.

These were found by adding runtime.GC() at the end of a TestMain()
in all packages in the repository.

The plan is to follow up with some instrumentation that allows the caller
to get notified when the sys.FD finalizer successfully closes a file
descriptor during a GC round.
```

```
If a Map fails to be populated or frozen during creation,
we would leak a fd for the runtime to collect. This patch ensures
the fd is closed before returning from NewMapWithOptions.
```
