### PR TITLE
Tidy up btf.Handle related APIs

### DIFF
--- a/btf/btf.go
+++ b/btf/btf.go
@@ -734,6 +734,8 @@ func NewHandle(spec *Spec) (*Handle, error) {
 
 // NewHandleFromID returns the BTF handle for a given id.
 //
+// Prefer calling [ebpf.Program.Handle] or [ebpf.Map.Handle] if possible.
+//
 // Returns ErrNotExist, if there is no BTF with the given id.
 //
 // Requires CAP_SYS_ADMIN.

--- a/btf/btf.go
+++ b/btf/btf.go
@@ -685,8 +685,7 @@ func (iter *TypesIterator) Next() bool {
 
 // Handle is a reference to BTF loaded into the kernel.
 type Handle struct {
-	spec *Spec
-	fd   *sys.FD
+	fd *sys.FD
 }
 
 // NewHandle loads BTF into the kernel.
@@ -729,7 +728,7 @@ func NewHandle(spec *Spec) (*Handle, error) {
 		return nil, internal.ErrorWithLog(err, logBuf)
 	}
 
-	return &Handle{spec.Copy(), fd}, nil
+	return &Handle{fd}, nil
 }
 
 // NewHandleFromID returns the BTF handle for a given id.
@@ -747,18 +746,17 @@ func NewHandleFromID(id ID) (*Handle, error) {
 		return nil, fmt.Errorf("get FD for ID %d: %w", id, err)
 	}
 
-	info, err := newInfoFromFd(fd)
-	if err != nil {
-		_ = fd.Close()
-		return nil, fmt.Errorf("get BTF spec for handle: %w", err)
-	}
-
-	return &Handle{info.BTF, fd}, nil
+	return &Handle{fd}, nil
 }
 
 // Spec returns the Spec that defined the BTF loaded into the kernel.
-func (h *Handle) Spec() *Spec {
-	return h.spec
+func (h *Handle) Spec() (*Spec, error) {
+	info, err := newInfoFromFd(h.fd)
+	if err != nil {
+		return nil, fmt.Errorf("get BTF spec for handle: %w", err)
+	}
+
+	return info.BTF, nil
 }
 
 // Close destroys the handle.

--- a/btf/info.go
+++ b/btf/info.go
@@ -2,6 +2,7 @@ package btf
 
 import (
 	"bytes"
+	"fmt"
 
 	"github.com/cilium/ebpf/internal"
 	"github.com/cilium/ebpf/internal/sys"
@@ -26,7 +27,7 @@ func newInfoFromFd(fd *sys.FD) (*info, error) {
 	// buffers to receive the data.
 	var btfInfo sys.BtfInfo
 	if err := sys.ObjInfo(fd, &btfInfo); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("get BTF info for fd %s: %w", fd, err)
 	}
 
 	if btfInfo.NameLen > 0 {

--- a/info.go
+++ b/info.go
@@ -177,6 +177,7 @@ func (pi *ProgramInfo) ID() (ProgramID, bool) {
 
 // BTFID returns the BTF ID associated with the program.
 //
+// The ID is only valid as long as the associated program is kept alive.
 // Available from 5.0.
 //
 // The bool return value indicates whether this optional field is available and

--- a/link/tracing.go
+++ b/link/tracing.go
@@ -41,15 +41,7 @@ func AttachFreplace(targetProg *ebpf.Program, name string, prog *ebpf.Program) (
 		typeID btf.TypeID
 	)
 	if targetProg != nil {
-		info, err := targetProg.Info()
-		if err != nil {
-			return nil, err
-		}
-		btfID, ok := info.BTFID()
-		if !ok {
-			return nil, fmt.Errorf("could not get BTF ID for program %s: %w", info.Name, errInvalidInput)
-		}
-		btfHandle, err := btf.NewHandleFromID(btfID)
+		btfHandle, err := targetProg.Handle()
 		if err != nil {
 			return nil, err
 		}

--- a/link/tracing.go
+++ b/link/tracing.go
@@ -47,13 +47,18 @@ func AttachFreplace(targetProg *ebpf.Program, name string, prog *ebpf.Program) (
 		}
 		defer btfHandle.Close()
 
+		spec, err := btfHandle.Spec()
+		if err != nil {
+			return nil, err
+		}
+
 		var function *btf.Func
-		if err := btfHandle.Spec().TypeByName(name, &function); err != nil {
+		if err := spec.TypeByName(name, &function); err != nil {
 			return nil, err
 		}
 
 		target = targetProg.FD()
-		typeID, err = btfHandle.Spec().TypeID(function)
+		typeID, err = spec.TypeID(function)
 		if err != nil {
 			return nil, err
 		}

--- a/prog.go
+++ b/prog.go
@@ -860,7 +860,10 @@ func findTargetInProgram(prog *Program, name string, progType ProgramType, attac
 	}
 	defer btfHandle.Close()
 
-	spec := btfHandle.Spec()
+	spec, err := btfHandle.Spec()
+	if err != nil {
+		return 0, err
+	}
 
 	var targetFunc *btf.Func
 	err = spec.TypeByName(typeName, &targetFunc)


### PR DESCRIPTION
btf: lazily decode types in Handle.Spec

    We currently decode BTF when calling NewHandleFromID. This can be very
    expensive for large BTF blobs like vmlinux, even though not all users
    will want to inspect decoded BTF in the first place.

    Move the decoding into Handle.Spec, which is a breaking change.

    Updates #705

program: add getter for btf.Handle

    Given a loaded program, it takes four calls to retrieve parsed BTF:

    1. Program.Info()
    2. ProgramInfo.BTFID()
    3. NewHandleFromID()
    4. btf.Handle.Spec()

    This chain of calls has a subtle requirement: the loaded program
    must be kept alive for steps 1-3, since otherwise the BTF ID might
    be deallocated or reused by the kernel. Program.Handle encapsulates
    these steps while keeping program alive.