### PR TITLE
program: add getter for btf.Handle

### DIFF
--- a/btf/btf.go
+++ b/btf/btf.go
@@ -734,6 +734,8 @@ func NewHandle(spec *Spec) (*Handle, error) {
 
 // NewHandleFromID returns the BTF handle for a given id.
 //
+// Prefer calling [ebpf.Program.Handle] or [ebpf.Map.Handle] if possible.
+//
 // Returns ErrNotExist, if there is no BTF with the given id.
 //
 // Requires CAP_SYS_ADMIN.

--- a/info.go
+++ b/info.go
@@ -177,6 +177,7 @@ func (pi *ProgramInfo) ID() (ProgramID, bool) {
 
 // BTFID returns the BTF ID associated with the program.
 //
+// The ID is only valid as long as the associated program is kept alive.
 // Available from 5.0.
 //
 // The bool return value indicates whether this optional field is available and

--- a/link/tracing.go
+++ b/link/tracing.go
@@ -41,15 +41,7 @@ func AttachFreplace(targetProg *ebpf.Program, name string, prog *ebpf.Program) (
 		typeID btf.TypeID
 	)
 	if targetProg != nil {
-		info, err := targetProg.Info()
-		if err != nil {
-			return nil, err
-		}
-		btfID, ok := info.BTFID()
-		if !ok {
-			return nil, fmt.Errorf("could not get BTF ID for program %s: %w", info.Name, errInvalidInput)
-		}
-		btfHandle, err := btf.NewHandleFromID(btfID)
+		btfHandle, err := targetProg.Handle()
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Given a loaded program, it takes four calls to retrieve parsed BTF:

1. Program.Info()
2. ProgramInfo.BTFID()
3. NewHandleFromID()
4. btf.Handle.Spec()

This chain of calls has a subtle requirement: the loaded program
must be kept alive for steps 1-3, since otherwise the BTF ID might
be deallocated or reused by the kernel. Program.Handle encapsulates
these steps while keeping program alive.