### PR TITLE
sys: add fd leak tracing instrumentation

### DIFF
--- a/collection_test.go
+++ b/collection_test.go
@@ -10,8 +10,13 @@ import (
 	"github.com/cilium/ebpf/btf"
 	"github.com/cilium/ebpf/internal"
 	"github.com/cilium/ebpf/internal/testutils"
+	"github.com/cilium/ebpf/internal/testutils/fdtrace"
 	qt "github.com/frankban/quicktest"
 )
+
+func TestMain(m *testing.M) {
+	fdtrace.TestMain(m)
+}
 
 func TestCollectionSpecNotModified(t *testing.T) {
 	cs := CollectionSpec{

--- a/collection_test.go
+++ b/collection_test.go
@@ -586,6 +586,10 @@ func TestIncompleteLoadAndAssign(t *testing.T) {
 		t.Fatal("expected error loading invalid ProgramSpec")
 	}
 
+	if s.Valid == nil {
+		t.Fatal("expected valid prog to be non-nil")
+	}
+
 	if fd := s.Valid.FD(); fd != -1 {
 		t.Fatal("expected valid prog to have closed fd -1, got:", fd)
 	}

--- a/elf_reader_test.go
+++ b/elf_reader_test.go
@@ -479,6 +479,7 @@ func TestStringSection(t *testing.T) {
 	if err != nil {
 		t.Fatalf("new collection: %s", err)
 	}
+	defer coll.Close()
 
 	prog := coll.Programs["filter"]
 	if prog == nil {

--- a/features/prog_test.go
+++ b/features/prog_test.go
@@ -10,7 +10,12 @@ import (
 	"github.com/cilium/ebpf/asm"
 	"github.com/cilium/ebpf/internal"
 	"github.com/cilium/ebpf/internal/testutils"
+	"github.com/cilium/ebpf/internal/testutils/fdtrace"
 )
+
+func TestMain(m *testing.M) {
+	fdtrace.TestMain(m)
+}
 
 func TestHaveProgramType(t *testing.T) {
 	testutils.CheckFeatureMatrix(t, haveProgramTypeMatrix)

--- a/internal/feature_test.go
+++ b/internal/feature_test.go
@@ -4,7 +4,13 @@ import (
 	"errors"
 	"strings"
 	"testing"
+
+	"github.com/cilium/ebpf/internal/testutils/fdtrace"
 )
+
+func TestMain(m *testing.M) {
+	fdtrace.TestMain(m)
+}
 
 func TestFeatureTest(t *testing.T) {
 	var called bool

--- a/internal/sys/fd_trace.go
+++ b/internal/sys/fd_trace.go
@@ -1,0 +1,78 @@
+package sys
+
+import (
+	"runtime"
+	"sync"
+)
+
+// OnLeakFD controls tracing [FD] lifetime to detect resources that are not
+// closed by Close().
+//
+// If fn is not nil, tracing is enabled for all FDs created going forward. fn is
+// invoked for all FDs that are closed by the garbage collector instead of an
+// explicit Close() by a caller. Calling OnLeakFD twice with a non-nil fn
+// (without disabling tracing in the meantime) will cause a panic.
+//
+// If fn is nil, tracing will be disabled. Any FDs that have not been closed are
+// considered to be leaked, fn will be invoked for them, and the process will be
+// terminated.
+//
+// fn will be invoked at most once for every unique sys.FD allocation since a
+// runtime.Frames can only be unwound once.
+func OnLeakFD(fn func(*runtime.Frames)) {
+	// Enable leak tracing if new fn is provided.
+	if fn != nil {
+		if onLeakFD != nil {
+			panic("OnLeakFD called twice with non-nil fn")
+		}
+
+		onLeakFD = fn
+		return
+	}
+
+	// fn is nil past this point.
+
+	if onLeakFD == nil {
+		return
+	}
+
+	// Call onLeakFD for all open fds.
+	if fs := flushFrames(); len(fs) != 0 {
+		for _, f := range fs {
+			onLeakFD(f)
+		}
+	}
+
+	onLeakFD = nil
+}
+
+var onLeakFD func(*runtime.Frames)
+
+// fds is a registry of all file descriptors wrapped into sys.fds that were
+// created while an fd tracer was active.
+var fds sync.Map // map[int]*runtime.Frames
+
+// flushFrames removes all elements from fds and returns them as a slice. This
+// deals with the fact that a runtime.Frames can only be unwound once using
+// Next().
+func flushFrames() []*runtime.Frames {
+	var frames []*runtime.Frames
+	fds.Range(func(key, value any) bool {
+		frames = append(frames, value.(*runtime.Frames))
+		fds.Delete(key)
+		return true
+	})
+	return frames
+}
+
+func callersFrames() *runtime.Frames {
+	c := make([]uintptr, 32)
+
+	// Skip runtime.Callers and this function.
+	i := runtime.Callers(2, c)
+	if i == 0 {
+		return nil
+	}
+
+	return runtime.CallersFrames(c)
+}

--- a/internal/testutils/fdtrace/fd.go
+++ b/internal/testutils/fdtrace/fd.go
@@ -1,0 +1,47 @@
+package fdtrace
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"runtime"
+	"testing"
+
+	"github.com/cilium/ebpf/internal/sys"
+)
+
+// TestMain runs m with sys.FD leak tracing enabled.
+func TestMain(m *testing.M) {
+	// fn can either be invoked asynchronously by the gc or during disabling of
+	// the leak tracer below. Don't terminate the program immediately, instead
+	// capture a boolean that will be used to set the exit code. This avoids races
+	// and gives all events the chance to be written to stderr.
+	var leak bool
+	sys.OnLeakFD(func(fs *runtime.Frames) {
+		fmt.Fprintln(os.Stderr, "leaked fd created at:")
+		fmt.Fprintln(os.Stderr, formatFrames(fs))
+		leak = true
+	})
+
+	ret := m.Run()
+
+	sys.OnLeakFD(nil)
+
+	if leak {
+		ret = 99
+	}
+
+	os.Exit(ret)
+}
+
+func formatFrames(fs *runtime.Frames) string {
+	var b bytes.Buffer
+	for {
+		f, more := fs.Next()
+		b.WriteString(fmt.Sprintf("\t%s+%#x\n\t\t%s:%d\n", f.Function, f.PC-f.Entry, f.File, f.Line))
+		if !more {
+			break
+		}
+	}
+	return b.String()
+}

--- a/link/cgroup_test.go
+++ b/link/cgroup_test.go
@@ -19,6 +19,7 @@ func TestAttachCgroup(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer link.Close()
 
 	if haveBPFLink() == nil {
 		if _, ok := link.(*linkCgroup); !ok {

--- a/link/kprobe_multi_test.go
+++ b/link/kprobe_multi_test.go
@@ -80,12 +80,14 @@ func TestKprobeMultiCookie(t *testing.T) {
 
 	prog := mustLoadProgram(t, ebpf.Kprobe, ebpf.AttachTraceKprobeMulti, "")
 
-	if _, err := KprobeMulti(prog, KprobeMultiOptions{
+	km, err := KprobeMulti(prog, KprobeMultiOptions{
 		Symbols: kprobeMultiSyms,
 		Cookies: []uint64{0, 1},
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatal(err)
 	}
+	_ = km.Close()
 }
 
 func TestKprobeMultiProgramCall(t *testing.T) {

--- a/link/link_test.go
+++ b/link/link_test.go
@@ -12,10 +12,15 @@ import (
 	"github.com/cilium/ebpf/asm"
 	"github.com/cilium/ebpf/internal/sys"
 	"github.com/cilium/ebpf/internal/testutils"
+	"github.com/cilium/ebpf/internal/testutils/fdtrace"
 	"github.com/cilium/ebpf/internal/unix"
 
 	qt "github.com/frankban/quicktest"
 )
+
+func TestMain(m *testing.M) {
+	fdtrace.TestMain(m)
+}
 
 func TestRawLink(t *testing.T) {
 	cgroup, prog := mustCgroupFixtures(t)

--- a/link/link_test.go
+++ b/link/link_test.go
@@ -55,11 +55,11 @@ func TestRawLink(t *testing.T) {
 func TestUnpinRawLink(t *testing.T) {
 	cgroup, prog := mustCgroupFixtures(t)
 	link, _ := newPinnedRawLink(t, cgroup, prog)
+	defer link.Close()
 
 	qt.Assert(t, link.IsPinned(), qt.IsTrue)
 
-	err := link.Unpin()
-	if err != nil {
+	if err := link.Unpin(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -69,6 +69,7 @@ func TestUnpinRawLink(t *testing.T) {
 func TestRawLinkLoadPinnedWithOptions(t *testing.T) {
 	cgroup, prog := mustCgroupFixtures(t)
 	link, path := newPinnedRawLink(t, cgroup, prog)
+	defer link.Close()
 
 	qt.Assert(t, link.IsPinned(), qt.IsTrue)
 

--- a/marshaler_example_test.go
+++ b/marshaler_example_test.go
@@ -27,7 +27,15 @@ func (ce *customEncoding) UnmarshalBinary(buf []byte) error {
 
 // ExampleMarshaler shows how to use custom encoding with map methods.
 func Example_customMarshaler() {
-	hash := createHash()
+	hash, err := NewMap(&MapSpec{
+		Type:       Hash,
+		KeySize:    5,
+		ValueSize:  4,
+		MaxEntries: 10,
+	})
+	if err != nil {
+		panic(err)
+	}
 	defer hash.Close()
 
 	if err := hash.Put(&customEncoding{"hello"}, uint32(111)); err != nil {

--- a/perf/reader_test.go
+++ b/perf/reader_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cilium/ebpf/asm"
 	"github.com/cilium/ebpf/internal"
 	"github.com/cilium/ebpf/internal/testutils"
+	"github.com/cilium/ebpf/internal/testutils/fdtrace"
 	"github.com/cilium/ebpf/internal/unix"
 
 	qt "github.com/frankban/quicktest"
@@ -22,6 +23,10 @@ import (
 var (
 	readTimeout = 250 * time.Millisecond
 )
+
+func TestMain(m *testing.M) {
+	fdtrace.TestMain(m)
+}
 
 func TestPerfReader(t *testing.T) {
 	prog, events := mustOutputSamplesProg(t, 5)

--- a/prog_test.go
+++ b/prog_test.go
@@ -441,7 +441,7 @@ func TestProgramVerifierLogTruncated(t *testing.T) {
 		}
 		var ve *internal.VerifierError
 		if !errors.As(err, &ve) {
-			t.Error("Error is not a VerifierError")
+			t.Fatal("Error is not a VerifierError")
 		}
 		if !ve.Truncated {
 			t.Errorf("VerifierError is not truncated: %+v", ve)

--- a/ringbuf/reader_test.go
+++ b/ringbuf/reader_test.go
@@ -11,8 +11,13 @@ import (
 	"github.com/cilium/ebpf/asm"
 	"github.com/cilium/ebpf/internal"
 	"github.com/cilium/ebpf/internal/testutils"
+	"github.com/cilium/ebpf/internal/testutils/fdtrace"
 	"github.com/google/go-cmp/cmp"
 )
+
+func TestMain(m *testing.M) {
+	fdtrace.TestMain(m)
+}
 
 func TestRingbufReader(t *testing.T) {
 	testutils.SkipOnOldKernel(t, "5.8", "BPF ring buffer")


### PR DESCRIPTION
In an effort to improve the library's fd hygiene, this patch adds optional
metadata to sys.FD to hold a name and a stack trace of where the fd was
created, as well as a simple subscription mechanism for packages to
get notified when a live fd gets garbage collected due to losing its reference.

Metadata is only collected when there are active tracers, so they must be
registered before creating the first sys.FD.

This has shaken out a few minor bugs so far. Most of them from the test suite,
but also a few where we forgot to close resources that were no longer needed
before returning from LoadAndAssign and some other internal APIs

All test packages now also include a TestMain that sets up leak tracing and
starts a GC round before finishing the test, so we can catch these kinds of
errors more easily in the future.

The idea is to export the sys package over time, which would make this
instrumentation available to all, after it has been given some time to mature.