### PR TITLE
program: support tracing of kernel modules

### DIFF
--- a/btf/btf.go
+++ b/btf/btf.go
@@ -609,6 +609,9 @@ func (s *Spec) AnyTypeByName(name string) (Type, error) {
 // Type exists in the Spec. If multiple candidates are found,
 // an error is returned.
 func (s *Spec) TypeByName(name string, typ interface{}) error {
+	typeInterface := reflect.TypeOf((*Type)(nil)).Elem()
+
+	// typ may be **T or *Type
 	typValue := reflect.ValueOf(typ)
 	if typValue.Kind() != reflect.Ptr {
 		return fmt.Errorf("%T is not a pointer", typ)
@@ -620,7 +623,12 @@ func (s *Spec) TypeByName(name string, typ interface{}) error {
 	}
 
 	wanted := typPtr.Type()
-	if !wanted.AssignableTo(reflect.TypeOf((*Type)(nil)).Elem()) {
+	if wanted == typeInterface {
+		// This is *Type. Unwrap the value's type.
+		wanted = typPtr.Elem().Type()
+	}
+
+	if !wanted.AssignableTo(typeInterface) {
 		return fmt.Errorf("%T does not satisfy Type interface", typ)
 	}
 
@@ -643,7 +651,7 @@ func (s *Spec) TypeByName(name string, typ interface{}) error {
 	}
 
 	if candidate == nil {
-		return fmt.Errorf("type %s: %w", name, ErrNotFound)
+		return fmt.Errorf("%s %s: %w", wanted, name, ErrNotFound)
 	}
 
 	typPtr.Set(reflect.ValueOf(candidate))

--- a/btf/btf_test.go
+++ b/btf/btf_test.go
@@ -130,6 +130,12 @@ func TestTypeByName(t *testing.T) {
 		t.Fatal("multiple TypeByName calls for `iphdr` name do not return the same addresses")
 	}
 
+	// It's valid to pass a *Type to TypeByName.
+	typ := Type(iphdr2)
+	if err := spec.TypeByName("iphdr", &typ); err != nil {
+		t.Fatal("Can't look up using *Type:", err)
+	}
+
 	// Excerpt from linux/ip.h, https://elixir.bootlin.com/linux/latest/A/ident/iphdr
 	//
 	// struct iphdr {

--- a/btf/handle.go
+++ b/btf/handle.go
@@ -71,48 +71,59 @@ func (i *HandleInfo) IsModule() bool {
 
 // HandleIterator allows enumerating BTF blobs loaded into the kernel.
 type HandleIterator struct {
-	// The ID of the last retrieved handle. Only valid after a call to Next.
-	ID  ID
-	err error
+	// The ID of the current handle. Only valid after a call to Next.
+	ID ID
+	// The current Handle. Only valid until a call to Next.
+	// See Take if you want to retain the handle.
+	Handle *Handle
+	err    error
 }
 
-// Next retrieves a handle for the next BTF blob.
+// Next retrieves a handle for the next BTF object.
 //
-// [Handle.Close] is called if *handle is non-nil to avoid leaking fds.
-//
-// Returns true if another BTF blob was found. Call [HandleIterator.Err] after
+// Returns true if another BTF object was found. Call [HandleIterator.Err] after
 // the function returns false.
-func (it *HandleIterator) Next(handle **Handle) bool {
-	if *handle != nil {
-		(*handle).Close()
-		*handle = nil
-	}
-
+func (it *HandleIterator) Next() bool {
 	id := it.ID
 	for {
 		attr := &sys.BtfGetNextIdAttr{Id: id}
 		err := sys.BtfGetNextId(attr)
 		if errors.Is(err, os.ErrNotExist) {
 			// There are no more BTF objects.
-			return false
+			break
 		} else if err != nil {
 			it.err = fmt.Errorf("get next BTF ID: %w", err)
-			return false
+			break
 		}
 
 		id = attr.NextId
-		*handle, err = NewHandleFromID(id)
+		handle, err := NewHandleFromID(id)
 		if errors.Is(err, os.ErrNotExist) {
 			// Try again with the next ID.
 			continue
 		} else if err != nil {
 			it.err = fmt.Errorf("retrieve handle for ID %d: %w", id, err)
-			return false
+			break
 		}
 
-		it.ID = id
+		it.Handle.Close()
+		it.ID, it.Handle = id, handle
 		return true
 	}
+
+	// No more handles or we encountered an error.
+	it.Handle.Close()
+	it.Handle = nil
+	return false
+}
+
+// Take the ownership of the current handle.
+//
+// It's the callers responsibility to close the handle.
+func (it *HandleIterator) Take() *Handle {
+	handle := it.Handle
+	it.Handle = nil
+	return handle
 }
 
 // Err returns an error if iteration failed for some reason.

--- a/btf/handle_test.go
+++ b/btf/handle_test.go
@@ -50,60 +50,25 @@ func TestParseModuleSplitSpec(t *testing.T) {
 	// See TestNewHandleFromID for reasoning.
 	testutils.SkipOnOldKernel(t, "5.11", "vmlinux BTF ID")
 
-	var module *btf.Handle
+	module, err := btf.FindHandle(func(info *btf.HandleInfo) bool {
+		if info.IsModule() {
+			t.Log("Using module", info.Name)
+			return true
+		}
+		return false
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer module.Close()
 
-	it := new(btf.HandleIterator)
-	defer it.Handle.Close()
-
-	for it.Next() {
-		info, err := it.Handle.Info()
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if !info.IsModule() {
-			continue
-		}
-
-		t.Log("Using module", info.Name)
-		module = it.Take()
-		break
-	}
-	if err := it.Err(); err != nil {
+	vmlinux, err := btf.FindHandle(func(info *btf.HandleInfo) bool {
+		return info.IsVmlinux()
+	})
+	if err != nil {
 		t.Fatal(err)
 	}
-
-	if module == nil {
-		t.Fatal("No BTF for kernel module found")
-	}
-
-	var vmlinux *btf.Handle
 	defer vmlinux.Close()
-
-	it = new(btf.HandleIterator)
-	defer it.Handle.Close()
-
-	for it.Next() {
-		info, err := it.Handle.Info()
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if !info.IsVmlinux() {
-			continue
-		}
-
-		vmlinux = it.Take()
-		break
-	}
-	if err := it.Err(); err != nil {
-		t.Fatal(err)
-	}
-
-	if vmlinux == nil {
-		t.Fatal("No BTF for kernel found")
-	}
 
 	vmlinuxSpec, err := vmlinux.Spec(nil)
 	if err != nil {

--- a/internal/cmd/gentypes/main.go
+++ b/internal/cmd/gentypes/main.go
@@ -285,6 +285,7 @@ import (
 					"fd_array",
 					"core_relos",
 				),
+				choose(20, "attach_btf_obj_fd"),
 			},
 		},
 		{

--- a/internal/sys/types.go
+++ b/internal/sys/types.go
@@ -967,7 +967,7 @@ type ProgLoadAttr struct {
 	LineInfo           Pointer
 	LineInfoCnt        uint32
 	AttachBtfId        uint32
-	AttachProgFd       uint32
+	AttachBtfObjFd     uint32
 	CoreReloCnt        uint32
 	FdArray            Pointer
 	CoreRelos          Pointer

--- a/prog.go
+++ b/prog.go
@@ -43,8 +43,7 @@ type ProgramOptions struct {
 	// Controls the output buffer size for the verifier. Defaults to
 	// DefaultVerifierLogSize.
 	LogSize int
-	// Type information used for CO-RE relocations and when attaching to
-	// kernel functions.
+	// Type information used for CO-RE relocations.
 	//
 	// This is useful in environments where the kernel BTF is not available
 	// (containers) or where it is in a non-standard location. Defaults to
@@ -206,14 +205,12 @@ func newProgramWithOptions(spec *ProgramSpec, opts ProgramOptions, handles *hand
 		attr.ProgName = sys.NewObjName(spec.Name)
 	}
 
-	kernelTypes := opts.KernelTypes
-
 	insns := make(asm.Instructions, len(spec.Instructions))
 	copy(insns, spec.Instructions)
 
 	var btfDisabled bool
 	if spec.BTF != nil {
-		if err := applyRelocations(insns, spec.BTF, kernelTypes); err != nil {
+		if err := applyRelocations(insns, spec.BTF, opts.KernelTypes); err != nil {
 			return nil, fmt.Errorf("apply CO-RE relocations: %w", err)
 		}
 
@@ -262,10 +259,10 @@ func newProgramWithOptions(spec *ProgramSpec, opts ProgramOptions, handles *hand
 		}
 
 		attr.AttachBtfId = uint32(targetID)
-		attr.AttachProgFd = uint32(spec.AttachTarget.FD())
+		attr.AttachBtfObjFd = uint32(spec.AttachTarget.FD())
 		defer runtime.KeepAlive(spec.AttachTarget)
 	} else if spec.AttachTo != "" {
-		targetID, err := findTargetInKernel(kernelTypes, spec.AttachTo, spec.Type, spec.AttachType)
+		module, targetID, err := findTargetInKernel(spec.AttachTo, spec.Type, spec.AttachType)
 		if err != nil && !errors.Is(err, errUnrecognizedAttachType) {
 			// We ignore errUnrecognizedAttachType since AttachTo may be non-empty
 			// for programs that don't attach anywhere.
@@ -273,6 +270,10 @@ func newProgramWithOptions(spec *ProgramSpec, opts ProgramOptions, handles *hand
 		}
 
 		attr.AttachBtfId = uint32(targetID)
+		if module != nil {
+			attr.AttachBtfObjFd = uint32(module.FD())
+			defer module.Close()
+		}
 	}
 
 	logSize := DefaultVerifierLogSize
@@ -770,11 +771,15 @@ var errUnrecognizedAttachType = errors.New("unrecognized attach type")
 
 // find an attach target type in the kernel.
 //
-// spec may be nil and defaults to the canonical kernel BTF. name together with
-// progType and attachType determine which type we need to attach to.
+// name, progType and attachType determine which type we need to attach to.
 //
-// Returns errUnrecognizedAttachType.
-func findTargetInKernel(spec *btf.Spec, name string, progType ProgramType, attachType AttachType) (btf.TypeID, error) {
+// The attach target may be in a loaded kernel module.
+// In that case the returned handle will be non-nil.
+// The caller is responsible for closing the handle.
+//
+// Returns errUnrecognizedAttachType if the combination of progType and attachType
+// is not recognised.
+func findTargetInKernel(name string, progType ProgramType, attachType AttachType) (*btf.Handle, btf.TypeID, error) {
 	type match struct {
 		p ProgramType
 		a AttachType
@@ -811,24 +816,80 @@ func findTargetInKernel(spec *btf.Spec, name string, progType ProgramType, attac
 		featureName = fmt.Sprintf("raw_tp %s", name)
 		target = (*btf.Typedef)(nil)
 	default:
-		return 0, errUnrecognizedAttachType
+		return nil, 0, errUnrecognizedAttachType
 	}
 
-	spec, err := maybeLoadKernelBTF(spec)
+	// maybeLoadKernelBTF may return external BTF if /sys/... is not available.
+	// Ideally we shouldn't use external BTF here, since we might try to use
+	// it for parsing kmod split BTF later on. That seems unlikely to work.
+	spec, err := maybeLoadKernelBTF(nil)
 	if err != nil {
-		return 0, fmt.Errorf("load kernel spec: %w", err)
+		return nil, 0, fmt.Errorf("load kernel spec: %w", err)
 	}
 
-	if err := spec.TypeByName(typeName, &target); err != nil {
+	err = spec.TypeByName(typeName, &target)
+	if errors.Is(err, btf.ErrNotFound) {
+		module, id, err := findTargetInModule(spec, typeName, target)
 		if errors.Is(err, btf.ErrNotFound) {
-			return 0, &internal.UnsupportedFeatureError{
-				Name: featureName,
-			}
+			return nil, 0, &internal.UnsupportedFeatureError{Name: featureName}
 		}
-		return 0, fmt.Errorf("find target for %s: %w", featureName, err)
+		if err != nil {
+			return nil, 0, fmt.Errorf("find target for %s in modules: %w", featureName, err)
+		}
+		return module, id, nil
+	}
+	if err != nil {
+		return nil, 0, fmt.Errorf("find target for %s in vmlinux: %w", featureName, err)
 	}
 
-	return spec.TypeID(target)
+	id, err := spec.TypeID(target)
+	return nil, id, err
+}
+
+// find an attach target type in a kernel module.
+//
+// vmlinux must contain the kernel's types and is used to parse kmod BTF.
+//
+// Returns btf.ErrNotFound if the target can't be found in any module.
+func findTargetInModule(vmlinux *btf.Spec, typeName string, target btf.Type) (*btf.Handle, btf.TypeID, error) {
+	it := new(btf.HandleIterator)
+	defer it.Handle.Close()
+
+	for it.Next() {
+		info, err := it.Handle.Info()
+		if err != nil {
+			return nil, 0, fmt.Errorf("get info for BTF ID %d: %w", it.ID, err)
+		}
+
+		if !info.IsModule() {
+			continue
+		}
+
+		spec, err := it.Handle.Spec(vmlinux)
+		if err != nil {
+			return nil, 0, fmt.Errorf("parse types for module %s: %w", info.Name, err)
+		}
+
+		err = spec.TypeByName(typeName, &target)
+		if errors.Is(err, btf.ErrNotFound) {
+			continue
+		}
+		if err != nil {
+			return nil, 0, fmt.Errorf("lookup type in module %s: %w", info.Name, err)
+		}
+
+		id, err := spec.TypeID(target)
+		if err != nil {
+			return nil, 0, fmt.Errorf("lookup type id in module %s: %w", info.Name, err)
+		}
+
+		return it.Take(), id, nil
+	}
+	if err := it.Err(); err != nil {
+		return nil, 0, fmt.Errorf("iterate modules: %w", err)
+	}
+
+	return nil, 0, btf.ErrNotFound
 }
 
 // find an attach target type in a program.


### PR DESCRIPTION
program: support tracing of kernel modules

    Allow tracing functions in kernel modules via fentry, fexit, fmod_ret
    and tp_btf programs. The behaviour follows libbpf and is transparent
    to the user: if we can't find a target in vmlinux we attempt to find
    it in any loaded kernel module.

    Refactor TestProgramTypeLSM to test attaching via BTF. This removes
    LSM tests for BPF_F_SLEEPABLE, since they don't excercise library
    behaviour beyond passing ProgramSpec.Flags to the kernel.

    Updates #705

btf: add FindHandle

    Add a helper that iterates all BTF objects in the kernel and returns
    the first one for which a user supplied callback returns true.

btf: allow passing *Type to Spec.TypeByName