### PR TITLE
internal: fix VerifierError output with empty log

### DIFF
--- a/internal/errors.go
+++ b/internal/errors.go
@@ -20,7 +20,7 @@ func ErrorWithLog(err error, log []byte) *VerifierError {
 	// and trimming trailing whitespace before interpreting as a Go string.
 	truncated := false
 	if i := bytes.IndexByte(log, 0); i != -1 {
-		if i == len(log)-1 && !bytes.HasSuffix(log[:i], []byte{'\n'}) {
+		if i > 0 && i == len(log)-1 && log[i-1] != '\n' {
 			// The null byte is at the end of the buffer and it's not preceded
 			// by a newline character. Most likely the buffer was too short.
 			truncated = true
@@ -33,6 +33,10 @@ func ErrorWithLog(err error, log []byte) *VerifierError {
 	}
 
 	log = bytes.Trim(log, whitespace)
+	if len(log) == 0 {
+		return &VerifierError{err, nil, false}
+	}
+
 	logLines := bytes.Split(log, []byte{'\n'})
 	lines := make([]string, 0, len(logLines))
 	for _, line := range logLines {

--- a/internal/errors_test.go
+++ b/internal/errors_test.go
@@ -22,15 +22,16 @@ func TestVerifierErrorWhitespace(t *testing.T) {
 	)
 
 	err := ErrorWithLog(errors.New("test"), b)
+	qt.Assert(t, err.Error(), qt.Equals, "test: unreachable insn 28")
 
-	want := "test: unreachable insn 28"
-	got := err.Error()
+	err = ErrorWithLog(errors.New("test"), nil)
+	qt.Assert(t, err.Error(), qt.Equals, "test")
 
-	t.Log(got)
+	err = ErrorWithLog(errors.New("test"), []byte("\x00"))
+	qt.Assert(t, err.Error(), qt.Equals, "test")
 
-	if want != got {
-		t.Fatalf("\nwant: %s\ngot: %s", want, got)
-	}
+	err = ErrorWithLog(errors.New("test"), []byte(" "))
+	qt.Assert(t, err.Error(), qt.Equals, "test")
 }
 
 func TestVerifierError(t *testing.T) {


### PR DESCRIPTION
Formatting a VerifierError that has no log includes a trailing ": ".

Make formatting of nil or empty logs consistent.