### PR TITLE
features: implement probes for StructOps maps and programs

### DIFF
--- a/features/map.go
+++ b/features/map.go
@@ -25,73 +25,59 @@ type mapCache struct {
 }
 
 func createMapTypeAttr(mt ebpf.MapType) *sys.MapCreateAttr {
-	var (
-		keySize        uint32 = 4
-		valueSize      uint32 = 4
-		maxEntries     uint32 = 1
-		innerMapFd     uint32
-		flags          uint32
-		btfKeyTypeID   uint32
-		btfValueTypeID uint32
-		btfFd          uint32
-	)
+	a := &sys.MapCreateAttr{
+		MapType:    sys.MapType(mt),
+		KeySize:    4,
+		ValueSize:  4,
+		MaxEntries: 1,
+	}
 
 	// switch on map types to generate correct MapCreateAttr
 	switch mt {
 	case ebpf.StackTrace:
 		// valueSize needs to be sizeof(uint64)
-		valueSize = 8
+		a.ValueSize = 8
 	case ebpf.LPMTrie:
 		// keySize and valueSize need to be sizeof(struct{u32 + u8}) + 1 + padding = 8
 		// BPF_F_NO_PREALLOC needs to be set
 		// checked at allocation time for lpm_trie maps
-		keySize = 8
-		valueSize = 8
-		flags = unix.BPF_F_NO_PREALLOC
+		a.KeySize = 8
+		a.ValueSize = 8
+		a.MapFlags = unix.BPF_F_NO_PREALLOC
 	case ebpf.ArrayOfMaps, ebpf.HashOfMaps:
 		// assign invalid innerMapFd to pass validation check
 		// will return EBADF
-		innerMapFd = ^uint32(0)
+		a.InnerMapFd = ^uint32(0)
 	case ebpf.CGroupStorage, ebpf.PerCPUCGroupStorage:
 		// keySize needs to be sizeof(struct{u32 + u64}) = 12 (+ padding = 16)
 		// by using unsafe.Sizeof(int) we are making sure that this works on 32bit and 64bit archs
 		// checked at allocation time
 		var align int
-		keySize = uint32(8 + unsafe.Sizeof(align))
-		maxEntries = 0
+		a.KeySize = uint32(8 + unsafe.Sizeof(align))
+		a.MaxEntries = 0
 	case ebpf.Queue, ebpf.Stack:
 		// keySize needs to be 0, see alloc_check for queue and stack maps
-		keySize = 0
+		a.KeySize = 0
 	case ebpf.RingBuf:
 		// keySize and valueSize need to be 0
 		// maxEntries needs to be power of 2 and PAGE_ALIGNED
 		// checked at allocation time
-		keySize = 0
-		valueSize = 0
-		maxEntries = uint32(os.Getpagesize())
+		a.KeySize = 0
+		a.ValueSize = 0
+		a.MaxEntries = uint32(os.Getpagesize())
 	case ebpf.SkStorage, ebpf.InodeStorage, ebpf.TaskStorage:
 		// maxEntries needs to be 0
 		// BPF_F_NO_PREALLOC needs to be set
 		// btf* fields need to be set
 		// see alloc_check for local_storage map types
-		maxEntries = 0
-		flags = unix.BPF_F_NO_PREALLOC
-		btfKeyTypeID = 1   // BTF_KIND_INT
-		btfValueTypeID = 3 // BTF_KIND_ARRAY
-		btfFd = ^uint32(0)
+		a.MaxEntries = 0
+		a.MapFlags = unix.BPF_F_NO_PREALLOC
+		a.BtfKeyTypeId = 1   // BTF_KIND_INT
+		a.BtfValueTypeId = 3 // BTF_KIND_ARRAY
+		a.BtfFd = ^uint32(0)
 	}
 
-	return &sys.MapCreateAttr{
-		MapType:        sys.MapType(mt),
-		KeySize:        keySize,
-		ValueSize:      valueSize,
-		MaxEntries:     maxEntries,
-		InnerMapFd:     innerMapFd,
-		MapFlags:       flags,
-		BtfKeyTypeId:   btfKeyTypeID,
-		BtfValueTypeId: btfValueTypeID,
-		BtfFd:          btfFd,
-	}
+	return a
 }
 
 // HaveMapType probes the running kernel for the availability of the specified map type.

--- a/features/map_test.go
+++ b/features/map_test.go
@@ -37,7 +37,7 @@ var mapTypeMinVersion = map[ebpf.MapType]string{
 	ebpf.Stack:               "4.20",
 	ebpf.SkStorage:           "5.2",
 	ebpf.DevMapHash:          "5.4",
-	ebpf.StructOpsMap:        "5.6", // requires vmlinux BTF, skip for now
+	ebpf.StructOpsMap:        "5.6",
 	ebpf.RingBuf:             "5.8",
 	ebpf.InodeStorage:        "5.10",
 	ebpf.TaskStorage:         "5.11",
@@ -55,10 +55,6 @@ func TestHaveMapType(t *testing.T) {
 		feature := fmt.Sprintf("map type %s", mt.String())
 
 		t.Run(mt.String(), func(t *testing.T) {
-			if mt == ebpf.StructOpsMap {
-				t.Skip("Test for map type StructOpsMap requires working probe")
-			}
-
 			testutils.SkipOnOldKernel(t, minVersion, feature)
 
 			if err := HaveMapType(mt); err != nil {
@@ -79,9 +75,5 @@ func TestHaveMapTypeUnsupported(t *testing.T) {
 func TestHaveMapTypeInvalid(t *testing.T) {
 	if err := HaveMapType(ebpf.MapType(math.MaxUint32)); !errors.Is(err, os.ErrInvalid) {
 		t.Fatalf("Expected os.ErrInvalid but was: %v", err)
-	}
-
-	if err := HaveMapType(ebpf.MapType(ebpf.StructOpsMap)); err == nil {
-		t.Fatal("Expected but was nil")
 	}
 }

--- a/features/prog.go
+++ b/features/prog.go
@@ -154,6 +154,12 @@ func haveProgramType(pt ebpf.ProgramType) error {
 	// to support the given prog type.
 	case errors.Is(err, unix.EINVAL), errors.Is(err, unix.E2BIG):
 		err = ebpf.ErrNotSupported
+
+	// ENOTSUPP means the program type is at least known to the kernel.
+	case errors.Is(err, sys.ENOTSUPP):
+		if pt == ebpf.StructOps {
+			err = nil
+		}
 	}
 
 	pc.types[pt] = err
@@ -241,7 +247,7 @@ func haveProgramHelper(pt ebpf.ProgramType, helper asm.BuiltinFunc) error {
 
 func progLoadProbeNotImplemented(pt ebpf.ProgramType) bool {
 	switch pt {
-	case ebpf.Tracing, ebpf.StructOps, ebpf.Extension, ebpf.LSM:
+	case ebpf.Tracing, ebpf.Extension, ebpf.LSM:
 		return true
 	}
 	return false


### PR DESCRIPTION
Turns out this was never really blocking: https://github.com/cilium/ebpf/issues/344. Specifying any invalid vmlinux type id when creating a map is enough to get some information other than EINVAL.