### PR TITLE
features: remove EPERM wrapping exception, automatically wrap errors

### DIFF
--- a/features/errors.go
+++ b/features/errors.go
@@ -1,0 +1,38 @@
+package features
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/cilium/ebpf"
+)
+
+// wrapProbeErrors wraps err to prevent callers from directly comparing
+// it to exported sentinels. Error rewriting in Go can be implemented by
+// deferring a closure over a named error return variable. This gives the
+// closure access to the stack space where the return value will be written,
+// allowing it to intercept and rewrite all returns, regardless of whether
+// or not the return statements use the named return variable.
+//
+//  func foo() (err error) {
+//    defer func() {
+//      err = wrapProbeErrors(err)
+//    }
+//    return errors.New("this error will be wrapped")
+//  }
+func wrapProbeErrors(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	// Wrap all errors to prevent them from being compared directly
+	// to exported sentinels by the caller.
+	errStr := "%w"
+
+	if !errors.Is(err, ebpf.ErrNotSupported) {
+		// Wrap unexpected errors with an appropriate error string.
+		errStr = "unexpected error during feature probe: %w"
+	}
+
+	return fmt.Errorf(errStr, err)
+}

--- a/features/map.go
+++ b/features/map.go
@@ -2,7 +2,6 @@ package features
 
 import (
 	"errors"
-	"fmt"
 	"os"
 	"sync"
 	"unsafe"
@@ -98,7 +97,12 @@ func createMapTypeAttr(mt ebpf.MapType) *sys.MapCreateAttr {
 // HaveMapType probes the running kernel for the availability of the specified map type.
 //
 // See the package documentation for the meaning of the error return value.
-func HaveMapType(mt ebpf.MapType) error {
+func HaveMapType(mt ebpf.MapType) (err error) {
+	defer func() {
+		// This closure modifies a named return variable.
+		err = wrapProbeErrors(err)
+	}()
+
 	if err := validateMaptype(mt); err != nil {
 		return err
 	}
@@ -108,7 +112,7 @@ func HaveMapType(mt ebpf.MapType) error {
 
 func validateMaptype(mt ebpf.MapType) error {
 	if mt > mt.Max() {
-		return fmt.Errorf("%w", os.ErrInvalid)
+		return os.ErrInvalid
 	}
 
 	if mt == ebpf.StructOpsMap {
@@ -146,11 +150,7 @@ func haveMapType(mt ebpf.MapType) error {
 	// of the struct known by the running kernel, meaning the kernel is too old
 	// to support the given map type.
 	case errors.Is(err, unix.EINVAL), errors.Is(err, unix.E2BIG):
-		err = fmt.Errorf("%w", ebpf.ErrNotSupported)
-
-	// Wrap unexpected errors.
-	case err != nil:
-		err = fmt.Errorf("unexpected error during feature probe: %w", err)
+		err = ebpf.ErrNotSupported
 	}
 
 	mc.mapTypes[mt] = err

--- a/features/misc.go
+++ b/features/misc.go
@@ -92,6 +92,9 @@ func probeMisc(mt miscType) error {
 	}
 
 	fd, err := sys.ProgLoad(attr)
+	if err == nil {
+		fd.Close()
+	}
 
 	switch {
 	// EINVAL occurs when attempting to create a program with an unknown type.
@@ -101,16 +104,9 @@ func probeMisc(mt miscType) error {
 	case errors.Is(err, unix.EINVAL), errors.Is(err, unix.E2BIG):
 		err = fmt.Errorf("%w", ebpf.ErrNotSupported)
 
-	// EPERM is kept as-is and is not converted or wrapped.
-	case errors.Is(err, unix.EPERM):
-		break
-
 	// Wrap unexpected errors.
 	case err != nil:
 		err = fmt.Errorf("unexpected error during feature probe: %w", err)
-
-	default:
-		fd.Close()
 	}
 
 	miscs.miscTypes[mt] = err


### PR DESCRIPTION
```
In an attempt to simplify the switch blocks in all types of feature
probes, lift the arbitrary EPERM wrapping exception.

Also, move the call to fd.Close() out of the switch statement to live
closer to the call that returns the fd. The fd can always be immediately
closed.
```

```
Instead of relying on repeated calls to fmt.Errorf("...: %w", err) to ensure
we never return naked sentinels, add error wrappers at a few key locations.

This abstracts and centralizes the wrapping logic to make the probe logic
itself a bit leaner.
```