### PR TITLE
link: add maxactive for kretprobe

### DIFF
--- a/link/kprobe.go
+++ b/link/kprobe.go
@@ -412,14 +412,9 @@ func tracefsProbe(typ probeType, args probeArgs) (_ *perfEvent, err error) {
 	if errors.Is(err, os.ErrNotExist) {
 		if typ == kprobeType && args.ret && args.retprobeMaxActive != 0 {
 			// In kernels earlier than 4.12, if maxactive is used to create kretprobe events,
-			// the event names created are not expected. We need to delete that event and
-			// create again without maxactive.
+			// the event names created are not expected.
 			_ = removeTraceFSProbeEvent(typ, fmt.Sprintf("-:kprobes/r_%s_0", sanitizeSymbol(args.symbol)))
-			args.retprobeMaxActive = 0
-			if err = createTraceFSProbeEvent(typ, args); err != nil {
-				return nil, fmt.Errorf("creating probe entry on tracefs: %w", err)
-			}
-			tid, err = getTraceEventID(group, args.symbol)
+			return nil, fmt.Errorf("create trace event with non-default maxactive: %w", ErrNotSupported)
 		}
 	}
 	if err != nil {

--- a/link/kprobe.go
+++ b/link/kprobe.go
@@ -424,7 +424,7 @@ func createTraceFSProbeEvent(typ probeType, args probeArgs) (uint64, error) {
 	// entry, so we need to rely on reads for detecting uniqueness.
 	_, err := getTraceEventID(args.group, args.symbol)
 	if err == nil {
-		return 0, fmt.Errorf("trace event already exists: %s/%s", args.group, args.symbol)
+		return 0, fmt.Errorf("trace event %s/%s: %w", args.group, args.symbol, os.ErrExist)
 	}
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return 0, fmt.Errorf("checking trace event %s/%s: %w", args.group, args.symbol, err)

--- a/link/kprobe.go
+++ b/link/kprobe.go
@@ -403,7 +403,7 @@ func tracefsProbe(typ probeType, args probeArgs) (_ *perfEvent, err error) {
 			// If a livepatch handler is already active on the symbol, the write to
 			// tracefs will succeed, a trace event will show up, but creating the
 			// perf event will fail with EBUSY.
-			_ = closeTraceFSProbeEvent(typ, args.group, args.symbol, false)
+			_ = closeTraceFSProbeEvent(typ, args.group, args.symbol)
 		}
 	}()
 
@@ -414,7 +414,7 @@ func tracefsProbe(typ probeType, args probeArgs) (_ *perfEvent, err error) {
 			// In kernels earlier than 4.12, if maxactive is used to create kretprobe events,
 			// the event names created are not expected. We need to delete that event and
 			// create again without maxactive.
-			_ = closeTraceFSProbeEvent(typ, args.group, args.symbol, true)
+			_ = removeTraceFSProbeEvent(typ, fmt.Sprintf("-:kprobes/r_%s_0", sanitizeSymbol(args.symbol)))
 			args.retprobeMaxActive = 0
 			if err = createTraceFSProbeEvent(typ, args); err != nil {
 				return nil, fmt.Errorf("creating probe entry on tracefs: %w", err)
@@ -521,9 +521,13 @@ func createTraceFSProbeEvent(typ probeType, args probeArgs) error {
 }
 
 // closeTraceFSProbeEvent removes the [k,u]probe with the given type, group and symbol
-// from <tracefs>/[k,u]probe_events. The lowkernel flag is used to delete kretprobe
-// events that use maxactive in low version kernels (kernel < 4.12)
-func closeTraceFSProbeEvent(typ probeType, group, symbol string, lowKernel bool) error {
+// from <tracefs>/[k,u]probe_events.
+func closeTraceFSProbeEvent(typ probeType, group, symbol string) error {
+	pe := fmt.Sprintf("%s/%s", group, sanitizeSymbol(symbol))
+	return removeTraceFSProbeEvent(typ, pe)
+}
+
+func removeTraceFSProbeEvent(typ probeType, pe string) error {
 	f, err := os.OpenFile(typ.EventsPath(), os.O_APPEND|os.O_WRONLY, 0666)
 	if err != nil {
 		return fmt.Errorf("error opening %s: %w", typ.EventsPath(), err)
@@ -532,14 +536,8 @@ func closeTraceFSProbeEvent(typ probeType, group, symbol string, lowKernel bool)
 
 	// See [k,u]probe_events syntax above. The probe type does not need to be specified
 	// for removals.
-	var pe string
-	if lowKernel {
-		pe = fmt.Sprintf("-:kprobes/r_%s_0", symbol)
-	} else {
-		pe = fmt.Sprintf("-:%s/%s", group, sanitizeSymbol(symbol))
-	}
-	if _, err = f.WriteString(pe); err != nil {
-		return fmt.Errorf("writing '%s' to '%s': %w", pe, typ.EventsPath(), err)
+	if _, err = f.WriteString("-:" + pe); err != nil {
+		return fmt.Errorf("remove event %q from %s: %w", pe, typ.EventsPath(), err)
 	}
 
 	return nil

--- a/link/kprobe.go
+++ b/link/kprobe.go
@@ -502,7 +502,7 @@ func createTraceFSProbeEvent(typ probeType, args probeArgs) (uint64, error) {
 	if args.retprobeMaxActive != 0 && errors.Is(err, os.ErrNotExist) {
 		// In kernels earlier than 4.12, if maxactive is used to create kretprobe events,
 		// the event names created are not expected.
-		removeErr := removeTraceFSProbeEvent(typ, fmt.Sprintf("-:kprobes/r_%s_0", sanitizeSymbol(args.symbol)))
+		removeErr := removeTraceFSProbeEvent(typ, fmt.Sprintf("kprobes/r_%s_0", sanitizeSymbol(args.symbol)))
 		if removeErr != nil {
 			return 0, fmt.Errorf("failed to remove spurious maxactive event: %s", removeErr)
 		}

--- a/link/kprobe.go
+++ b/link/kprobe.go
@@ -408,6 +408,8 @@ func tracefsProbe(typ probeType, args probeArgs) (*perfEvent, error) {
 	}, nil
 }
 
+var errInvalidMaxActive = errors.New("can only set maxactive on kretprobes")
+
 // createTraceFSProbeEvent creates a new ephemeral trace event.
 //
 // Returns os.ErrNotExist if symbol is not a valid
@@ -453,7 +455,7 @@ func createTraceFSProbeEvent(typ probeType, args probeArgs) (uint64, error) {
 		// the eBPF program itself.
 		// See Documentation/kprobes.txt for more details.
 		if args.retprobeMaxActive != 0 && !args.ret {
-			return 0, fmt.Errorf("can only set maxactive on kretprobes")
+			return 0, errInvalidMaxActive
 		}
 		token = kprobeToken(args)
 		pe = fmt.Sprintf("%s:%s/%s %s", probePrefix(args.ret, args.retprobeMaxActive), args.group, sanitizeSymbol(args.symbol), token)
@@ -469,7 +471,7 @@ func createTraceFSProbeEvent(typ probeType, args probeArgs) (uint64, error) {
 		//
 		// See Documentation/trace/uprobetracer.txt for more details.
 		if args.retprobeMaxActive != 0 {
-			return 0, fmt.Errorf("can only set maxactive on kretprobes")
+			return 0, errInvalidMaxActive
 		}
 		token = uprobeToken(args)
 		pe = fmt.Sprintf("%s:%s/%s %s", probePrefix(args.ret, 0), args.group, args.symbol, token)

--- a/link/kprobe.go
+++ b/link/kprobe.go
@@ -502,7 +502,7 @@ func createTraceFSProbeEvent(typ probeType, args probeArgs) (uint64, error) {
 	if args.retprobeMaxActive != 0 && errors.Is(err, os.ErrNotExist) {
 		// In kernels earlier than 4.12, if maxactive is used to create kretprobe events,
 		// the event names created are not expected.
-		removeErr := removeTraceFSProbeEvent(typ, fmt.Sprintf("kprobes/r_%s_0", sanitizeSymbol(args.symbol)))
+		removeErr := removeTraceFSProbeEvent(typ, fmt.Sprintf("kprobes/r_%s_0", args.symbol))
 		if removeErr != nil {
 			return 0, fmt.Errorf("failed to remove spurious maxactive event: %s", removeErr)
 		}

--- a/link/kprobe_test.go
+++ b/link/kprobe_test.go
@@ -276,8 +276,8 @@ func TestKprobeCreateTraceFS(t *testing.T) {
 
 	// Tee up cleanups in case any of the Asserts abort the function.
 	defer func() {
-		_ = closeTraceFSProbeEvent(kprobeType, pg, ksym, false)
-		_ = closeTraceFSProbeEvent(kprobeType, rg, ksym, false)
+		_ = closeTraceFSProbeEvent(kprobeType, pg, ksym)
+		_ = closeTraceFSProbeEvent(kprobeType, rg, ksym)
 	}()
 
 	// Prepare probe args.
@@ -294,7 +294,7 @@ func TestKprobeCreateTraceFS(t *testing.T) {
 		qt.Commentf("expected consecutive kprobe creation to contain os.ErrExist, got: %v", err))
 
 	// Expect a successful close of the kprobe.
-	c.Assert(closeTraceFSProbeEvent(kprobeType, pg, ksym, false), qt.IsNil)
+	c.Assert(closeTraceFSProbeEvent(kprobeType, pg, ksym), qt.IsNil)
 
 	args.group = rg
 	args.ret = true
@@ -308,7 +308,7 @@ func TestKprobeCreateTraceFS(t *testing.T) {
 		qt.Commentf("expected consecutive kretprobe creation to contain os.ErrExist, got: %v", err))
 
 	// Expect a successful close of the kretprobe.
-	c.Assert(closeTraceFSProbeEvent(kprobeType, rg, ksym, false), qt.IsNil)
+	c.Assert(closeTraceFSProbeEvent(kprobeType, rg, ksym), qt.IsNil)
 }
 
 func TestKprobeTraceFSGroup(t *testing.T) {

--- a/link/kprobe_test.go
+++ b/link/kprobe_test.go
@@ -235,13 +235,13 @@ func TestKprobeTraceFS(t *testing.T) {
 	args := probeArgs{group: "testgroup", symbol: "symbol"}
 
 	// Write a k(ret)probe event for a non-existing symbol.
-	err = createTraceFSProbeEvent(kprobeType, args)
+	_, err = createTraceFSProbeEvent(kprobeType, args)
 	c.Assert(errors.Is(err, os.ErrNotExist), qt.IsTrue, qt.Commentf("got error: %s", err))
 
 	// A kernel bug was fixed in 97c753e62e6c where EINVAL was returned instead
 	// of ENOENT, but only for kretprobes.
 	args.ret = true
-	err = createTraceFSProbeEvent(kprobeType, args)
+	_, err = createTraceFSProbeEvent(kprobeType, args)
 	if !(errors.Is(err, os.ErrNotExist) || errors.Is(err, unix.EINVAL)) {
 		t.Fatal(err)
 	}
@@ -284,12 +284,12 @@ func TestKprobeCreateTraceFS(t *testing.T) {
 	args := probeArgs{group: pg, symbol: ksym}
 
 	// Create a kprobe.
-	err := createTraceFSProbeEvent(kprobeType, args)
+	_, err := createTraceFSProbeEvent(kprobeType, args)
 	c.Assert(err, qt.IsNil)
 
 	// Attempt to create an identical kprobe using tracefs,
 	// expect it to fail with os.ErrExist.
-	err = createTraceFSProbeEvent(kprobeType, args)
+	_, err = createTraceFSProbeEvent(kprobeType, args)
 	c.Assert(errors.Is(err, os.ErrExist), qt.IsTrue,
 		qt.Commentf("expected consecutive kprobe creation to contain os.ErrExist, got: %v", err))
 
@@ -300,10 +300,10 @@ func TestKprobeCreateTraceFS(t *testing.T) {
 	args.ret = true
 
 	// Same test for a kretprobe.
-	err = createTraceFSProbeEvent(kprobeType, args)
+	_, err = createTraceFSProbeEvent(kprobeType, args)
 	c.Assert(err, qt.IsNil)
 
-	err = createTraceFSProbeEvent(kprobeType, args)
+	_, err = createTraceFSProbeEvent(kprobeType, args)
 	c.Assert(os.IsExist(err), qt.IsFalse,
 		qt.Commentf("expected consecutive kretprobe creation to contain os.ErrExist, got: %v", err))
 

--- a/link/kprobe_test.go
+++ b/link/kprobe_test.go
@@ -83,7 +83,7 @@ func TestKretprobeMaxActive(t *testing.T) {
 		k.Close()
 	}
 
-	k, err = Kretprobe("do_sys_open", prog, &KprobeOptions{RetprobeMaxActive: 4096})
+	k, err = Kretprobe("__put_task_struct", prog, &KprobeOptions{RetprobeMaxActive: 4096})
 	if err != nil {
 		if testutils.MustKernelVersion().Less(internal.Version{4, 12, 0}) {
 			if !errors.Is(err, ErrNotSupported) {
@@ -286,7 +286,7 @@ func TestKprobeCreateTraceFS(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 
 	// Attempt to create an identical kprobe using tracefs,
-	// expect it to fail with os.ErrExist.
+	// expect it to fail with 'trace event already exists:group/symbol'.
 	_, err = createTraceFSProbeEvent(kprobeType, args)
 	errMsg := fmt.Sprintf("trace event already exists: %s/%s", args.group, args.symbol)
 	c.Assert(strings.Contains(err.Error(), errMsg), qt.IsTrue,

--- a/link/perf_event.go
+++ b/link/perf_event.go
@@ -93,12 +93,12 @@ func (pe *perfEvent) Close() error {
 	case kprobeEvent, kretprobeEvent:
 		// Clean up kprobe tracefs entry.
 		if pe.tracefsID != 0 {
-			return closeTraceFSProbeEvent(kprobeType, pe.group, pe.name, false)
+			return closeTraceFSProbeEvent(kprobeType, pe.group, pe.name)
 		}
 	case uprobeEvent, uretprobeEvent:
 		// Clean up uprobe tracefs entry.
 		if pe.tracefsID != 0 {
-			return closeTraceFSProbeEvent(uprobeType, pe.group, pe.name, false)
+			return closeTraceFSProbeEvent(uprobeType, pe.group, pe.name)
 		}
 	case tracepointEvent:
 		// Tracepoint trace events don't hold any extra resources.

--- a/link/perf_event.go
+++ b/link/perf_event.go
@@ -93,12 +93,12 @@ func (pe *perfEvent) Close() error {
 	case kprobeEvent, kretprobeEvent:
 		// Clean up kprobe tracefs entry.
 		if pe.tracefsID != 0 {
-			return closeTraceFSProbeEvent(kprobeType, pe.group, pe.name)
+			return closeTraceFSProbeEvent(kprobeType, pe.group, pe.name, false)
 		}
 	case uprobeEvent, uretprobeEvent:
 		// Clean up uprobe tracefs entry.
 		if pe.tracefsID != 0 {
-			return closeTraceFSProbeEvent(uprobeType, pe.group, pe.name)
+			return closeTraceFSProbeEvent(uprobeType, pe.group, pe.name, false)
 		}
 	case tracepointEvent:
 		// Tracepoint trace events don't hold any extra resources.
@@ -272,7 +272,7 @@ func getTraceEventID(group, name string) (uint64, error) {
 	name = sanitizeSymbol(name)
 	tid, err := uint64FromFile(tracefsPath, "events", group, name, "id")
 	if errors.Is(err, os.ErrNotExist) {
-		return 0, fmt.Errorf("trace event %s/%s: %w", group, name, os.ErrNotExist)
+		return 0, err
 	}
 	if err != nil {
 		return 0, fmt.Errorf("reading trace event ID of %s/%s: %w", group, name, err)

--- a/link/uprobe_test.go
+++ b/link/uprobe_test.go
@@ -278,12 +278,12 @@ func TestUprobeCreateTraceFS(t *testing.T) {
 	}
 
 	// Create a uprobe.
-	err = createTraceFSProbeEvent(uprobeType, args)
+	_, err = createTraceFSProbeEvent(uprobeType, args)
 	c.Assert(err, qt.IsNil)
 
 	// Attempt to create an identical uprobe using tracefs,
 	// expect it to fail with os.ErrExist.
-	err = createTraceFSProbeEvent(uprobeType, args)
+	_, err = createTraceFSProbeEvent(uprobeType, args)
 	c.Assert(errors.Is(err, os.ErrExist), qt.IsTrue,
 		qt.Commentf("expected consecutive uprobe creation to contain os.ErrExist, got: %v", err))
 
@@ -294,10 +294,10 @@ func TestUprobeCreateTraceFS(t *testing.T) {
 	args.ret = true
 
 	// Same test for a kretprobe.
-	err = createTraceFSProbeEvent(uprobeType, args)
+	_, err = createTraceFSProbeEvent(uprobeType, args)
 	c.Assert(err, qt.IsNil)
 
-	err = createTraceFSProbeEvent(uprobeType, args)
+	_, err = createTraceFSProbeEvent(uprobeType, args)
 	c.Assert(os.IsExist(err), qt.IsFalse,
 		qt.Commentf("expected consecutive uretprobe creation to contain os.ErrExist, got: %v", err))
 

--- a/link/uprobe_test.go
+++ b/link/uprobe_test.go
@@ -265,8 +265,8 @@ func TestUprobeCreateTraceFS(t *testing.T) {
 
 	// Tee up cleanups in case any of the Asserts abort the function.
 	defer func() {
-		_ = closeTraceFSProbeEvent(uprobeType, pg, ssym)
-		_ = closeTraceFSProbeEvent(uprobeType, rg, ssym)
+		_ = closeTraceFSProbeEvent(uprobeType, pg, ssym, false)
+		_ = closeTraceFSProbeEvent(uprobeType, rg, ssym, false)
 	}()
 
 	// Prepare probe args.
@@ -288,7 +288,7 @@ func TestUprobeCreateTraceFS(t *testing.T) {
 		qt.Commentf("expected consecutive uprobe creation to contain os.ErrExist, got: %v", err))
 
 	// Expect a successful close of the kprobe.
-	c.Assert(closeTraceFSProbeEvent(uprobeType, pg, ssym), qt.IsNil)
+	c.Assert(closeTraceFSProbeEvent(uprobeType, pg, ssym, false), qt.IsNil)
 
 	args.group = rg
 	args.ret = true
@@ -302,7 +302,7 @@ func TestUprobeCreateTraceFS(t *testing.T) {
 		qt.Commentf("expected consecutive uretprobe creation to contain os.ErrExist, got: %v", err))
 
 	// Expect a successful close of the uretprobe.
-	c.Assert(closeTraceFSProbeEvent(uprobeType, rg, ssym), qt.IsNil)
+	c.Assert(closeTraceFSProbeEvent(uprobeType, rg, ssym, false), qt.IsNil)
 }
 
 func TestUprobeSanitizedSymbol(t *testing.T) {

--- a/link/uprobe_test.go
+++ b/link/uprobe_test.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"os/exec"
 	"path"
-	"strings"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
@@ -278,11 +277,10 @@ func TestUprobeCreateTraceFS(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 
 	// Attempt to create an identical uprobe using tracefs,
-	// expect it to fail with 'trace event already exists:group/symbol'.
+	// expect it to fail with os.ErrExist.
 	_, err = createTraceFSProbeEvent(uprobeType, args)
-	errMsg := fmt.Sprintf("trace event already exists: %s/%s", args.group, args.symbol)
-	c.Assert(strings.Contains(err.Error(), errMsg), qt.IsTrue,
-		qt.Commentf("expected consecutive uprobe creation to contain: %s, got: %v", errMsg, err))
+	c.Assert(errors.Is(err, os.ErrExist), qt.IsTrue,
+		qt.Commentf("expected consecutive uprobe creation to contain os.ErrExist, got: %v", err))
 
 	// Expect a successful close of the uprobe.
 	c.Assert(closeTraceFSProbeEvent(uprobeType, pg, ssym), qt.IsNil)
@@ -295,9 +293,8 @@ func TestUprobeCreateTraceFS(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 
 	_, err = createTraceFSProbeEvent(uprobeType, args)
-	errMsg = fmt.Sprintf("trace event already exists: %s/%s", args.group, args.symbol)
-	c.Assert(strings.Contains(err.Error(), errMsg), qt.IsTrue,
-		qt.Commentf("expected consecutive uretprobe creation to contain: %s, got: %v", errMsg, err))
+	c.Assert(os.IsExist(err), qt.IsFalse,
+		qt.Commentf("expected consecutive uretprobe creation to contain os.ErrExist, got: %v", err))
 
 	// Expect a successful close of the uretprobe.
 	c.Assert(closeTraceFSProbeEvent(uprobeType, rg, ssym), qt.IsNil)

--- a/link/uprobe_test.go
+++ b/link/uprobe_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"strings"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
@@ -245,12 +246,7 @@ func TestUprobeTraceFS(t *testing.T) {
 }
 
 // Test u(ret)probe creation writing directly to <tracefs>/uprobe_events.
-// Only runs on 5.0 and over. Earlier versions ignored writes of duplicate
-// events, while 5.0 started returning -EEXIST when a uprobe event already
-// exists.
 func TestUprobeCreateTraceFS(t *testing.T) {
-	testutils.SkipOnOldKernel(t, "5.0", "<tracefs>/uprobe_events doesn't reject duplicate events")
-
 	c := qt.New(t)
 
 	// Fetch the offset from the /bin/bash Executable already defined.
@@ -282,12 +278,13 @@ func TestUprobeCreateTraceFS(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 
 	// Attempt to create an identical uprobe using tracefs,
-	// expect it to fail with os.ErrExist.
+	// expect it to fail with 'trace event already exists:group/symbol'.
 	_, err = createTraceFSProbeEvent(uprobeType, args)
-	c.Assert(errors.Is(err, os.ErrExist), qt.IsTrue,
-		qt.Commentf("expected consecutive uprobe creation to contain os.ErrExist, got: %v", err))
+	errMsg := fmt.Sprintf("trace event already exists: %s/%s", args.group, args.symbol)
+	c.Assert(strings.Contains(err.Error(), errMsg), qt.IsTrue,
+		qt.Commentf("expected consecutive uprobe creation to contain: %s, got: %v", errMsg, err))
 
-	// Expect a successful close of the kprobe.
+	// Expect a successful close of the uprobe.
 	c.Assert(closeTraceFSProbeEvent(uprobeType, pg, ssym), qt.IsNil)
 
 	args.group = rg
@@ -298,8 +295,9 @@ func TestUprobeCreateTraceFS(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 
 	_, err = createTraceFSProbeEvent(uprobeType, args)
-	c.Assert(os.IsExist(err), qt.IsFalse,
-		qt.Commentf("expected consecutive uretprobe creation to contain os.ErrExist, got: %v", err))
+	errMsg = fmt.Sprintf("trace event already exists: %s/%s", args.group, args.symbol)
+	c.Assert(strings.Contains(err.Error(), errMsg), qt.IsTrue,
+		qt.Commentf("expected consecutive uretprobe creation to contain: %s, got: %v", errMsg, err))
 
 	// Expect a successful close of the uretprobe.
 	c.Assert(closeTraceFSProbeEvent(uprobeType, rg, ssym), qt.IsNil)

--- a/link/uprobe_test.go
+++ b/link/uprobe_test.go
@@ -265,8 +265,8 @@ func TestUprobeCreateTraceFS(t *testing.T) {
 
 	// Tee up cleanups in case any of the Asserts abort the function.
 	defer func() {
-		_ = closeTraceFSProbeEvent(uprobeType, pg, ssym, false)
-		_ = closeTraceFSProbeEvent(uprobeType, rg, ssym, false)
+		_ = closeTraceFSProbeEvent(uprobeType, pg, ssym)
+		_ = closeTraceFSProbeEvent(uprobeType, rg, ssym)
 	}()
 
 	// Prepare probe args.
@@ -288,7 +288,7 @@ func TestUprobeCreateTraceFS(t *testing.T) {
 		qt.Commentf("expected consecutive uprobe creation to contain os.ErrExist, got: %v", err))
 
 	// Expect a successful close of the kprobe.
-	c.Assert(closeTraceFSProbeEvent(uprobeType, pg, ssym, false), qt.IsNil)
+	c.Assert(closeTraceFSProbeEvent(uprobeType, pg, ssym), qt.IsNil)
 
 	args.group = rg
 	args.ret = true
@@ -302,7 +302,7 @@ func TestUprobeCreateTraceFS(t *testing.T) {
 		qt.Commentf("expected consecutive uretprobe creation to contain os.ErrExist, got: %v", err))
 
 	// Expect a successful close of the uretprobe.
-	c.Assert(closeTraceFSProbeEvent(uprobeType, rg, ssym, false), qt.IsNil)
+	c.Assert(closeTraceFSProbeEvent(uprobeType, rg, ssym), qt.IsNil)
 }
 
 func TestUprobeSanitizedSymbol(t *testing.T) {


### PR DESCRIPTION
In some case we want to missed as little as possible and
it is helpful to have this configuration option.