### PR TITLE
epoll deadline fixups

### DIFF
--- a/perf/reader.go
+++ b/perf/reader.go
@@ -304,7 +304,7 @@ func (pr *Reader) SetDeadline(t time.Time) {
 //
 // Calling Close interrupts the function.
 //
-// If SetDeadline the Read deadline, Read might return os.ErrDeadlineExceeded.
+// Returns os.ErrDeadlineExceeded if a deadline was set.
 func (pr *Reader) Read() (Record, error) {
 	var r Record
 	return r, pr.ReadInto(&r)


### PR DESCRIPTION
ringbuf: add SetDeadline

    Analogous to perf.Reader, add ringbuf.Reader.SetDeadline.

ringbuf: stop leaking a goroutine during tests

perf: add test for Reader.SetDeadline

epoll: correctly handle out of bounds deadlines

    Explicitly check for deadlines in the past and far future.