### PR TITLE
feature: define `sys.MapFlags` and re-export it for map flags feature detection

### DIFF
--- a/features/map.go
+++ b/features/map.go
@@ -164,9 +164,10 @@ func isStorageMap(mt ebpf.MapType) bool {
 	return false
 }
 
-// MapFlags indicates the flags passed to the kernel during map creation
+// MapFlags document which flags may be feature probed.
 type MapFlags = sys.MapFlags
 
+// Flags which may be feature probed.
 const (
 	BPF_F_NO_PREALLOC MapFlags = unix.BPF_F_NO_PREALLOC
 	BPF_F_RDONLY_PROG MapFlags = unix.BPF_F_RDONLY_PROG
@@ -177,6 +178,7 @@ const (
 
 // HaveMapFlag probes the running kernel for the availability of the specified map flag.
 //
+// Returns an error if flag is not one of the flags declared in this package.
 // See the package documentation for the meaning of the error return value.
 func HaveMapFlag(flag MapFlags) (err error) {
 	defer func() {

--- a/features/map.go
+++ b/features/map.go
@@ -13,7 +13,7 @@ import (
 
 func init() {
 	mc.mapTypes = make(map[ebpf.MapType]error)
-	mc.mapFlags = make(map[uint32]error)
+	mc.mapFlags = make(map[MapFlags]error)
 }
 
 var (
@@ -23,7 +23,7 @@ var (
 type mapCache struct {
 	sync.Mutex
 	mapTypes map[ebpf.MapType]error
-	mapFlags map[uint32]error
+	mapFlags map[MapFlags]error
 }
 
 func createMapTypeAttr(mt ebpf.MapType) *sys.MapCreateAttr {
@@ -164,10 +164,21 @@ func isStorageMap(mt ebpf.MapType) bool {
 	return false
 }
 
+// MapFlags indicates the flags passed to the kernel during map creation
+type MapFlags = sys.MapFlags
+
+const (
+	BPF_F_NO_PREALLOC MapFlags = unix.BPF_F_NO_PREALLOC
+	BPF_F_RDONLY_PROG MapFlags = unix.BPF_F_RDONLY_PROG
+	BPF_F_WRONLY_PROG MapFlags = unix.BPF_F_WRONLY_PROG
+	BPF_F_MMAPABLE    MapFlags = unix.BPF_F_MMAPABLE
+	BPF_F_INNER_MAP   MapFlags = unix.BPF_F_INNER_MAP
+)
+
 // HaveMapFlag probes the running kernel for the availability of the specified map flag.
 //
 // See the package documentation for the meaning of the error return value.
-func HaveMapFlag(flag uint32) (err error) {
+func HaveMapFlag(flag MapFlags) (err error) {
 	defer func() {
 		// This closure modifies a named return variable.
 		err = wrapProbeErrors(err)
@@ -176,7 +187,7 @@ func HaveMapFlag(flag uint32) (err error) {
 	return haveMapFlag(flag)
 }
 
-func haveMapFlag(flag uint32) error {
+func haveMapFlag(flag MapFlags) error {
 	mc.Lock()
 	defer mc.Unlock()
 	err, ok := mc.mapFlags[flag]
@@ -204,7 +215,7 @@ func haveMapFlag(flag uint32) error {
 	return err
 }
 
-func createMapFlagTypeAttr(flag uint32) (*sys.MapCreateAttr, error) {
+func createMapFlagTypeAttr(flag MapFlags) (*sys.MapCreateAttr, error) {
 	a := &sys.MapCreateAttr{
 		KeySize:    4,
 		ValueSize:  4,

--- a/features/map_test.go
+++ b/features/map_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/internal/testutils"
-	"github.com/cilium/ebpf/internal/unix"
 )
 
 var mapTypeMinVersion = map[ebpf.MapType]string{
@@ -66,18 +65,18 @@ func TestHaveMapType(t *testing.T) {
 }
 
 type haveMapFlagsTestEntry struct {
-	flags            uint32
+	flags            MapFlags
 	minKernelVersion string
 	description      string
 }
 
 func TestHaveMapFlag(t *testing.T) {
 	mapFlagTestEntries := []haveMapFlagsTestEntry{
-		{unix.BPF_F_RDONLY_PROG, "5.2", "read_only_array_map"},
-		{unix.BPF_F_WRONLY_PROG, "5.2", "write_only_array_map"},
-		{unix.BPF_F_MMAPABLE, "5.5", "mmapable_array_map"},
-		{unix.BPF_F_INNER_MAP, "5.10", "inner_map_array_map"},
-		{unix.BPF_F_NO_PREALLOC, "4.6", "no_prealloc_hash_map"},
+		{BPF_F_RDONLY_PROG, "5.2", "read_only_array_map"},
+		{BPF_F_WRONLY_PROG, "5.2", "write_only_array_map"},
+		{BPF_F_MMAPABLE, "5.5", "mmapable_array_map"},
+		{BPF_F_INNER_MAP, "5.10", "inner_map_array_map"},
+		{BPF_F_NO_PREALLOC, "4.6", "no_prealloc_hash_map"},
 	}
 
 	for _, entry := range mapFlagTestEntries {

--- a/info.go
+++ b/info.go
@@ -48,7 +48,7 @@ func newMapInfoFromFd(fd *sys.FD) (*MapInfo, error) {
 		info.KeySize,
 		info.ValueSize,
 		info.MaxEntries,
-		info.MapFlags,
+		uint32(info.MapFlags),
 		unix.ByteSliceToString(info.Name[:]),
 	}, nil
 }

--- a/internal/cmd/gentypes/main.go
+++ b/internal/cmd/gentypes/main.go
@@ -121,7 +121,6 @@ import (
 		{"HdrStartOff", "bpf_hdr_start_off"},
 		{"RetCode", "bpf_ret_code"},
 		{"XdpAction", "xdp_action"},
-		{"MapFlags", ""},
 	}
 
 	sort.Slice(enums, func(i, j int) bool {
@@ -132,16 +131,9 @@ import (
 	for _, o := range enums {
 		fmt.Println("enum", o.goType)
 
-		var t btf.Type
-		if o.cType != "" {
-			var enumTy *btf.Enum
-			if err := spec.TypeByName(o.cType, &enumTy); err != nil {
-				return nil, err
-			}
-			t = enumTy
-		} else {
-			// in the case of an anonymous enum, we default to an uin32
-			t = &btf.Int{Size: 4}
+		var t *btf.Enum
+		if err := spec.TypeByName(o.cType, &t); err != nil {
+			return nil, err
 		}
 
 		// Add the enum as a predeclared type so that generated structs

--- a/internal/sys/syscall.go
+++ b/internal/sys/syscall.go
@@ -110,6 +110,9 @@ type LinkID uint32
 // BTFID uniquely identifies a BTF blob loaded into the kernel.
 type BTFID uint32
 
+// MapFlags control map behaviour.
+type MapFlags uint32
+
 // wrappedErrno wraps syscall.Errno to prevent direct comparisons with
 // syscall.E* or unix.E* constants.
 //

--- a/internal/sys/types.go
+++ b/internal/sys/types.go
@@ -326,6 +326,7 @@ const (
 	MAX_BPF_LINK_TYPE            LinkType = 9
 )
 
+type MapFlags uint32
 type MapType int32
 
 const (
@@ -474,7 +475,7 @@ type MapInfo struct {
 	KeySize               uint32
 	ValueSize             uint32
 	MaxEntries            uint32
-	MapFlags              uint32
+	MapFlags              MapFlags
 	Name                  ObjName
 	Ifindex               uint32
 	BtfVmlinuxValueTypeId uint32
@@ -680,7 +681,7 @@ type MapCreateAttr struct {
 	KeySize               uint32
 	ValueSize             uint32
 	MaxEntries            uint32
-	MapFlags              uint32
+	MapFlags              MapFlags
 	InnerMapFd            uint32
 	NumaNode              uint32
 	MapName               ObjName

--- a/internal/sys/types.go
+++ b/internal/sys/types.go
@@ -326,7 +326,6 @@ const (
 	MAX_BPF_LINK_TYPE            LinkType = 9
 )
 
-type MapFlags uint32
 type MapType int32
 
 const (

--- a/map.go
+++ b/map.go
@@ -413,7 +413,7 @@ func (spec *MapSpec) createMap(inner *sys.FD, opts MapOptions, handles *handleCa
 		KeySize:    spec.KeySize,
 		ValueSize:  spec.ValueSize,
 		MaxEntries: spec.MaxEntries,
-		MapFlags:   spec.Flags,
+		MapFlags:   sys.MapFlags(spec.Flags),
 		NumaNode:   spec.NumaNode,
 	}
 


### PR DESCRIPTION
As requested in https://github.com/cilium/ebpf/pull/673 this PR defines a new internal type `sys.MapFlags` describing the different map flags constant, and use a re-exported version of it as the type argument for `HaveMapFlag` feature detection API