### PR TITLE
bpf2go: add flag for alternative filename stem

### DIFF
--- a/cmd/bpf2go/main.go
+++ b/cmd/bpf2go/main.go
@@ -81,6 +81,7 @@ func run(stdout io.Writer, pkg, outputDir string, args []string) (err error) {
 	fs.StringVar(&b2g.makeBase, "makebase", "", "write make compatible depinfo files relative to `directory`")
 	fs.Var(&b2g.cTypes, "type", "`Name` of a type to generate a Go declaration for, may be repeated")
 	fs.BoolVar(&b2g.skipGlobalTypes, "no-global-types", false, "Skip generating types for map keys and values, etc.")
+	fs.StringVar(&b2g.outputStem, "output-stem", "", "alternative stem for names of generated files (defaults to ident)")
 
 	fs.SetOutput(stdout)
 	fs.Usage = func() {
@@ -150,6 +151,10 @@ func run(stdout io.Writer, pkg, outputDir string, args []string) (err error) {
 		if err != nil {
 			return err
 		}
+	}
+
+	if b2g.outputStem != "" && strings.ContainsRune(b2g.outputStem, filepath.Separator) {
+		return fmt.Errorf("-output-stem %q must not contain path separation characters", b2g.outputStem)
 	}
 
 	if strings.ContainsRune(b2g.tags, '\n') {
@@ -240,6 +245,8 @@ type bpf2go struct {
 	sourceFile string
 	// Absolute path to a directory where .go are written
 	outputDir string
+	// Alternative output stem. If empty, ident is used.
+	outputStem string
 	// Valid go package name.
 	pkg string
 	// Valid go identifier.
@@ -269,9 +276,13 @@ func (b2g *bpf2go) convert(tgt target, arches []string) (err error) {
 		f.Close()
 	}
 
-	stem := fmt.Sprintf("%s_%s", strings.ToLower(b2g.ident), tgt.clang)
+	outputStem := b2g.outputStem
+	if outputStem == "" {
+		outputStem = strings.ToLower(b2g.ident)
+	}
+	stem := fmt.Sprintf("%s_%s", outputStem, tgt.clang)
 	if tgt.linux != "" {
-		stem = fmt.Sprintf("%s_%s_%s", strings.ToLower(b2g.ident), tgt.clang, tgt.linux)
+		stem = fmt.Sprintf("%s_%s_%s", outputStem, tgt.clang, tgt.linux)
 	}
 
 	objFileName := filepath.Join(b2g.outputDir, stem+".o")


### PR DESCRIPTION
In our project, the eBPF source files are named with underscores, like `ext_vx_decap.c`. We want to have the .go and .o files generated by bpf2go to follow the same naming scheme (e.g. `ext_vx_decap_bpfel.go`). But currently, when setting the `<ident>` parameter to `ext_vx_decap`, the result will be some broken Go type names like `type ext_vx_decapPrograms`

So instead, this PR adds a new `-filename-stem` flag, which allows specifying an alternative filename prefix while one can keep the `ident` as it is supposed to.
The `-filename-stem` flag is optional and if it's not set, the `ident` will be used instead. So this is not a breaking change.

Sample usage:
```
bpf2go [...] -filename-stem ext_vx_decap ExtVxDecap src/ext_vx_decap.c
```