### PR TITLE
cmd/bpf2go: clarify -target usage with bpf_tracing.h

### DIFF
--- a/cmd/bpf2go/compile.go
+++ b/cmd/bpf2go/compile.go
@@ -66,7 +66,7 @@ func compile(args compileArgs) error {
 		"-fdebug-compilation-dir", ".",
 		// We always want BTF to be generated, so enforce debug symbols
 		"-g",
-		fmt.Sprintf("-D__BPF_TARGET_MISSING=%q", "GCC error \"The eBPF is using target specific macros, please provide -target\""),
+		fmt.Sprintf("-D__BPF_TARGET_MISSING=%q", "GCC error \"The eBPF is using target specific macros, please provide -target that is not bpf, bpfel or bpfeb\""),
 	)
 	cmd.Dir = args.dir
 

--- a/cmd/bpf2go/main.go
+++ b/cmd/bpf2go/main.go
@@ -77,7 +77,7 @@ func run(stdout io.Writer, pkg, outputDir string, args []string) (err error) {
 	fs.BoolVar(&b2g.disableStripping, "no-strip", false, "disable stripping of DWARF")
 	flagCFlags := fs.String("cflags", "", "flags passed to the compiler, may contain quoted arguments")
 	fs.StringVar(&b2g.tags, "tags", "", "list of Go build tags to include in generated files")
-	flagTarget := fs.String("target", "bpfel,bpfeb", "clang target to compile for")
+	flagTarget := fs.String("target", "bpfel,bpfeb", "clang target(s) to compile for (comma separated)")
 	fs.StringVar(&b2g.makeBase, "makebase", "", "write make compatible depinfo files relative to `directory`")
 	fs.Var(&b2g.cTypes, "type", "`Name` of a type to generate a Go declaration for, may be repeated")
 	fs.BoolVar(&b2g.skipGlobalTypes, "no-global-types", false, "Skip generating types for map keys and values, etc.")


### PR DESCRIPTION
Using tracing macros like PT_REGS_PARM1 causes an error when compiling for
generic targets bpf, bpfel and bpfeb:

    offcpu.c:33:41: error: The eBPF is using target specific macros, please provide -target

This is confusing if the user already provides "-target bpfel" or similar.
Clarify that specific arch has to be selected for tracing to work.

See #772 