### PR TITLE
link: memoize PMU event types read from sysfs

### DIFF
--- a/link/kprobe_test.go
+++ b/link/kprobe_test.go
@@ -307,19 +307,6 @@ func TestKprobeTraceFSGroup(t *testing.T) {
 	c.Assert(err, qt.Not(qt.IsNil))
 }
 
-func TestDetermineRetprobeBit(t *testing.T) {
-	testutils.SkipOnOldKernel(t, "4.17", "perf_kprobe PMU")
-	c := qt.New(t)
-
-	rpk, err := kretprobeBit()
-	c.Assert(err, qt.IsNil)
-	c.Assert(rpk, qt.Equals, uint64(0))
-
-	rpu, err := uretprobeBit()
-	c.Assert(err, qt.IsNil)
-	c.Assert(rpu, qt.Equals, uint64(0))
-}
-
 func TestKprobeProgramCall(t *testing.T) {
 	m, p := newUpdaterMapProg(t, ebpf.Kprobe)
 

--- a/link/perf_event_test.go
+++ b/link/perf_event_test.go
@@ -2,27 +2,11 @@ package link
 
 import (
 	"errors"
-	"os"
 	"testing"
 
 	"github.com/cilium/ebpf/internal/testutils"
 	qt "github.com/frankban/quicktest"
 )
-
-func TestTraceEventTypePMU(t *testing.T) {
-	// Requires at least 4.17 (e12f03d7031a "perf/core: Implement the 'perf_kprobe' PMU")
-	testutils.SkipOnOldKernel(t, "4.17", "perf_kprobe PMU")
-
-	c := qt.New(t)
-
-	et, err := getPMUEventType(kprobeType)
-	c.Assert(err, qt.IsNil)
-	c.Assert(et, qt.Not(qt.Equals), 0)
-
-	et, err = getPMUEventType(uprobeType)
-	c.Assert(err, qt.IsNil)
-	c.Assert(et, qt.Not(qt.Equals), 0)
-}
 
 func TestTraceEventID(t *testing.T) {
 	c := qt.New(t)
@@ -32,15 +16,15 @@ func TestTraceEventID(t *testing.T) {
 	c.Assert(eid, qt.Not(qt.Equals), 0)
 }
 
-func TestTraceReadID(t *testing.T) {
-	_, err := uint64FromFile("/base/path/", "../escaped")
+func TestSanitizePath(t *testing.T) {
+	_, err := sanitizePath("/base/path/", "../escaped")
 	if !errors.Is(err, errInvalidInput) {
 		t.Errorf("expected error %s, got: %s", errInvalidInput, err)
 	}
 
-	_, err = uint64FromFile("/base/path/not", "../not/escaped")
-	if !errors.Is(err, os.ErrNotExist) {
-		t.Errorf("expected os.ErrNotExist, got: %s", err)
+	_, err = sanitizePath("/base/path/not", "../not/escaped")
+	if err != nil {
+		t.Errorf("expected no error, got: %s", err)
 	}
 }
 

--- a/link/uprobe.go
+++ b/link/uprobe.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/internal"
@@ -15,12 +14,6 @@ import (
 
 var (
 	uprobeEventsPath = filepath.Join(tracefsPath, "uprobe_events")
-
-	uprobeRetprobeBit = struct {
-		once  sync.Once
-		value uint64
-		err   error
-	}{}
 
 	uprobeRefCtrOffsetPMUPath = "/sys/bus/event_source/devices/uprobe/format/ref_ctr_offset"
 	// elixir.bootlin.com/linux/v5.15-rc7/source/kernel/events/core.c#L9799
@@ -363,11 +356,4 @@ func uprobeToken(args probeArgs) string {
 	}
 
 	return po
-}
-
-func uretprobeBit() (uint64, error) {
-	uprobeRetprobeBit.once.Do(func() {
-		uprobeRetprobeBit.value, uprobeRetprobeBit.err = determineRetprobeBit(uprobeType)
-	})
-	return uprobeRetprobeBit.value, uprobeRetprobeBit.err
 }


### PR DESCRIPTION
Instead of parsing the same files over and over, read them once and store
the result. This cuts down on unnecessary file I/O.

Fixes #744