### PR TITLE
may uint128 to [16]byte

### DIFF
--- a/btf/format.go
+++ b/btf/format.go
@@ -182,8 +182,7 @@ func (gf *GoFormatter) writeIntLit(i *Int) error {
 		// we are dealing with unsigned, since this works nicely with []byte
 		// in Go code.
 		fallthrough
-	case Unsigned:
-	case Signed:
+	case Unsigned, Signed:
 		stem := "uint"
 		if i.Encoding == Signed {
 			stem = "int"

--- a/btf/format.go
+++ b/btf/format.go
@@ -175,7 +175,11 @@ func (gf *GoFormatter) writeIntLit(i *Int) error {
 		}
 		gf.w.WriteString("bool")
 	case Signed:
-		fmt.Fprintf(&gf.w, "int%d", bits)
+		if i.Size > 8 {
+			fmt.Fprintf(&gf.w, "[%d]byte /* int%d */", i.Size, i.Size*8)
+		} else {
+			fmt.Fprintf(&gf.w, "int%d", bits)
+		}
 	case Char:
 		if i.Size != 1 {
 			return fmt.Errorf("char with size %d", i.Size)
@@ -185,7 +189,11 @@ func (gf *GoFormatter) writeIntLit(i *Int) error {
 		// in Go code.
 		fallthrough
 	case Unsigned:
-		fmt.Fprintf(&gf.w, "uint%d", bits)
+		if i.Size > 8 {
+			fmt.Fprintf(&gf.w, "[%d]byte /* uint%d */", i.Size, i.Size*8)
+		} else {
+			fmt.Fprintf(&gf.w, "uint%d", bits)
+		}
 	default:
 		return fmt.Errorf("can't encode %s", i.Encoding)
 	}

--- a/btf/format.go
+++ b/btf/format.go
@@ -174,12 +174,6 @@ func (gf *GoFormatter) writeIntLit(i *Int) error {
 			return fmt.Errorf("bool with size %d", i.Size)
 		}
 		gf.w.WriteString("bool")
-	case Signed:
-		if i.Size > 8 {
-			fmt.Fprintf(&gf.w, "[%d]byte /* int%d */", i.Size, i.Size*8)
-		} else {
-			fmt.Fprintf(&gf.w, "int%d", bits)
-		}
 	case Char:
 		if i.Size != 1 {
 			return fmt.Errorf("char with size %d", i.Size)
@@ -189,10 +183,15 @@ func (gf *GoFormatter) writeIntLit(i *Int) error {
 		// in Go code.
 		fallthrough
 	case Unsigned:
+	case Signed:
+		stem := "uint"
+		if i.Encoding == Signed {
+			stem = "int"
+		}
 		if i.Size > 8 {
-			fmt.Fprintf(&gf.w, "[%d]byte /* uint%d */", i.Size, i.Size*8)
+			fmt.Fprintf(&gf.w, "[%d]byte /* %s%d */", i.Size, stem, i.Size*8)
 		} else {
-			fmt.Fprintf(&gf.w, "uint%d", bits)
+			fmt.Fprintf(&gf.w, "%s%d", stem, bits)
 		}
 	default:
 		return fmt.Errorf("can't encode %s", i.Encoding)

--- a/btf/format_test.go
+++ b/btf/format_test.go
@@ -20,7 +20,7 @@ func TestGoTypeDeclaration(t *testing.T) {
 		{&Int{Size: 4, Encoding: Signed}, "type t int32"},
 		{&Int{Size: 8}, "type t uint64"},
 		{&Typedef{Name: "frob", Type: &Int{Size: 8}}, "type t uint64"},
-		{&Int{Size: 16}, "type t uint128"},
+		{&Int{Size: 16}, "type t [16]byte /* uint128 */"},
 		{&Enum{Values: []EnumValue{{"FOO", 32}}, Size: 4}, "type t uint32; const ( tFOO t = 32; )"},
 		{&Enum{Values: []EnumValue{{"BAR", 1}}, Size: 1, Signed: true}, "type t int8; const ( tBAR t = 1; )"},
 		{


### PR DESCRIPTION
When using **uint128** in ebpf, it was escaping golang's **uint128** which was obviously incorrect, so a temporary solution was added to convert it to **[16]byte** instead. I am also testing further .... 