### PR TITLE
Fix haveProgTestRun on kernel version 5.15.65

### DIFF
--- a/prog.go
+++ b/prog.go
@@ -624,8 +624,12 @@ var haveProgTestRun = internal.FeatureTest("BPF_PROG_TEST_RUN", "4.12", func() e
 	}
 	defer prog.Close()
 
-	// Programs require at least 14 bytes input
-	in := make([]byte, 14)
+	// Programs require at least 15 bytes input
+	// Looking in net/bpf/test_run.c, bpf_test_init() requires that the input is
+	// at least ETH_HLEN (14) bytes.  A recent patch[0] also ensures that the skb
+	// is not empty after the layer 2 header is removed.
+	// [0]: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=fd1894224407c484f652ad456e1ce423e89bb3eb
+	in := make([]byte, 15)
 	attr := sys.ProgRunAttr{
 		ProgFd:     uint32(prog.FD()),
 		DataSizeIn: uint32(len(in)),


### PR DESCRIPTION
A recent patch[0] to the kernel prevents bpf_prog_test_run_skb() from running the bpf program with with an empty skb.  This makes the existing feature check fail, so to fix it an additional byte of input data is needed.

[0]: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=fd1894224407c484f652ad456e1ce423e89bb3eb

I tried tracing through the kernel code, and to be honest I'm only partially confident that I understand the issue.  I can't quite find the place where the `skb->len` is getting reset to zero, because before the call to `convert___skb_to_skb()` is a call to `__skb_put()` with the size of the input data.  The patch I linked is essentially a good guess at the root cause.

I am confident that this issue is introduced in 5.15.65 ([changelog](https://cdn.kernel.org/pub/linux/kernel/v5.x/ChangeLog-5.15.65)).
```
root@localhost:~/ebpf# uname -r
5.15.65
root@localhost:~/ebpf# go test -v -run=TestHaveProgTestRun ./...
=== RUN   TestHaveProgTestRun
    prog_test.go:539: Feature 'BPF_PROG_TEST_RUN' isn't supported even though kernel v5.15.65 is newer than v4.12
--- FAIL: TestHaveProgTestRun (0.00s)
```
I did take the time to build 5.15.64 and run the test above; it passed without this patch.

That test also passes on 5.15.65 with this patch applied.  It looks like the CI for this repo won't catch the issue because it is pinned to 5.15.19 ([ref](https://github.com/cilium/ci-kernels/blob/a821407449eedc9730fb9c7c702a9db14f2b3f7c/make.sh#L13)).