### PR TITLE
prep work for BTF marshaling

### DIFF
--- a/btf/core.go
+++ b/btf/core.go
@@ -873,8 +873,8 @@ func coreAreTypesCompatible(localType Type, targetType Type) error {
 
 		case *Pointer, *Array:
 			depth++
-			localType.walk(&localTs)
-			targetType.walk(&targetTs)
+			walkType(localType, localTs.push)
+			walkType(targetType, targetTs.push)
 
 		case *FuncProto:
 			tv := targetType.(*FuncProto)
@@ -883,8 +883,8 @@ func coreAreTypesCompatible(localType Type, targetType Type) error {
 			}
 
 			depth++
-			localType.walk(&localTs)
-			targetType.walk(&targetTs)
+			walkType(localType, localTs.push)
+			walkType(targetType, targetTs.push)
 
 		default:
 			return fmt.Errorf("unsupported type %T", localType)

--- a/btf/core.go
+++ b/btf/core.go
@@ -855,7 +855,7 @@ func coreAreTypesCompatible(localType Type, targetType Type) error {
 		depth             = 0
 	)
 
-	for ; l != nil && t != nil; l, t = localTs.shift(), targetTs.shift() {
+	for ; l != nil && t != nil; l, t = localTs.Shift(), targetTs.Shift() {
 		if depth >= maxTypeDepth {
 			return errors.New("types are nested too deep")
 		}
@@ -873,8 +873,8 @@ func coreAreTypesCompatible(localType Type, targetType Type) error {
 
 		case *Pointer, *Array:
 			depth++
-			walkType(localType, localTs.push)
-			walkType(targetType, targetTs.push)
+			walkType(localType, localTs.Push)
+			walkType(targetType, targetTs.Push)
 
 		case *FuncProto:
 			tv := targetType.(*FuncProto)
@@ -883,8 +883,8 @@ func coreAreTypesCompatible(localType Type, targetType Type) error {
 			}
 
 			depth++
-			walkType(localType, localTs.push)
-			walkType(targetType, targetTs.push)
+			walkType(localType, localTs.Push)
+			walkType(targetType, targetTs.Push)
 
 		default:
 			return fmt.Errorf("unsupported type %T", localType)

--- a/btf/core.go
+++ b/btf/core.go
@@ -156,16 +156,17 @@ func (k coreKind) String() string {
 	}
 }
 
-// CORERelocate calculates the difference in types between local and target.
+// CORERelocate calculates changes needed to adjust eBPF instructions for differences
+// in types.
 //
 // Returns a list of fixups which can be applied to instructions to make them
 // match the target type(s).
 //
 // Fixups are returned in the order of relos, e.g. fixup[i] is the solution
 // for relos[i].
-func CORERelocate(local, target *Spec, relos []*CORERelocation) ([]COREFixup, error) {
-	if local.byteOrder != target.byteOrder {
-		return nil, fmt.Errorf("can't relocate %s against %s", local.byteOrder, target.byteOrder)
+func CORERelocate(relos []*CORERelocation, target *Spec, bo binary.ByteOrder) ([]COREFixup, error) {
+	if bo != target.byteOrder {
+		return nil, fmt.Errorf("can't relocate %s against %s", bo, target.byteOrder)
 	}
 
 	type reloGroup struct {
@@ -185,15 +186,14 @@ func CORERelocate(local, target *Spec, relos []*CORERelocation) ([]COREFixup, er
 				return nil, fmt.Errorf("%s: unexpected accessor %v", relo.kind, relo.accessor)
 			}
 
-			id, err := local.TypeID(relo.typ)
-			if err != nil {
-				return nil, fmt.Errorf("%s: %w", relo.kind, err)
-			}
-
 			result[i] = COREFixup{
-				kind:   relo.kind,
-				local:  uint32(id),
-				target: uint32(id),
+				kind:  relo.kind,
+				local: uint32(relo.id),
+				// NB: Using relo.id as the target here is incorrect, since
+				// it doesn't match the BTF we generate on the fly. This isn't
+				// too bad for now since there are no uses of the local type ID
+				// in the kernel, yet.
+				target: uint32(relo.id),
 			}
 			continue
 		}
@@ -214,7 +214,7 @@ func CORERelocate(local, target *Spec, relos []*CORERelocation) ([]COREFixup, er
 		}
 
 		targets := target.namedTypes[newEssentialName(localTypeName)]
-		fixups, err := coreCalculateFixups(local, target, localType, targets, group.relos)
+		fixups, err := coreCalculateFixups(group.relos, target, targets, bo)
 		if err != nil {
 			return nil, fmt.Errorf("relocate %s: %w", localType, err)
 		}
@@ -230,18 +230,13 @@ func CORERelocate(local, target *Spec, relos []*CORERelocation) ([]COREFixup, er
 var errAmbiguousRelocation = errors.New("ambiguous relocation")
 var errImpossibleRelocation = errors.New("impossible relocation")
 
-// coreCalculateFixups calculates the fixups for the given relocations using
-// the "best" target.
+// coreCalculateFixups finds the target type that best matches all relocations.
+//
+// All relos must target the same type.
 //
 // The best target is determined by scoring: the less poisoning we have to do
 // the better the target is.
-func coreCalculateFixups(localSpec, targetSpec *Spec, local Type, targets []Type, relos []*CORERelocation) ([]COREFixup, error) {
-	localID, err := localSpec.TypeID(local)
-	if err != nil {
-		return nil, fmt.Errorf("local type ID: %w", err)
-	}
-	local = Copy(local, UnderlyingType)
-
+func coreCalculateFixups(relos []*CORERelocation, targetSpec *Spec, targets []Type, bo binary.ByteOrder) ([]COREFixup, error) {
 	bestScore := len(relos)
 	var bestFixups []COREFixup
 	for i := range targets {
@@ -254,7 +249,7 @@ func coreCalculateFixups(localSpec, targetSpec *Spec, local Type, targets []Type
 		score := 0 // lower is better
 		fixups := make([]COREFixup, 0, len(relos))
 		for _, relo := range relos {
-			fixup, err := coreCalculateFixup(localSpec.byteOrder, local, localID, target, targetID, relo)
+			fixup, err := coreCalculateFixup(relo, target, targetID, bo)
 			if err != nil {
 				return nil, fmt.Errorf("target %s: %w", target, err)
 			}
@@ -305,7 +300,7 @@ func coreCalculateFixups(localSpec, targetSpec *Spec, local Type, targets []Type
 
 // coreCalculateFixup calculates the fixup for a single local type, target type
 // and relocation.
-func coreCalculateFixup(byteOrder binary.ByteOrder, local Type, localID TypeID, target Type, targetID TypeID, relo *CORERelocation) (COREFixup, error) {
+func coreCalculateFixup(relo *CORERelocation, target Type, targetID TypeID, bo binary.ByteOrder) (COREFixup, error) {
 	fixup := func(local, target uint32) (COREFixup, error) {
 		return COREFixup{kind: relo.kind, local: local, target: target}, nil
 	}
@@ -319,6 +314,8 @@ func coreCalculateFixup(byteOrder binary.ByteOrder, local Type, localID TypeID, 
 		return COREFixup{kind: relo.kind, poison: true}, nil
 	}
 	zero := COREFixup{}
+
+	local := Copy(relo.typ, UnderlyingType)
 
 	switch relo.kind {
 	case reloTypeIDTarget, reloTypeSize, reloTypeExists:
@@ -339,7 +336,7 @@ func coreCalculateFixup(byteOrder binary.ByteOrder, local Type, localID TypeID, 
 			return fixup(1, 1)
 
 		case reloTypeIDTarget:
-			return fixup(uint32(localID), uint32(targetID))
+			return fixup(uint32(relo.id), uint32(targetID))
 
 		case reloTypeSize:
 			localSize, err := Sizeof(local)
@@ -427,7 +424,7 @@ func coreCalculateFixup(byteOrder binary.ByteOrder, local Type, localID TypeID, 
 
 		case reloFieldLShiftU64:
 			var target uint32
-			if byteOrder == binary.LittleEndian {
+			if bo == binary.LittleEndian {
 				targetSize, err := targetField.sizeBits()
 				if err != nil {
 					return zero, err

--- a/btf/core_test.go
+++ b/btf/core_test.go
@@ -546,7 +546,7 @@ func TestCORERelocation(t *testing.T) {
 					relos = append(relos, reloInfo.relo)
 				}
 
-				fixups, err := CORERelocate(spec, spec, relos)
+				fixups, err := CORERelocate(relos, spec, spec.byteOrder)
 				if want := errs[name]; want != nil {
 					if !errors.Is(err, want) {
 						t.Fatal("Expected", want, "got", err)

--- a/btf/ext_info.go
+++ b/btf/ext_info.go
@@ -605,9 +605,12 @@ type bpfCORERelo struct {
 }
 
 type CORERelocation struct {
+	// The local type of the relocation, stripped of typedefs and qualifiers.
 	typ      Type
 	accessor coreAccessor
 	kind     coreKind
+	// The ID of the local type in the source BTF.
+	id TypeID
 }
 
 func CORERelocationMetadata(ins *asm.Instruction) *CORERelocation {
@@ -641,6 +644,7 @@ func newRelocationInfo(relo bpfCORERelo, ts types, strings *stringTable) (*coreR
 			typ,
 			accessor,
 			relo.Kind,
+			relo.TypeID,
 		},
 		asm.RawInstructionOffset(relo.InsnOff),
 	}, nil

--- a/btf/traversal.go
+++ b/btf/traversal.go
@@ -1,0 +1,56 @@
+package btf
+
+import "fmt"
+
+// walkType calls fn on each child of typ.
+func walkType(typ Type, fn func(*Type)) {
+	// Explicitly type switch on the most common types to allow the inliner to
+	// do its work. This avoids allocating intermediate slices from walk() on
+	// the heap.
+	switch v := typ.(type) {
+	case *Void, *Int, *Enum, *Fwd, *Float:
+		// No children to traverse.
+	case *Pointer:
+		fn(&v.Target)
+	case *Array:
+		fn(&v.Index)
+		fn(&v.Type)
+	case *Struct:
+		for i := range v.Members {
+			fn(&v.Members[i].Type)
+		}
+	case *Union:
+		for i := range v.Members {
+			fn(&v.Members[i].Type)
+		}
+	case *Typedef:
+		fn(&v.Type)
+	case *Volatile:
+		fn(&v.Type)
+	case *Const:
+		fn(&v.Type)
+	case *Restrict:
+		fn(&v.Type)
+	case *Func:
+		fn(&v.Type)
+	case *FuncProto:
+		fn(&v.Return)
+		for i := range v.Params {
+			fn(&v.Params[i].Type)
+		}
+	case *Var:
+		fn(&v.Type)
+	case *Datasec:
+		for i := range v.Vars {
+			fn(&v.Vars[i].Type)
+		}
+	case *declTag:
+		fn(&v.Type)
+	case *typeTag:
+		fn(&v.Type)
+	case *cycle:
+		// cycle has children, but we ignore them deliberately.
+	default:
+		panic(fmt.Sprintf("don't know how to walk Type %T", v))
+	}
+}

--- a/btf/types.go
+++ b/btf/types.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 	"io"
 	"math"
-	"math/bits"
 	"reflect"
 	"strings"
 
 	"github.com/cilium/ebpf/asm"
+	"github.com/cilium/ebpf/internal"
 )
 
 const maxTypeDepth = 32
@@ -678,7 +678,7 @@ type copier map[Type]Type
 
 func (c copier) copy(typ *Type, transform Transformer) {
 	var work typeDeque
-	for t := typ; t != nil; t = work.pop() {
+	for t := typ; t != nil; t = work.Pop() {
 		// *t is the identity of the type.
 		if cpy := c[*t]; cpy != nil {
 			*t = cpy
@@ -696,97 +696,11 @@ func (c copier) copy(typ *Type, transform Transformer) {
 		*t = cpy
 
 		// Mark any nested types for copying.
-		walkType(cpy, work.push)
+		walkType(cpy, work.Push)
 	}
 }
 
-type typeDeque = deque[*Type]
-
-// deque implements a double ended queue.
-type deque[T any] struct {
-	elems       []T
-	read, write uint64
-	mask        uint64
-}
-
-func (dq *deque[T]) empty() bool {
-	return dq.read == dq.write
-}
-
-func (dq *deque[T]) remainingCap() int {
-	return len(dq.elems) - int(dq.write-dq.read)
-}
-
-// push adds an element to the end.
-func (dq *deque[T]) push(e T) {
-	if dq.remainingCap() >= 1 {
-		dq.elems[dq.write&dq.mask] = e
-		dq.write++
-		return
-	}
-
-	elems := dq.linearise(1)
-	elems = append(elems, e)
-
-	dq.elems = elems[:cap(elems)]
-	dq.mask = uint64(cap(elems)) - 1
-	dq.read, dq.write = 0, uint64(len(elems))
-}
-
-// shift returns the first element or the zero value.
-func (dq *deque[T]) shift() T {
-	var zero T
-
-	if dq.empty() {
-		return zero
-	}
-
-	index := dq.read & dq.mask
-	t := dq.elems[index]
-	dq.elems[index] = zero
-	dq.read++
-	return t
-}
-
-// pop returns the last element or the zero value.
-func (dq *deque[T]) pop() T {
-	var zero T
-
-	if dq.empty() {
-		return zero
-	}
-
-	dq.write--
-	index := dq.write & dq.mask
-	t := dq.elems[index]
-	dq.elems[index] = zero
-	return t
-}
-
-// linearise the contents of the deque.
-//
-// The returned slice has space for at least n more elements and has power
-// of two capacity.
-func (dq *deque[T]) linearise(n int) []T {
-	length := dq.write - dq.read
-	need := length + uint64(n)
-	if need < length {
-		panic("overflow")
-	}
-
-	// Round up to the new power of two which is at least 8.
-	// See https://jameshfisher.com/2018/03/30/round-up-power-2/
-	capacity := 1 << (64 - bits.LeadingZeros64(need-1))
-	if capacity < 8 {
-		capacity = 8
-	}
-
-	types := make([]T, length, capacity)
-	pivot := dq.read & dq.mask
-	copied := copy(types, dq.elems[pivot:])
-	copy(types[copied:], dq.elems[:pivot])
-	return types
-}
+type typeDeque = internal.Deque[*Type]
 
 // inflateRawTypes takes a list of raw btf types linked via type IDs, and turns
 // it into a graph of Types connected via pointers.

--- a/btf/types_test.go
+++ b/btf/types_test.go
@@ -193,77 +193,78 @@ func countChildren(t *testing.T, typ reflect.Type) int {
 	return n
 }
 
-func TestTypeDeque(t *testing.T) {
-	a, b := new(Type), new(Type)
-
+func TestDeque(t *testing.T) {
 	t.Run("pop", func(t *testing.T) {
-		var td typeDeque
-		td.push(a)
-		td.push(b)
+		var dq deque[int]
+		dq.push(1)
+		dq.push(2)
 
-		if td.pop() != b {
-			t.Error("Didn't pop b first")
+		if dq.pop() != 2 {
+			t.Error("Didn't pop 2 first")
 		}
 
-		if td.pop() != a {
-			t.Error("Didn't pop a second")
+		if dq.pop() != 1 {
+			t.Error("Didn't pop 1 second")
 		}
 
-		if td.pop() != nil {
-			t.Error("Didn't pop nil")
+		if dq.pop() != 0 {
+			t.Error("Didn't pop zero")
 		}
 	})
 
 	t.Run("shift", func(t *testing.T) {
-		var td typeDeque
-		td.push(a)
-		td.push(b)
+		var td deque[int]
+		td.push(1)
+		td.push(2)
 
-		if td.shift() != a {
-			t.Error("Didn't shift a second")
+		if td.shift() != 1 {
+			t.Error("Didn't shift 1 first")
 		}
 
-		if td.shift() != b {
-			t.Error("Didn't shift b first")
+		if td.shift() != 2 {
+			t.Error("Didn't shift b second")
 		}
 
-		if td.shift() != nil {
-			t.Error("Didn't shift nil")
+		if td.shift() != 0 {
+			t.Error("Didn't shift zero")
 		}
 	})
 
 	t.Run("push", func(t *testing.T) {
-		var td typeDeque
-		td.push(a)
-		td.push(b)
+		var td deque[int]
+		td.push(1)
+		td.push(2)
 		td.shift()
 
-		ts := make([]Type, 12)
-		for i := range ts {
-			td.push(&ts[i])
+		for i := 1; i <= 12; i++ {
+			td.push(i)
 		}
 
-		if td.shift() != b {
-			t.Error("Didn't shift b first")
+		if td.shift() != 2 {
+			t.Error("Didn't shift 2 first")
 		}
-		for i := range ts {
-			if td.shift() != &ts[i] {
-				t.Fatal("Shifted wrong Type at pos", i)
+		for i := 1; i <= 12; i++ {
+			if v := td.shift(); v != i {
+				t.Fatalf("Shifted %d at pos %d", v, i)
 			}
 		}
 	})
 
-	t.Run("all", func(t *testing.T) {
-		var td typeDeque
-		td.push(a)
-		td.push(b)
+	t.Run("linearise", func(t *testing.T) {
+		var td deque[int]
+		td.push(1)
+		td.push(2)
 
-		all := td.all()
+		all := td.linearise(0)
 		if len(all) != 2 {
 			t.Fatal("Expected 2 elements, got", len(all))
 		}
 
-		if all[0] != a || all[1] != b {
+		if cap(all)&(cap(all)-1) != 0 {
+			t.Fatalf("Capacity %d is not a power of two", cap(all))
+		}
+
+		if all[0] != 1 || all[1] != 2 {
 			t.Fatal("Elements don't match")
 		}
 	})

--- a/btf/types_test.go
+++ b/btf/types_test.go
@@ -415,6 +415,37 @@ func TestInflateLegacyBitfield(t *testing.T) {
 	}
 }
 
+func BenchmarkWalk(b *testing.B) {
+	types := []Type{
+		&Void{},
+		&Int{},
+		&Pointer{},
+		&Array{},
+		&Struct{Members: make([]Member, 2)},
+		&Union{Members: make([]Member, 2)},
+		&Enum{},
+		&Fwd{},
+		&Typedef{},
+		&Volatile{},
+		&Const{},
+		&Restrict{},
+		&Func{},
+		&FuncProto{Params: make([]FuncParam, 2)},
+		&Var{},
+		&Datasec{Vars: make([]VarSecinfo, 2)},
+	}
+
+	for _, typ := range types {
+		b.Run(fmt.Sprint(typ), func(b *testing.B) {
+			b.ReportAllocs()
+
+			for i := 0; i < b.N; i++ {
+				typ.walk(&typeDeque{})
+			}
+		})
+	}
+}
+
 func BenchmarkUnderlyingType(b *testing.B) {
 	b.Run("no unwrapping", func(b *testing.B) {
 		v := &Int{}

--- a/btf/types_test.go
+++ b/btf/types_test.go
@@ -193,83 +193,6 @@ func countChildren(t *testing.T, typ reflect.Type) int {
 	return n
 }
 
-func TestDeque(t *testing.T) {
-	t.Run("pop", func(t *testing.T) {
-		var dq deque[int]
-		dq.push(1)
-		dq.push(2)
-
-		if dq.pop() != 2 {
-			t.Error("Didn't pop 2 first")
-		}
-
-		if dq.pop() != 1 {
-			t.Error("Didn't pop 1 second")
-		}
-
-		if dq.pop() != 0 {
-			t.Error("Didn't pop zero")
-		}
-	})
-
-	t.Run("shift", func(t *testing.T) {
-		var td deque[int]
-		td.push(1)
-		td.push(2)
-
-		if td.shift() != 1 {
-			t.Error("Didn't shift 1 first")
-		}
-
-		if td.shift() != 2 {
-			t.Error("Didn't shift b second")
-		}
-
-		if td.shift() != 0 {
-			t.Error("Didn't shift zero")
-		}
-	})
-
-	t.Run("push", func(t *testing.T) {
-		var td deque[int]
-		td.push(1)
-		td.push(2)
-		td.shift()
-
-		for i := 1; i <= 12; i++ {
-			td.push(i)
-		}
-
-		if td.shift() != 2 {
-			t.Error("Didn't shift 2 first")
-		}
-		for i := 1; i <= 12; i++ {
-			if v := td.shift(); v != i {
-				t.Fatalf("Shifted %d at pos %d", v, i)
-			}
-		}
-	})
-
-	t.Run("linearise", func(t *testing.T) {
-		var td deque[int]
-		td.push(1)
-		td.push(2)
-
-		all := td.linearise(0)
-		if len(all) != 2 {
-			t.Fatal("Expected 2 elements, got", len(all))
-		}
-
-		if cap(all)&(cap(all)-1) != 0 {
-			t.Fatalf("Capacity %d is not a power of two", cap(all))
-		}
-
-		if all[0] != 1 || all[1] != 2 {
-			t.Fatal("Elements don't match")
-		}
-	})
-}
-
 type testFormattableType struct {
 	name  string
 	extra []interface{}
@@ -471,7 +394,7 @@ func BenchmarkWalk(b *testing.B) {
 
 			for i := 0; i < b.N; i++ {
 				var dq typeDeque
-				walkType(typ, dq.push)
+				walkType(typ, dq.Push)
 			}
 		})
 	}

--- a/internal/deque.go
+++ b/internal/deque.go
@@ -1,0 +1,89 @@
+package internal
+
+import "math/bits"
+
+// Deque implements a double ended queue.
+type Deque[T any] struct {
+	elems       []T
+	read, write uint64
+	mask        uint64
+}
+
+func (dq *Deque[T]) Empty() bool {
+	return dq.read == dq.write
+}
+
+func (dq *Deque[T]) remainingCap() int {
+	return len(dq.elems) - int(dq.write-dq.read)
+}
+
+// Push adds an element to the end.
+func (dq *Deque[T]) Push(e T) {
+	if dq.remainingCap() >= 1 {
+		dq.elems[dq.write&dq.mask] = e
+		dq.write++
+		return
+	}
+
+	elems := dq.linearise(1)
+	elems = append(elems, e)
+
+	dq.elems = elems[:cap(elems)]
+	dq.mask = uint64(cap(elems)) - 1
+	dq.read, dq.write = 0, uint64(len(elems))
+}
+
+// Shift returns the first element or the zero value.
+func (dq *Deque[T]) Shift() T {
+	var zero T
+
+	if dq.Empty() {
+		return zero
+	}
+
+	index := dq.read & dq.mask
+	t := dq.elems[index]
+	dq.elems[index] = zero
+	dq.read++
+	return t
+}
+
+// Pop returns the last element or the zero value.
+func (dq *Deque[T]) Pop() T {
+	var zero T
+
+	if dq.Empty() {
+		return zero
+	}
+
+	dq.write--
+	index := dq.write & dq.mask
+	t := dq.elems[index]
+	dq.elems[index] = zero
+	return t
+}
+
+// linearise the contents of the deque.
+//
+// The returned slice has space for at least n more elements and has power
+// of two capacity.
+func (dq *Deque[T]) linearise(n int) []T {
+	length := dq.write - dq.read
+	need := length + uint64(n)
+	if need < length {
+		panic("overflow")
+	}
+
+	// Round up to the new power of two which is at least 8.
+	// See https://jameshfisher.com/2018/03/30/round-up-power-2/
+	capacity := 1 << (64 - bits.LeadingZeros64(need-1))
+	if capacity < 8 {
+		capacity = 8
+	}
+
+	types := make([]T, length, capacity)
+	pivot := dq.read & dq.mask
+	copied := copy(types, dq.elems[pivot:])
+	copy(types[copied:], dq.elems[:pivot])
+	return types
+}

--- a/internal/deque_test.go
+++ b/internal/deque_test.go
@@ -1,0 +1,80 @@
+package internal
+
+import "testing"
+
+func TestDeque(t *testing.T) {
+	t.Run("pop", func(t *testing.T) {
+		var dq Deque[int]
+		dq.Push(1)
+		dq.Push(2)
+
+		if dq.Pop() != 2 {
+			t.Error("Didn't pop 2 first")
+		}
+
+		if dq.Pop() != 1 {
+			t.Error("Didn't pop 1 second")
+		}
+
+		if dq.Pop() != 0 {
+			t.Error("Didn't pop zero")
+		}
+	})
+
+	t.Run("shift", func(t *testing.T) {
+		var td Deque[int]
+		td.Push(1)
+		td.Push(2)
+
+		if td.Shift() != 1 {
+			t.Error("Didn't shift 1 first")
+		}
+
+		if td.Shift() != 2 {
+			t.Error("Didn't shift b second")
+		}
+
+		if td.Shift() != 0 {
+			t.Error("Didn't shift zero")
+		}
+	})
+
+	t.Run("push", func(t *testing.T) {
+		var td Deque[int]
+		td.Push(1)
+		td.Push(2)
+		td.Shift()
+
+		for i := 1; i <= 12; i++ {
+			td.Push(i)
+		}
+
+		if td.Shift() != 2 {
+			t.Error("Didn't shift 2 first")
+		}
+		for i := 1; i <= 12; i++ {
+			if v := td.Shift(); v != i {
+				t.Fatalf("Shifted %d at pos %d", v, i)
+			}
+		}
+	})
+
+	t.Run("linearise", func(t *testing.T) {
+		var td Deque[int]
+		td.Push(1)
+		td.Push(2)
+
+		all := td.linearise(0)
+		if len(all) != 2 {
+			t.Fatal("Expected 2 elements, got", len(all))
+		}
+
+		if cap(all)&(cap(all)-1) != 0 {
+			t.Fatalf("Capacity %d is not a power of two", cap(all))
+		}
+
+		if all[0] != 1 || all[1] != 2 {
+			t.Fatal("Elements don't match")
+		}
+	})
+}

--- a/prog.go
+++ b/prog.go
@@ -243,10 +243,6 @@ func newProgramWithOptions(spec *ProgramSpec, opts ProgramOptions, handles *hand
 
 	var btfDisabled bool
 	if spec.BTF != nil {
-		if err := applyRelocations(insns, spec.BTF, opts.KernelTypes); err != nil {
-			return nil, fmt.Errorf("apply CO-RE relocations: %w", err)
-		}
-
 		handle, err := handles.btfHandle(spec.BTF)
 		btfDisabled = errors.Is(err, btf.ErrNotSupported)
 		if err != nil && !btfDisabled {
@@ -269,6 +265,10 @@ func newProgramWithOptions(spec *ProgramSpec, opts ProgramOptions, handles *hand
 			attr.LineInfoCnt = uint32(len(lib)) / btf.LineInfoSize
 			attr.LineInfo = sys.NewSlicePointer(lib)
 		}
+	}
+
+	if err := applyRelocations(insns, opts.KernelTypes, spec.ByteOrder); err != nil {
+		return nil, fmt.Errorf("apply CO-RE relocations: %w", err)
 	}
 
 	if err := fixupAndValidate(insns); err != nil {


### PR DESCRIPTION
This is the first of three PRs to add BTF marshaling to the library, and does some groundwork. The second PR will contain the actual marshaling code, while the third PR has some more memory optimizations.

For the curious, the whole shebang is on [my btf-encoder branch](https://github.com/lmb/ebpf/tree/btf-encoder).

internal: move Deque
    
    Move Deque from btf into internal and export methods. No other code changes.

btf: make typeDeque generic
    
    Make typeDeque a generic container type so that we can re-use it
    for postorderTraversal.

btf: avoid heap allocations when walking types
    
    Type.walk() forces the typeDeque argument to always escape, since the escape analyzer has
    to be conservative when dealing with interfaces. We can apply two tricks that reduce
    allocations.
    
    First, Type.walk() is replaced with
    
        children() []*Type
    
    This removes the typeDeque parameter, and for types that don't have any children (like Void) we
    never incur an allocation at all. For types that do have children we've unfortunately swapped
    heap allocating typeDeque with allocating the []*Type slice instead.
    
    Which brings us to the second trick: by using a type switch we allow the compiler to inline the
    children() function for the most important Types, which in turn enables allocating most []*Type on
    the stack instead of on the heap.
    
    One notable exception is FuncProto, which allocates the returned slice as such:
    
        types := make([]*Type, len(fp.Params)+1)
    
    It seems like this trips up escape analysis for some reason as the slice is heap allocated.
    
        name                                      old time/op    new time/op    delta
        Walk/Void-4                                 22.6ns ± 2%     2.8ns ± 2%   -87.40%  (p=0.029 n=4+4)
        Walk/Int[unsigned_size=0]-4                 22.7ns ± 1%     3.2ns ± 1%   -86.09%  (p=0.029 n=4+4)
        Walk/Pointer[target=<nil>]-4                61.3ns ± 1%    38.5ns ± 1%   -37.26%  (p=0.029 n=4+4)
        Walk/Array[index=<nil>_type=<nil>_n=0]-4    63.8ns ± 1%    42.2ns ± 0%   -33.91%  (p=0.029 n=4+4)
        Walk/Struct[fields=2]-4                     64.9ns ± 1%    59.5ns ± 0%    -8.29%  (p=0.029 n=4+4)
        Walk/Union[fields=2]-4                      66.6ns ± 3%    59.3ns ± 0%   -10.84%  (p=0.029 n=4+4)
        Walk/Enum[size=0_values=0]-4                22.5ns ± 4%     2.9ns ± 2%   -87.22%  (p=0.029 n=4+4)
        Walk/Fwd[struct]-4                          22.2ns ± 1%     2.8ns ± 1%   -87.23%  (p=0.029 n=4+4)
        Walk/Typedef[<nil>]-4                       60.8ns ± 1%    38.7ns ± 1%   -36.42%  (p=0.029 n=4+4)
        Walk/Volatile[<nil>]-4                      62.9ns ± 3%    38.4ns ± 2%   -38.89%  (p=0.029 n=4+4)
        Walk/Const[<nil>]-4                         61.9ns ± 1%    39.8ns ± 3%   -35.78%  (p=0.029 n=4+4)
        Walk/Restrict[<nil>]-4                      64.2ns ± 1%    39.2ns ± 1%   -38.91%  (p=0.029 n=4+4)
        Walk/Func[static_proto=<nil>]-4             63.3ns ± 4%    39.5ns ± 2%   -37.57%  (p=0.029 n=4+4)
        Walk/FuncProto[args=2_return=<nil>]-4       67.8ns ± 5%    77.3ns ± 2%   +14.03%  (p=0.029 n=4+4)
        Walk/Var[static]-4                          63.2ns ± 1%    38.5ns ± 0%   -39.03%  (p=0.029 n=4+4)
        Walk/Datasec-4                              67.5ns ± 2%    58.5ns ± 1%   -13.31%  (p=0.029 n=4+4)
    
        name                                      old alloc/op   new alloc/op   delta
        Walk/Void-4                                  48.0B ± 0%      0.0B       -100.00%  (p=0.029 n=4+4)
        Walk/Int[unsigned_size=0]-4                  48.0B ± 0%      0.0B       -100.00%  (p=0.029 n=4+4)
        Walk/Pointer[target=<nil>]-4                  112B ± 0%       64B ± 0%   -42.86%  (p=0.029 n=4+4)
        Walk/Array[index=<nil>_type=<nil>_n=0]-4      112B ± 0%       64B ± 0%   -42.86%  (p=0.029 n=4+4)
        Walk/Struct[fields=2]-4                       112B ± 0%       80B ± 0%   -28.57%  (p=0.029 n=4+4)
        Walk/Union[fields=2]-4                        112B ± 0%       80B ± 0%   -28.57%  (p=0.029 n=4+4)
        Walk/Enum[size=0_values=0]-4                 48.0B ± 0%      0.0B       -100.00%  (p=0.029 n=4+4)
        Walk/Fwd[struct]-4                           48.0B ± 0%      0.0B       -100.00%  (p=0.029 n=4+4)
        Walk/Typedef[<nil>]-4                         112B ± 0%       64B ± 0%   -42.86%  (p=0.029 n=4+4)
        Walk/Volatile[<nil>]-4                        112B ± 0%       64B ± 0%   -42.86%  (p=0.029 n=4+4)
        Walk/Const[<nil>]-4                           112B ± 0%       64B ± 0%   -42.86%  (p=0.029 n=4+4)
        Walk/Restrict[<nil>]-4                        112B ± 0%       64B ± 0%   -42.86%  (p=0.029 n=4+4)
        Walk/Func[static_proto=<nil>]-4               112B ± 0%       64B ± 0%   -42.86%  (p=0.029 n=4+4)
        Walk/FuncProto[args=2_return=<nil>]-4         112B ± 0%       88B ± 0%   -21.43%  (p=0.029 n=4+4)
        Walk/Var[static]-4                            112B ± 0%       64B ± 0%   -42.86%  (p=0.029 n=4+4)
        Walk/Datasec-4                                112B ± 0%       80B ± 0%   -28.57%  (p=0.029 n=4+4)
    
        name                                      old allocs/op  new allocs/op  delta
        Walk/Void-4                                   1.00 ± 0%      0.00       -100.00%  (p=0.029 n=4+4)
        Walk/Int[unsigned_size=0]-4                   1.00 ± 0%      0.00       -100.00%  (p=0.029 n=4+4)
        Walk/Pointer[target=<nil>]-4                  2.00 ± 0%      1.00 ± 0%   -50.00%  (p=0.029 n=4+4)
        Walk/Array[index=<nil>_type=<nil>_n=0]-4      2.00 ± 0%      1.00 ± 0%   -50.00%  (p=0.029 n=4+4)
        Walk/Struct[fields=2]-4                       2.00 ± 0%      2.00 ± 0%      ~     (all equal)
        Walk/Union[fields=2]-4                        2.00 ± 0%      2.00 ± 0%      ~     (all equal)
        Walk/Enum[size=0_values=0]-4                  1.00 ± 0%      0.00       -100.00%  (p=0.029 n=4+4)
        Walk/Fwd[struct]-4                            1.00 ± 0%      0.00       -100.00%  (p=0.029 n=4+4)
        Walk/Typedef[<nil>]-4                         2.00 ± 0%      1.00 ± 0%   -50.00%  (p=0.029 n=4+4)
        Walk/Volatile[<nil>]-4                        2.00 ± 0%      1.00 ± 0%   -50.00%  (p=0.029 n=4+4)
        Walk/Const[<nil>]-4                           2.00 ± 0%      1.00 ± 0%   -50.00%  (p=0.029 n=4+4)
        Walk/Restrict[<nil>]-4                        2.00 ± 0%      1.00 ± 0%   -50.00%  (p=0.029 n=4+4)
        Walk/Func[static_proto=<nil>]-4               2.00 ± 0%      1.00 ± 0%   -50.00%  (p=0.029 n=4+4)
        Walk/FuncProto[args=2_return=<nil>]-4         2.00 ± 0%      2.00 ± 0%      ~     (all equal)
        Walk/Var[static]-4                            2.00 ± 0%      1.00 ± 0%   -50.00%  (p=0.029 n=4+4)
        Walk/Datasec-4                                2.00 ± 0%      2.00 ± 0%      ~     (all equal)

btf: add benchmark for Type.Walk
    
    Benchmark the cost of adding a type and its children to a typeDeque.
    
        name                                      time/op
        Walk/Void-4                               22.8ns ± 3%
        Walk/Int[unsigned_size=0]-4               22.3ns ± 1%
        Walk/Pointer[target=<nil>]-4              61.3ns ± 0%
        Walk/Array[index=<nil>_type=<nil>_n=0]-4  62.4ns ± 0%
        Walk/Struct[fields=2]-4                   64.2ns ± 0%
        Walk/Union[fields=2]-4                    64.6ns ± 0%
        Walk/Enum[size=0_values=0]-4              22.1ns ± 0%
        Walk/Fwd[struct]-4                        22.1ns ± 0%
        Walk/Typedef[<nil>]-4                     61.2ns ± 0%
        Walk/Volatile[<nil>]-4                    61.2ns ± 0%
        Walk/Const[<nil>]-4                       61.2ns ± 0%
        Walk/Restrict[<nil>]-4                    61.2ns ± 0%
        Walk/Func[static_proto=<nil>]-4           61.6ns ± 0%
        Walk/FuncProto[args=2_return=<nil>]-4     66.1ns ± 0%
        Walk/Var[static]-4                        61.5ns ± 1%
        Walk/Datasec-4                            64.4ns ± 0%
    
        name                                      alloc/op
        Walk/Void-4                                48.0B ± 0%
        Walk/Int[unsigned_size=0]-4                48.0B ± 0%
        Walk/Pointer[target=<nil>]-4                112B ± 0%
        Walk/Array[index=<nil>_type=<nil>_n=0]-4    112B ± 0%
        Walk/Struct[fields=2]-4                     112B ± 0%
        Walk/Union[fields=2]-4                      112B ± 0%
        Walk/Enum[size=0_values=0]-4               48.0B ± 0%
        Walk/Fwd[struct]-4                         48.0B ± 0%
        Walk/Typedef[<nil>]-4                       112B ± 0%
        Walk/Volatile[<nil>]-4                      112B ± 0%
        Walk/Const[<nil>]-4                         112B ± 0%
        Walk/Restrict[<nil>]-4                      112B ± 0%
        Walk/Func[static_proto=<nil>]-4             112B ± 0%
        Walk/FuncProto[args=2_return=<nil>]-4       112B ± 0%
        Walk/Var[static]-4                          112B ± 0%
        Walk/Datasec-4                              112B ± 0%
    
        name                                      allocs/op
        Walk/Void-4                                 1.00 ± 0%
        Walk/Int[unsigned_size=0]-4                 1.00 ± 0%
        Walk/Pointer[target=<nil>]-4                2.00 ± 0%
        Walk/Array[index=<nil>_type=<nil>_n=0]-4    2.00 ± 0%
        Walk/Struct[fields=2]-4                     2.00 ± 0%
        Walk/Union[fields=2]-4                      2.00 ± 0%
        Walk/Enum[size=0_values=0]-4                1.00 ± 0%
        Walk/Fwd[struct]-4                          1.00 ± 0%
        Walk/Typedef[<nil>]-4                       2.00 ± 0%
        Walk/Volatile[<nil>]-4                      2.00 ± 0%
        Walk/Const[<nil>]-4                         2.00 ± 0%
        Walk/Restrict[<nil>]-4                      2.00 ± 0%
        Walk/Func[static_proto=<nil>]-4             2.00 ± 0%
        Walk/FuncProto[args=2_return=<nil>]-4       2.00 ± 0%
        Walk/Var[static]-4                          2.00 ± 0%
        Walk/Datasec-4                              2.00 ± 0%

btf: drop local btf.Spec argument to CORERelocate
    
    CORERelocate currently takes ProgramSpec.BTF as an argument, since a CO-RE relocation
    may ask for the local type ID. This is problematic, since we want to get rid of ProgramSpec.BTF.
    
    Instead, cache the type ID when constructing the CORERelocation itself.
