### PR TITLE
cmd/bpf2go: test against clang-14 by default

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -45,6 +45,8 @@ blocks:
           value: /tmp
         - name: CI_MAX_KERNEL_VERSION
           value: "5.18"
+        - name: CI_MIN_CLANG_VERSION
+          value: "9"
       jobs:
       - name: Build and Lint
         commands:

--- a/cmd/bpf2go/compile_test.go
+++ b/cmd/bpf2go/compile_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -11,10 +12,19 @@ import (
 
 const minimalSocketFilter = `__attribute__((section("socket"), used)) int main() { return 0; }`
 
-// Test against the minimum supported version of clang to avoid regressions.
-const (
-	clangBin = "clang-9"
-)
+var clangBin string
+
+func init() {
+	// Use a recent clang version for local development, but allow CI to run
+	// agains oldest supported clang.
+	if minVersion := os.Getenv("CI_MIN_CLANG_VERSION"); minVersion != "" {
+		clangBin = fmt.Sprintf("clang-%s", minVersion)
+	} else {
+		clangBin = "clang-14"
+	}
+
+	fmt.Println("Testing against", clangBin)
+}
 
 func TestCompile(t *testing.T) {
 	dir := mustWriteTempFile(t, "test.c", minimalSocketFilter)

--- a/cmd/bpf2go/main_test.go
+++ b/cmd/bpf2go/main_test.go
@@ -110,7 +110,7 @@ func TestDisableStripping(t *testing.T) {
 	dir := mustWriteTempFile(t, "test.c", minimalSocketFilter)
 
 	err := run(io.Discard, "foo", dir, []string{
-		"-cc", "clang-9",
+		"-cc", clangBin,
 		"-strip", "binary-that-certainly-doesnt-exist",
 		"-no-strip",
 		"bar",


### PR DESCRIPTION
clang-9 is getting difficult to get a hold of on recent distributions. Default to clang-14 for bpf2go tests, but allow CI to still use clang-9. This avoids regressing clang-9 support by for example using a new command line option.