### PR TITLE
btf: fix IntEncoding

### DIFF
--- a/btf/format.go
+++ b/btf/format.go
@@ -119,7 +119,7 @@ func (gf *GoFormatter) writeTypeLit(typ Type, depth int) error {
 	var err error
 	switch v := skipQualifiers(typ).(type) {
 	case *Int:
-		gf.writeIntLit(v)
+		err = gf.writeIntLit(v)
 
 	case *Enum:
 		if !v.Signed {
@@ -166,19 +166,30 @@ func (gf *GoFormatter) writeTypeLit(typ Type, depth int) error {
 	return nil
 }
 
-func (gf *GoFormatter) writeIntLit(i *Int) {
-	// NB: Encoding.IsChar is ignored.
-	if i.Encoding.IsBool() && i.Size == 1 {
-		gf.w.WriteString("bool")
-		return
-	}
-
+func (gf *GoFormatter) writeIntLit(i *Int) error {
 	bits := i.Size * 8
-	if i.Encoding.IsSigned() {
+	switch i.Encoding {
+	case Bool:
+		if i.Size != 1 {
+			return fmt.Errorf("bool with size %d", i.Size)
+		}
+		gf.w.WriteString("bool")
+	case Signed:
 		fmt.Fprintf(&gf.w, "int%d", bits)
-	} else {
+	case Char:
+		if i.Size != 1 {
+			return fmt.Errorf("char with size %d", i.Size)
+		}
+		// BTF doesn't have a way to specify the signedness of a char. Assume
+		// we are dealing with unsigned, since this works nicely with []byte
+		// in Go code.
+		fallthrough
+	case Unsigned:
 		fmt.Fprintf(&gf.w, "uint%d", bits)
+	default:
+		return fmt.Errorf("can't encode %s", i.Encoding)
 	}
+	return nil
 }
 
 func (gf *GoFormatter) writeStructLit(size uint32, members []Member, depth int) error {

--- a/btf/types.go
+++ b/btf/types.go
@@ -77,36 +77,29 @@ func (v *Void) copy() Type                     { return (*Void)(nil) }
 
 type IntEncoding byte
 
+// Valid IntEncodings.
+//
+// These may look like they are flags, but they aren't.
 const (
-	Signed IntEncoding = 1 << iota
-	Char
-	Bool
+	Unsigned IntEncoding = 0
+	Signed   IntEncoding = 1
+	Char     IntEncoding = 2
+	Bool     IntEncoding = 4
 )
 
-func (ie IntEncoding) IsSigned() bool {
-	return ie&Signed != 0
-}
-
-func (ie IntEncoding) IsChar() bool {
-	return ie&Char != 0
-}
-
-func (ie IntEncoding) IsBool() bool {
-	return ie&Bool != 0
-}
-
 func (ie IntEncoding) String() string {
-	switch {
-	case ie.IsChar() && ie.IsSigned():
+	switch ie {
+	case Char:
+		// NB: There is no way to determine signedness for char.
 		return "char"
-	case ie.IsChar() && !ie.IsSigned():
-		return "uchar"
-	case ie.IsBool():
+	case Bool:
 		return "bool"
-	case ie.IsSigned():
+	case Signed:
 		return "signed"
-	default:
+	case Unsigned:
 		return "unsigned"
+	default:
+		return fmt.Sprintf("IntEncoding(%d)", byte(ie))
 	}
 }
 


### PR DESCRIPTION
We currently treat IntEncoding as if it was a set of flags, but the kernel and bpftool treat it like an enum. Additionally, clang doesn't generate Char encodings in the first place.

Remove the Is* methods on IntEncoding since they give users the wrong idea of how the type works. Tidy up GoFormatter to be more strict when outputting Int.

Updates #656