### PR TITLE
reopen may uint128 to [16]byte

### DIFF
--- a/btf/format.go
+++ b/btf/format.go
@@ -174,8 +174,6 @@ func (gf *GoFormatter) writeIntLit(i *Int) error {
 			return fmt.Errorf("bool with size %d", i.Size)
 		}
 		gf.w.WriteString("bool")
-	case Signed:
-		fmt.Fprintf(&gf.w, "int%d", bits)
 	case Char:
 		if i.Size != 1 {
 			return fmt.Errorf("char with size %d", i.Size)
@@ -184,8 +182,16 @@ func (gf *GoFormatter) writeIntLit(i *Int) error {
 		// we are dealing with unsigned, since this works nicely with []byte
 		// in Go code.
 		fallthrough
-	case Unsigned:
-		fmt.Fprintf(&gf.w, "uint%d", bits)
+	case Unsigned, Signed:
+		stem := "uint"
+		if i.Encoding == Signed {
+			stem = "int"
+		}
+		if i.Size > 8 {
+			fmt.Fprintf(&gf.w, "[%d]byte /* %s%d */", i.Size, stem, i.Size*8)
+		} else {
+			fmt.Fprintf(&gf.w, "%s%d", stem, bits)
+		}
 	default:
 		return fmt.Errorf("can't encode %s", i.Encoding)
 	}

--- a/btf/format_test.go
+++ b/btf/format_test.go
@@ -20,7 +20,7 @@ func TestGoTypeDeclaration(t *testing.T) {
 		{&Int{Size: 4, Encoding: Signed}, "type t int32"},
 		{&Int{Size: 8}, "type t uint64"},
 		{&Typedef{Name: "frob", Type: &Int{Size: 8}}, "type t uint64"},
-		{&Int{Size: 16}, "type t uint128"},
+		{&Int{Size: 16}, "type t [16]byte /* uint128 */"},
 		{&Enum{Values: []EnumValue{{"FOO", 32}}, Size: 4}, "type t uint32; const ( tFOO t = 32; )"},
 		{&Enum{Values: []EnumValue{{"BAR", 1}}, Size: 1, Signed: true}, "type t int8; const ( tBAR t = 1; )"},
 		{


### PR DESCRIPTION
The latest code seems to have changed quite a bit so it was changed to:

[format.go#L185](https://github.com/Benjamin-Yim/ebpf/blob/fix_uint128/btf/format.go#L185)

```golang
...
	case Unsigned, Signed:
		stem := "uint"
		if i.Encoding == Signed {
			stem = "int"
		}
		if i.Size > 8 {
			fmt.Fprintf(&gf.w, "[%d]byte /* %s%d */", i.Size, stem, i.Size*8)
		} else {
			fmt.Fprintf(&gf.w, "%s%d", stem, bits)
		}
```
