### PR TITLE
Semaphore: remove manual Go installation, expedite 'cache restore'

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -23,14 +23,13 @@ blocks:
       prologue:
         commands:
           - sudo sh -c 'swapoff -a && fallocate -l 2G /swapfile && chmod 0600 /swapfile && mkswap /swapfile && swapon /swapfile'
-          - sudo mkdir -p /usr/local/golang/1.19 && curl -fL "https://go.dev/dl/go1.19.1.linux-amd64.tar.gz" | sudo tar -xz -C /usr/local/golang/1.19
-          - sem-version go 1.19
+          - sem-version go 1.19.1
           - export PATH="$PATH:$(go env GOPATH)/bin"
-          - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.48.0
-          - go install gotest.tools/gotestsum@v1.8.1
           - checkout
           - cache restore
           - go mod tidy
+          - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.48.0
+          - go install gotest.tools/gotestsum@v1.8.1
           - sudo pip3 install https://github.com/amluto/virtme/archive/beb85146cd91de37ae455eccb6ab67c393e6e290.zip
           - sudo apt-get update
           - sudo apt-get install -y --no-install-recommends qemu-system-x86 clang-9 llvm-9


### PR DESCRIPTION
Some recommendations from Semaphore support.

'sem-version' apparently installs Go, so rely on it instead of isntalling Go manually.

Execute 'cache restore' before 'go install' to avoid tar errors unpacking the cache archive:

```
Unpacking command failed: tar: /home/semaphore/go/pkg/mod/github.com/jonboulle/clockwork@v0.2.2/.github/workflows/ci.yml: Cannot open: File exists
tar: /home/semaphore/go/pkg/mod/github.com/jonboulle/clockwork@v0.2.2/.github/workflows/.editorconfig: Cannot open: File exists
tar: /home/semaphore/go/pkg/mod/github.com/jonboulle/clockwork@v0.2.2/ticker.go: Cannot open: File exists
...
```