### PR TITLE
internal/unix: add some documentation and tidy up stubs

### DIFF
--- a/internal/unix/doc.go
+++ b/internal/unix/doc.go
@@ -1,0 +1,11 @@
+// Package unix re-exports Linux specific parts of golang.org/x/sys/unix.
+//
+// It avoids breaking compilation on other OS by providing stubs as follows:
+//   - Invoking a function always returns an error.
+//   - Errnos have distinct, non-zero values.
+//   - Constants have distinct but meaningless values.
+//   - Types use the same names for members, but may or may not follow the
+//     Linux layout.
+package unix
+
+// Note: please don't add any custom API to this package. Use internal/sys instead.

--- a/internal/unix/types_linux.go
+++ b/internal/unix/types_linux.go
@@ -24,7 +24,9 @@ const (
 	EFAULT  = linux.EFAULT
 	EACCES  = linux.EACCES
 	EILSEQ  = linux.EILSEQ
+)
 
+const (
 	BPF_F_NO_PREALLOC         = linux.BPF_F_NO_PREALLOC
 	BPF_F_NUMA_NODE           = linux.BPF_F_NUMA_NODE
 	BPF_F_RDONLY              = linux.BPF_F_RDONLY
@@ -70,9 +72,8 @@ const (
 	SO_DETACH_BPF             = linux.SO_DETACH_BPF
 	SOL_SOCKET                = linux.SOL_SOCKET
 	SIGPROF                   = linux.SIGPROF
-
-	SIG_BLOCK   = linux.SIG_BLOCK
-	SIG_UNBLOCK = linux.SIG_UNBLOCK
+	SIG_BLOCK                 = linux.SIG_BLOCK
+	SIG_UNBLOCK               = linux.SIG_UNBLOCK
 )
 
 type Statfs_t = linux.Statfs_t
@@ -80,125 +81,95 @@ type Stat_t = linux.Stat_t
 type Rlimit = linux.Rlimit
 type Signal = linux.Signal
 type Sigset_t = linux.Sigset_t
+type PerfEventMmapPage = linux.PerfEventMmapPage
+type EpollEvent = linux.EpollEvent
+type PerfEventAttr = linux.PerfEventAttr
+type Utsname = linux.Utsname
 
-// Syscall is a wrapper
 func Syscall(trap, a1, a2, a3 uintptr) (r1, r2 uintptr, err syscall.Errno) {
 	return linux.Syscall(trap, a1, a2, a3)
 }
 
-// PthreadSigmask is a wrapper
 func PthreadSigmask(how int, set, oldset *Sigset_t) error {
 	return linux.PthreadSigmask(how, set, oldset)
 }
 
-// FcntlInt is a wrapper
 func FcntlInt(fd uintptr, cmd, arg int) (int, error) {
 	return linux.FcntlInt(fd, cmd, arg)
 }
 
-// IoctlSetInt is a wrapper
 func IoctlSetInt(fd int, req uint, value int) error {
 	return linux.IoctlSetInt(fd, req, value)
 }
 
-// Statfs is a wrapper
 func Statfs(path string, buf *Statfs_t) (err error) {
 	return linux.Statfs(path, buf)
 }
 
-// Close is a wrapper
 func Close(fd int) (err error) {
 	return linux.Close(fd)
 }
 
-// EpollEvent is a wrapper
-type EpollEvent = linux.EpollEvent
-
-// EpollWait is a wrapper
 func EpollWait(epfd int, events []EpollEvent, msec int) (n int, err error) {
 	return linux.EpollWait(epfd, events, msec)
 }
 
-// EpollCtl is a wrapper
 func EpollCtl(epfd int, op int, fd int, event *EpollEvent) (err error) {
 	return linux.EpollCtl(epfd, op, fd, event)
 }
 
-// Eventfd is a wrapper
 func Eventfd(initval uint, flags int) (fd int, err error) {
 	return linux.Eventfd(initval, flags)
 }
 
-// Write is a wrapper
 func Write(fd int, p []byte) (n int, err error) {
 	return linux.Write(fd, p)
 }
 
-// EpollCreate1 is a wrapper
 func EpollCreate1(flag int) (fd int, err error) {
 	return linux.EpollCreate1(flag)
 }
 
-// PerfEventMmapPage is a wrapper
-type PerfEventMmapPage linux.PerfEventMmapPage
-
-// SetNonblock is a wrapper
 func SetNonblock(fd int, nonblocking bool) (err error) {
 	return linux.SetNonblock(fd, nonblocking)
 }
 
-// Mmap is a wrapper
 func Mmap(fd int, offset int64, length int, prot int, flags int) (data []byte, err error) {
 	return linux.Mmap(fd, offset, length, prot, flags)
 }
 
-// Munmap is a wrapper
 func Munmap(b []byte) (err error) {
 	return linux.Munmap(b)
 }
 
-// PerfEventAttr is a wrapper
-type PerfEventAttr = linux.PerfEventAttr
-
-// PerfEventOpen is a wrapper
 func PerfEventOpen(attr *PerfEventAttr, pid int, cpu int, groupFd int, flags int) (fd int, err error) {
 	return linux.PerfEventOpen(attr, pid, cpu, groupFd, flags)
 }
 
-// Utsname is a wrapper
-type Utsname = linux.Utsname
-
-// Uname is a wrapper
 func Uname(buf *Utsname) (err error) {
 	return linux.Uname(buf)
 }
 
-// Getpid is a wrapper
 func Getpid() int {
 	return linux.Getpid()
 }
 
-// Gettid is a wrapper
 func Gettid() int {
 	return linux.Gettid()
 }
 
-// Tgkill is a wrapper
 func Tgkill(tgid int, tid int, sig syscall.Signal) (err error) {
 	return linux.Tgkill(tgid, tid, sig)
 }
 
-// BytePtrFromString is a wrapper
 func BytePtrFromString(s string) (*byte, error) {
 	return linux.BytePtrFromString(s)
 }
 
-// ByteSliceToString is a wrapper
 func ByteSliceToString(s []byte) string {
 	return linux.ByteSliceToString(s)
 }
 
-// Renameat2 is a wrapper
 func Renameat2(olddirfd int, oldpath string, newdirfd int, newpath string, flags uint) error {
 	return linux.Renameat2(olddirfd, oldpath, newdirfd, newpath, flags)
 }

--- a/internal/unix/types_other.go
+++ b/internal/unix/types_other.go
@@ -10,71 +10,74 @@ import (
 
 var errNonLinux = fmt.Errorf("unsupported platform %s/%s", runtime.GOOS, runtime.GOARCH)
 
+// Errnos are distinct and non-zero.
 const (
-	ENOENT = syscall.ENOENT
-	EEXIST = syscall.EEXIST
-	EAGAIN = syscall.EAGAIN
-	ENOSPC = syscall.ENOSPC
-	EINVAL = syscall.EINVAL
-	EINTR  = syscall.EINTR
-	EPERM  = syscall.EPERM
-	ESRCH  = syscall.ESRCH
-	ENODEV = syscall.ENODEV
-	EBADF  = syscall.Errno(0)
-	E2BIG  = syscall.Errno(0)
-	EFAULT = syscall.EFAULT
-	EACCES = syscall.Errno(0)
-	EILSEQ = syscall.Errno(0)
+	ENOENT syscall.Errno = iota + 1
+	EEXIST
+	EAGAIN
+	ENOSPC
+	EINVAL
+	EINTR
+	EPERM
+	ESRCH
+	ENODEV
+	EBADF
+	E2BIG
+	EFAULT
+	EACCES
+	EILSEQ
+)
 
-	BPF_F_NO_PREALLOC         = 1 << 0
-	BPF_F_NUMA_NODE           = 0
-	BPF_F_RDONLY              = 0
-	BPF_F_WRONLY              = 0
-	BPF_F_RDONLY_PROG         = 1 << 7
-	BPF_F_WRONLY_PROG         = 1 << 8
-	BPF_F_SLEEPABLE           = 0
-	BPF_F_MMAPABLE            = 1 << 10
-	BPF_F_INNER_MAP           = 0
-	BPF_F_KPROBE_MULTI_RETURN = 0
-	BPF_OBJ_NAME_LEN          = 0x10
-	BPF_TAG_SIZE              = 0x8
-	BPF_RINGBUF_BUSY_BIT      = 0
-	BPF_RINGBUF_DISCARD_BIT   = 0
-	BPF_RINGBUF_HDR_SZ        = 0
-	SYS_BPF                   = 321
-	F_DUPFD_CLOEXEC           = 0x406
-	EPOLLIN                   = 0x1
-	EPOLL_CTL_ADD             = 0x1
-	EPOLL_CLOEXEC             = 0x80000
-	O_CLOEXEC                 = 0x80000
-	O_NONBLOCK                = 0x800
-	PROT_READ                 = 0x1
-	PROT_WRITE                = 0x2
-	MAP_SHARED                = 0x1
-	PERF_ATTR_SIZE_VER1       = 0
-	PERF_TYPE_SOFTWARE        = 0x1
-	PERF_TYPE_TRACEPOINT      = 0
-	PERF_COUNT_SW_BPF_OUTPUT  = 0xa
-	PERF_EVENT_IOC_DISABLE    = 0
-	PERF_EVENT_IOC_ENABLE     = 0
-	PERF_EVENT_IOC_SET_BPF    = 0
-	PerfBitWatermark          = 0x4000
-	PERF_SAMPLE_RAW           = 0x400
-	PERF_FLAG_FD_CLOEXEC      = 0x8
-	RLIM_INFINITY             = 0x7fffffffffffffff
-	RLIMIT_MEMLOCK            = 8
-	BPF_STATS_RUN_TIME        = 0
-	PERF_RECORD_LOST          = 2
-	PERF_RECORD_SAMPLE        = 9
-	AT_FDCWD                  = -0x2
-	RENAME_NOREPLACE          = 0x1
-	SO_ATTACH_BPF             = 0x32
-	SO_DETACH_BPF             = 0x1b
-	SOL_SOCKET                = 0x1
-	SIGPROF                   = 0
-
-	SIG_BLOCK   = 0
-	SIG_UNBLOCK = 0
+// Constants are distinct to avoid breaking switch statements.
+const (
+	BPF_F_NO_PREALLOC = iota
+	BPF_F_NUMA_NODE
+	BPF_F_RDONLY
+	BPF_F_WRONLY
+	BPF_F_RDONLY_PROG
+	BPF_F_WRONLY_PROG
+	BPF_F_SLEEPABLE
+	BPF_F_MMAPABLE
+	BPF_F_INNER_MAP
+	BPF_F_KPROBE_MULTI_RETURN
+	BPF_OBJ_NAME_LEN
+	BPF_TAG_SIZE
+	BPF_RINGBUF_BUSY_BIT
+	BPF_RINGBUF_DISCARD_BIT
+	BPF_RINGBUF_HDR_SZ
+	SYS_BPF
+	F_DUPFD_CLOEXEC
+	EPOLLIN
+	EPOLL_CTL_ADD
+	EPOLL_CLOEXEC
+	O_CLOEXEC
+	O_NONBLOCK
+	PROT_READ
+	PROT_WRITE
+	MAP_SHARED
+	PERF_ATTR_SIZE_VER1
+	PERF_TYPE_SOFTWARE
+	PERF_TYPE_TRACEPOINT
+	PERF_COUNT_SW_BPF_OUTPUT
+	PERF_EVENT_IOC_DISABLE
+	PERF_EVENT_IOC_ENABLE
+	PERF_EVENT_IOC_SET_BPF
+	PerfBitWatermark
+	PERF_SAMPLE_RAW
+	PERF_FLAG_FD_CLOEXEC
+	RLIM_INFINITY
+	RLIMIT_MEMLOCK
+	BPF_STATS_RUN_TIME
+	PERF_RECORD_LOST
+	PERF_RECORD_SAMPLE
+	AT_FDCWD
+	RENAME_NOREPLACE
+	SO_ATTACH_BPF
+	SO_DETACH_BPF
+	SOL_SOCKET
+	SIGPROF
+	SIG_BLOCK
+	SIG_UNBLOCK
 )
 
 type Statfs_t struct {
@@ -105,69 +108,56 @@ type Sigset_t struct {
 	Val [4]uint64
 }
 
-// Syscall is a wrapper
 func Syscall(trap, a1, a2, a3 uintptr) (r1, r2 uintptr, err syscall.Errno) {
-	return 0, 0, syscall.Errno(1)
+	return 0, 0, syscall.ENOTSUP
 }
 
-// PthreadSigmask is a wrapper
 func PthreadSigmask(how int, set, oldset *Sigset_t) error {
 	return errNonLinux
 }
 
-// FcntlInt is a wrapper
 func FcntlInt(fd uintptr, cmd, arg int) (int, error) {
 	return -1, errNonLinux
 }
 
-// IoctlSetInt is a wrapper
 func IoctlSetInt(fd int, req uint, value int) error {
 	return errNonLinux
 }
 
-// Statfs is a wrapper
 func Statfs(path string, buf *Statfs_t) error {
 	return errNonLinux
 }
 
-// Close is a wrapper
 func Close(fd int) (err error) {
 	return errNonLinux
 }
 
-// EpollEvent is a wrapper
 type EpollEvent struct {
 	Events uint32
 	Fd     int32
 	Pad    int32
 }
 
-// EpollWait is a wrapper
 func EpollWait(epfd int, events []EpollEvent, msec int) (n int, err error) {
 	return 0, errNonLinux
 }
 
-// EpollCtl is a wrapper
 func EpollCtl(epfd int, op int, fd int, event *EpollEvent) (err error) {
 	return errNonLinux
 }
 
-// Eventfd is a wrapper
 func Eventfd(initval uint, flags int) (fd int, err error) {
 	return 0, errNonLinux
 }
 
-// Write is a wrapper
 func Write(fd int, p []byte) (n int, err error) {
 	return 0, errNonLinux
 }
 
-// EpollCreate1 is a wrapper
 func EpollCreate1(flag int) (fd int, err error) {
 	return 0, errNonLinux
 }
 
-// PerfEventMmapPage is a wrapper
 type PerfEventMmapPage struct {
 	Version        uint32
 	Compat_version uint32
@@ -194,22 +184,18 @@ type PerfEventMmapPage struct {
 	Aux_size    uint64
 }
 
-// SetNonblock is a wrapper
 func SetNonblock(fd int, nonblocking bool) (err error) {
 	return errNonLinux
 }
 
-// Mmap is a wrapper
 func Mmap(fd int, offset int64, length int, prot int, flags int) (data []byte, err error) {
 	return []byte{}, errNonLinux
 }
 
-// Munmap is a wrapper
 func Munmap(b []byte) (err error) {
 	return errNonLinux
 }
 
-// PerfEventAttr is a wrapper
 type PerfEventAttr struct {
 	Type               uint32
 	Size               uint32
@@ -231,48 +217,39 @@ type PerfEventAttr struct {
 	Sample_max_stack   uint16
 }
 
-// PerfEventOpen is a wrapper
 func PerfEventOpen(attr *PerfEventAttr, pid int, cpu int, groupFd int, flags int) (fd int, err error) {
 	return 0, errNonLinux
 }
 
-// Utsname is a wrapper
 type Utsname struct {
 	Release [65]byte
 	Version [65]byte
 }
 
-// Uname is a wrapper
 func Uname(buf *Utsname) (err error) {
 	return errNonLinux
 }
 
-// Getpid is a wrapper
 func Getpid() int {
 	return -1
 }
 
-// Gettid is a wrapper
 func Gettid() int {
 	return -1
 }
 
-// Tgkill is a wrapper
 func Tgkill(tgid int, tid int, sig syscall.Signal) (err error) {
 	return errNonLinux
 }
 
-// BytePtrFromString is a wrapper
 func BytePtrFromString(s string) (*byte, error) {
 	return nil, errNonLinux
 }
 
-// ByteSliceToString is a wrapper
 func ByteSliceToString(s []byte) string {
 	return ""
 }
 
-// Renameat2 is a wrapper
 func Renameat2(olddirfd int, oldpath string, newdirfd int, newpath string, flags uint) error {
 	return errNonLinux
 }


### PR DESCRIPTION
Document why the package exists, and how stubs will behave on non-Linux OS. Simplify constants for other OS by giving them a distinct but meaninless value. Always use type aliases for structs on Linux and remove boilerplate function comments.