### PR TITLE
link: Allow kprobe multi to be disabled in kernel

### DIFF
--- a/internal/unix/types_linux.go
+++ b/internal/unix/types_linux.go
@@ -9,21 +9,22 @@ import (
 )
 
 const (
-	ENOENT  = linux.ENOENT
-	EEXIST  = linux.EEXIST
-	EAGAIN  = linux.EAGAIN
-	ENOSPC  = linux.ENOSPC
-	EINVAL  = linux.EINVAL
-	EPOLLIN = linux.EPOLLIN
-	EINTR   = linux.EINTR
-	EPERM   = linux.EPERM
-	ESRCH   = linux.ESRCH
-	ENODEV  = linux.ENODEV
-	EBADF   = linux.EBADF
-	E2BIG   = linux.E2BIG
-	EFAULT  = linux.EFAULT
-	EACCES  = linux.EACCES
-	EILSEQ  = linux.EILSEQ
+	ENOENT     = linux.ENOENT
+	EEXIST     = linux.EEXIST
+	EAGAIN     = linux.EAGAIN
+	ENOSPC     = linux.ENOSPC
+	EINVAL     = linux.EINVAL
+	EPOLLIN    = linux.EPOLLIN
+	EINTR      = linux.EINTR
+	EPERM      = linux.EPERM
+	ESRCH      = linux.ESRCH
+	ENODEV     = linux.ENODEV
+	EBADF      = linux.EBADF
+	E2BIG      = linux.E2BIG
+	EFAULT     = linux.EFAULT
+	EACCES     = linux.EACCES
+	EILSEQ     = linux.EILSEQ
+	EOPNOTSUPP = linux.EOPNOTSUPP
 )
 
 const (

--- a/internal/unix/types_other.go
+++ b/internal/unix/types_other.go
@@ -26,6 +26,7 @@ const (
 	EFAULT
 	EACCES
 	EILSEQ
+	EOPNOTSUPP
 )
 
 // Constants are distinct to avoid breaking switch statements.

--- a/link/kprobe_multi.go
+++ b/link/kprobe_multi.go
@@ -164,12 +164,16 @@ var haveBPFLinkKprobeMulti = internal.FeatureTest("bpf_link_kprobe_multi", "5.18
 		Count:      1,
 		Syms:       sys.NewStringSlicePointer([]string{"vprintk"}),
 	})
-	if errors.Is(err, unix.EINVAL) {
+	switch {
+	case errors.Is(err, unix.EINVAL):
 		return internal.ErrNotSupported
-	}
-	if err != nil {
+	// If CONFIG_FPROBE isn't set.
+	case errors.Is(err, unix.EOPNOTSUPP):
+		return internal.ErrNotSupported
+	case err != nil:
 		return err
 	}
+
 	fd.Close()
 
 	return nil


### PR DESCRIPTION
Kprobe multi support is gated on CONFIG_FPROBE, without it creating the link fails with ENOTSUP: https://elixir.bootlin.com/linux/latest/source/include/linux/fprobe.h#L56

Unfortunately the standard Debian sid kernel does not have it enabled.

Update the kprobe multi test to handle ENOTSUP, and drop the minimum kernel version check, tests otherwise fail with:

Feature 'bpf_link_kprobe_multi' isn't supported even though kernel v5.19.11 is newer than v5.18