### PR TITLE
perf: Add options to create over writable and backward written perf ring buffer

### DIFF
--- a/perf/reader.go
+++ b/perf/reader.go
@@ -166,6 +166,8 @@ type ReaderOptions struct {
 	Watermark     int
 	// This perf ring buffer will be written from backward.
 	WriteBackward bool
+	// This perf ring buffer will be over writable.
+	OverWritable bool
 }
 
 // NewReader creates a new reader with default options.
@@ -213,7 +215,7 @@ func NewReaderWithOptions(array *ebpf.Map, perCPUBuffer int, opts ReaderOptions)
 	// but doesn't allow using a wildcard like -1 to specify "all CPUs".
 	// Hence we have to create a ring for each CPU.
 	for i := 0; i < nCPU; i++ {
-		ring, err := newPerfEventRing(i, perCPUBuffer, opts.Watermark, opts.WriteBackward)
+		ring, err := newPerfEventRing(i, perCPUBuffer, opts.Watermark, opts.WriteBackward, opts.OverWritable)
 		if errors.Is(err, unix.ENODEV) {
 			// The requested CPU is currently offline, skip it.
 			rings = append(rings, nil)

--- a/perf/ring_test.go
+++ b/perf/ring_test.go
@@ -66,7 +66,7 @@ func makeRing(size, offset int) *ringReader {
 
 func TestPerfEventRing(t *testing.T) {
 	check := func(buffer, watermark int) {
-		ring, err := newPerfEventRing(0, buffer, watermark, false)
+		ring, err := newPerfEventRing(0, buffer, watermark, false, false)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -89,13 +89,13 @@ func TestPerfEventRing(t *testing.T) {
 	}
 
 	// watermark > buffer
-	_, err := newPerfEventRing(0, 8192, 8193, false)
+	_, err := newPerfEventRing(0, 8192, 8193, false, false)
 	if err == nil {
 		t.Fatal("watermark > buffer allowed")
 	}
 
 	// watermark == buffer
-	_, err = newPerfEventRing(0, 8192, 8192, false)
+	_, err = newPerfEventRing(0, 8192, 8192, false, false)
 	if err == nil {
 		t.Fatal("watermark == buffer allowed")
 	}


### PR DESCRIPTION
Hi.


First, I hope you are fine and the same for your relatives.

For a specific tool, I need to create overwritable and backward written perf ring buffers.
So, this PR adds two new options to `ReaderOptions`:

1. `WriteBackward` which indicates to the kernel the perf ring buffer should be written backward as it was implemented in this upstream [commit](https://github.com/torvalds/linux/commit/9ecda41acb971ebd07c8fb35faf24005c0baea12).
2. `OverWritable` which means the older events will be over written by newer ones. To do so, we only `mmap` perf ring buffer as read only.

I already wrote a function to read this kind of buffer by invoking a callback for each read event but I cannot ensure this function is totally ready as I did not get any feedback on it for the moment and I still need to modify it as I use `reflect` a lot.
Nonetheless, I think this contribution can be easily split in a first part dealing with the buffer creation and a second one to actually read the buffer.

If you see any way to improve this PR, do not hesitate to share.


Best regards and thank you in advance.