### PR TITLE
map, prog: fix broken links

### DIFF
--- a/map.go
+++ b/map.go
@@ -1095,7 +1095,8 @@ func (m *Map) Clone() (*Map, error) {
 // the new path already exists. Re-pinning across filesystems is not supported.
 // You can Clone a map to pin it to a different path.
 //
-// This requires bpffs to be mounted above fileName. See https://docs.cilium.io/en/k8s-doc/admin/#admin-mount-bpffs
+// This requires bpffs to be mounted above fileName.
+// See https://docs.cilium.io/en/stable/concepts/kubernetes/configuration/#mounting-bpffs-with-systemd
 func (m *Map) Pin(fileName string) error {
 	if err := internal.Pin(m.pinnedPath, fileName, m.fd); err != nil {
 		return err

--- a/prog.go
+++ b/prog.go
@@ -477,7 +477,8 @@ func (p *Program) Clone() (*Program, error) {
 // Calling Pin on a previously pinned program will overwrite the path, except when
 // the new path already exists. Re-pinning across filesystems is not supported.
 //
-// This requires bpffs to be mounted above fileName. See https://docs.cilium.io/en/k8s-doc/admin/#admin-mount-bpffs
+// This requires bpffs to be mounted above fileName.
+// See https://docs.cilium.io/en/stable/concepts/kubernetes/configuration/#mounting-bpffs-with-systemd
 func (p *Program) Pin(fileName string) error {
 	if err := internal.Pin(p.pinnedPath, fileName, p.fd); err != nil {
 		return err


### PR DESCRIPTION
Looks like [docs.cilium.io/en/k8s-doc/admin/#admin-mount-bpffs](https://docs.cilium.io/en/k8s-doc/admin/#admin-mount-bpffs) link is broken. It redirects itself.

```
~ ❯ curl -L https://docs.cilium.io/en/k8s-doc/admin -v
< HTTP/2 302 
< location: /en/k8s-doc/admin/

curl: (47) Maximum (50) redirects followed
```

I updated the link as [https://docs.cilium.io/en/stable/concepts/kubernetes/configuration/#mounting-bpffs-with-systemd](https://docs.cilium.io/en/stable/concepts/kubernetes/configuration/#mounting-bpffs-with-systemd), I guess it's the correct one.