### PR TITLE
Add IsPinned() to RawLink

### DIFF
--- a/link/link.go
+++ b/link/link.go
@@ -230,6 +230,11 @@ func (l *RawLink) Unpin() error {
 	return nil
 }
 
+// IsPinned returns true if the Link has a non-empty pinned path.
+func (l *RawLink) IsPinned() bool {
+	return l.pinnedPath != ""
+}
+
 // Update implements the Link interface.
 func (l *RawLink) Update(new *ebpf.Program) error {
 	return l.UpdateArgs(RawLinkUpdateOptions{


### PR DESCRIPTION
Map and Prog have IsPinned() func but RawLink doesn't have it. I added IsPinned() to RawLink. Also seems Unpin method of Rawlink doesn't have a test, I added it too.