### PR TITLE
ebpf: Allow to pass custom attr to perf ring reader

### DIFF
--- a/perf/reader_test.go
+++ b/perf/reader_test.go
@@ -299,7 +299,7 @@ func TestPerfReaderClose(t *testing.T) {
 }
 
 func TestCreatePerfEvent(t *testing.T) {
-	fd, err := createPerfEvent(0, 1)
+	fd, err := createPerfEvent(0, 1, nil)
 	if err != nil {
 		t.Fatal("Can't create perf event:", err)
 	}
@@ -315,7 +315,7 @@ func TestReadRecord(t *testing.T) {
 	}
 
 	var rec Record
-	err = readRecord(&buf, &rec, make([]byte, perfEventHeaderSize))
+	err = readRecord(&buf, &rec, make([]byte, perfEventHeaderSize), false)
 	if !IsUnknownEvent(err) {
 		t.Error("readRecord should return unknown event error, got", err)
 	}

--- a/perf/ring_test.go
+++ b/perf/ring_test.go
@@ -66,7 +66,7 @@ func makeRing(size, offset int) *ringReader {
 
 func TestPerfEventRing(t *testing.T) {
 	check := func(buffer, watermark int) {
-		ring, err := newPerfEventRing(0, buffer, watermark)
+		ring, err := newPerfEventRing(0, buffer, watermark, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -89,13 +89,13 @@ func TestPerfEventRing(t *testing.T) {
 	}
 
 	// watermark > buffer
-	_, err := newPerfEventRing(0, 8192, 8193)
+	_, err := newPerfEventRing(0, 8192, 8193, nil)
 	if err == nil {
 		t.Fatal("watermark > buffer allowed")
 	}
 
 	// watermark == buffer
-	_, err = newPerfEventRing(0, 8192, 8192)
+	_, err = newPerfEventRing(0, 8192, 8192, nil)
 	if err == nil {
 		t.Fatal("watermark == buffer allowed")
 	}


### PR DESCRIPTION
Adding support to pass custom perf event attribute object into
ReaderOptions that will be used to create event for perf reader.

Once there's custom attr defined the reader will not parse sample
events but will return the full event array in Record.RawEvent array.

This change allow user to create specific configuration for perf
event. At the same time it's now responsibility of the user to parse
received events.

Signed-off-by: Jiri Olsa <jolsa@kernel.org>
