### PR TITLE
program: clarify how to use VerifierError

### DIFF
--- a/prog.go
+++ b/prog.go
@@ -151,6 +151,10 @@ func (ps *ProgramSpec) Tag() (string, error) {
 	return ps.Instructions.Tag(internal.NativeEndian)
 }
 
+// VerifierError is returned by [NewProgram] and [NewProgramWithOptions] if a
+// program is rejected by the verifier.
+//
+// Use [errors.As] to access the error.
 type VerifierError = internal.VerifierError
 
 // Program represents BPF program loaded into the kernel.
@@ -179,8 +183,7 @@ func NewProgram(spec *ProgramSpec) (*Program, error) {
 // Loading a program for the first time will perform
 // feature detection by loading small, temporary programs.
 //
-// Returns an error wrapping VerifierError if the program or its BTF is rejected
-// by the kernel.
+// Returns a wrapped [VerifierError] if the program is rejected by the kernel.
 func NewProgramWithOptions(spec *ProgramSpec, opts ProgramOptions) (*Program, error) {
 	if spec == nil {
 		return nil, errors.New("can't load a program from a nil spec")

--- a/prog_test.go
+++ b/prog_test.go
@@ -873,8 +873,8 @@ func mustSocketFilter(tb testing.TB) *Program {
 	return prog
 }
 
-// Retrieve a verifier error when loading a program fails.
-func ExampleProgram_verifierError() {
+// Print the full verifier log when loading a program fails.
+func ExampleProgram_verboseVerifierError() {
 	_, err := NewProgram(&ProgramSpec{
 		Type: SocketFilter,
 		Instructions: asm.Instructions{
@@ -895,7 +895,7 @@ func ExampleProgram_verifierError() {
 // Use NewProgramWithOptions if you'd like to get the verifier output
 // for a program, or if you want to change the buffer size used when
 // generating error messages.
-func ExampleProgram_retrieveVerifierOutput() {
+func ExampleProgram_retrieveVerifierLog() {
 	spec := &ProgramSpec{
 		Type: SocketFilter,
 		Instructions: asm.Instructions{


### PR DESCRIPTION
Add more cross references betwen VerifierError and NewProgram* and reword the example to hopefully be more explicit.