### PR TITLE
btf: support enum64

### DIFF
--- a/btf/btf_types.go
+++ b/btf/btf_types.go
@@ -36,6 +36,8 @@ const (
 	// Added 5.16
 	kindDeclTag // DeclTag
 	kindTypeTag // TypeTag
+	// Added 6.0
+	kindEnum64 // Enum64
 )
 
 // FuncLinkage describes BTF function linkage metadata.
@@ -279,6 +281,12 @@ type btfEnum struct {
 	Val     uint32
 }
 
+type btfEnum64 struct {
+	NameOff uint32
+	ValLo32 uint32
+	ValHi32 uint32
+}
+
 type btfParam struct {
 	NameOff uint32
 	Type    TypeID
@@ -333,6 +341,8 @@ func readTypes(r io.Reader, bo binary.ByteOrder, typeLen uint32) ([]rawType, err
 		case kindDeclTag:
 			data = new(btfDeclTag)
 		case kindTypeTag:
+		case kindEnum64:
+			data = make([]btfEnum64, header.Vlen())
 		default:
 			return nil, fmt.Errorf("type id %v: unknown kind: %v", id, header.Kind())
 		}

--- a/btf/btf_types_string.go
+++ b/btf/btf_types_string.go
@@ -65,11 +65,12 @@ func _() {
 	_ = x[kindFloat-16]
 	_ = x[kindDeclTag-17]
 	_ = x[kindTypeTag-18]
+	_ = x[kindEnum64-19]
 }
 
-const _btfKind_name = "UnknownIntPointerArrayStructUnionEnumForwardTypedefVolatileConstRestrictFuncFuncProtoVarDatasecFloatDeclTagTypeTag"
+const _btfKind_name = "UnknownIntPointerArrayStructUnionEnumForwardTypedefVolatileConstRestrictFuncFuncProtoVarDatasecFloatDeclTagTypeTagkindEnum64"
 
-var _btfKind_index = [...]uint8{0, 7, 10, 17, 22, 28, 33, 37, 44, 51, 59, 64, 72, 76, 85, 88, 95, 100, 107, 114}
+var _btfKind_index = [...]uint8{0, 7, 10, 17, 22, 28, 33, 37, 44, 51, 59, 64, 72, 76, 85, 88, 95, 100, 107, 114, 124}
 
 func (i btfKind) String() string {
 	if i >= btfKind(len(_btfKind_index)-1) {

--- a/btf/types.go
+++ b/btf/types.go
@@ -276,6 +276,21 @@ func (e *Enum) copy() Type {
 	return &cpy
 }
 
+// has64BitValues returns true if the Enum contains a value larger than 32 bits.
+// Kernels before 6.0 have enum values that overrun u32 replaced with zeroes.
+//
+// 64-bit enums have their Enum.Size attributes correctly set to 8, but if we
+// use the size attribute as a heuristic during BTF marshaling, we'll emit
+// ENUM64s to kernels that don't support them.
+func (e *Enum) has64BitValues() bool {
+	for _, v := range e.Values {
+		if v.Value > math.MaxUint32 {
+			return true
+		}
+	}
+	return false
+}
+
 // FwdKind is the type of forward declaration.
 type FwdKind int
 

--- a/btf/types.go
+++ b/btf/types.go
@@ -982,6 +982,19 @@ func inflateRawTypes(rawTypes []rawType, baseTypes types, rawStrings *stringTabl
 			fixup(raw.Type(), &tt.Type)
 			typ = tt
 
+		case kindEnum64:
+			rawvals := raw.data.([]btfEnum64)
+			vals := make([]EnumValue, 0, len(rawvals))
+			for i, btfVal := range rawvals {
+				name, err := rawStrings.Lookup(btfVal.NameOff)
+				if err != nil {
+					return nil, fmt.Errorf("get name for enum64 value %d: %s", i, err)
+				}
+				value := (uint64(btfVal.ValHi32) << 32) | uint64(btfVal.ValLo32)
+				vals = append(vals, EnumValue{name, value})
+			}
+			typ = &Enum{name, raw.Size(), raw.Signed(), vals}
+
 		default:
 			return nil, fmt.Errorf("type id %d: unknown kind: %v", id, raw.Kind())
 		}


### PR DESCRIPTION
Implement support for the BTF_KIND_ENUM64 added in Linux 6.0 kernels. As discussed in https://github.com/cilium/ebpf/issues/780, the idea is to reuse the existing Enum type for the new enum64 since it has been extended to fit 64 bit values.

The majority of this implementation has been compied over from the original enum implementation. btfEnum64 layout comes from https://docs.kernel.org/bpf/btf.html?highlight=btf#btf-kind-enum64.

Please review carefully, as I'm not super familiar with the requirements here. Mostly just working off of what's already been done for the original enum type.

Fixes #780