### PR TITLE
Add uname parsing fallback path to KernelVersion()

### DIFF
--- a/internal/version_test.go
+++ b/internal/version_test.go
@@ -95,3 +95,26 @@ func TestKernelRelease(t *testing.T) {
 		t.Fatal("unexpected empty kernel release")
 	}
 }
+
+func TestParseKernelRelease(t *testing.T) {
+	var tests = []struct {
+		in   string
+		want Version
+	}{
+		{"5.15.17-1-lts", Version{5, 15, 17}},
+		{"4.19.0-16-amd6", Version{4, 19, 0}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			v, err := ParseKernelRelease(tt.in)
+			if err != nil {
+				t.Error(err)
+			}
+
+			if v != tt.want {
+				t.Errorf("got %v, want %v", v, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
It turns out if filecaps are assigned to a binary, it affects the processes "dumpability" (see `PR_SET_DUMPABLE` section in `man prctl`). When a process isn't globally dumpable, `/proc/self/auxv` is owned by `root:root`.

Put together, what this means is that if an executable uses this library and is assigned filecaps but run as a normal user, this library errors out when reading from `/proc/self/auxv`.

You can confirm this existing behavior by running this on master:

    $ cd internal
    $ go test -c
    $ sudo setcap cap_net_admin,cap_sys_admin+p internal.test
    $ ./internal.test
    --- FAIL: TestCurrentKernelVersion (0.00s)
        version_test.go:53: opening auxv: open /proc/self/auxv: permission denied
    FAIL

This commit makes `KernelVersion()` more reliable by adding a best-effort uname parsing codepath.

More details about the filecaps interaction is available here: https://dxuuu.xyz/filecaps.html .