### PR TITLE
internal: detect if /proc/self/auxv is not readable due to file caps

### DIFF
--- a/internal/vdso.go
+++ b/internal/vdso.go
@@ -23,6 +23,9 @@ func vdsoVersion() (uint32, error) {
 	// to the process. Go does not expose that data, so we must read it from procfs.
 	// https://man7.org/linux/man-pages/man3/getauxval.3.html
 	av, err := os.Open("/proc/self/auxv")
+	if errors.Is(err, unix.EACCES) {
+		return 0, fmt.Errorf("opening auxv: %w (process may not be dumpable due to file capabilities)", err)
+	}
 	if err != nil {
 		return 0, fmt.Errorf("opening auxv: %w", err)
 	}


### PR DESCRIPTION
As reported by Daniel Xu, setting capabilities on an executable file will prevent reading /proc/self/auxv since the file is owned by root. The work arounds to this have various trade offs, so the best we can do is tell the user why we failed and hope they check out our discussion or create an issue.

See https://github.com/cilium/ebpf/pull/823