### PR TITLE
btf: add specialised typeMap

### DIFF
--- a/btf/btf_test.go
+++ b/btf/btf_test.go
@@ -313,6 +313,12 @@ func TestLoadSpecFromElf(t *testing.T) {
 			t.Errorf("Expected Void for type id 0, but got: %T", vt)
 		}
 
+		if id, err := spec.TypeID(vt); err != nil {
+			t.Error("Error when looking up type id for Void:", err)
+		} else if id != 0 {
+			t.Error("Expected Void to have id 0, got", id)
+		}
+
 		var bpfMapDef *Struct
 		if err := spec.TypeByName("bpf_map_def", &bpfMapDef); err != nil {
 			t.Error("Can't find bpf_map_def:", err)

--- a/btf/traversal.go
+++ b/btf/traversal.go
@@ -20,7 +20,7 @@ type postorderIterator struct {
 	// Contains a boolean whether the type has been walked or not.
 	walked internal.Deque[bool]
 	// The set of types which has been pushed onto types.
-	pushed map[Type]struct{}
+	pushed typeMap[struct{}]
 
 	// The current type. Only valid after a call to Next().
 	Type Type
@@ -43,7 +43,7 @@ func postorderTraversal(root Type, skip func(Type) (skip bool)) postorderIterato
 }
 
 func (po *postorderIterator) push(t *Type) {
-	if _, ok := po.pushed[*t]; ok || *t == po.root {
+	if _, ok := po.pushed.Get(*t); ok || *t == po.root {
 		return
 	}
 
@@ -53,10 +53,10 @@ func (po *postorderIterator) push(t *Type) {
 
 	if po.pushed == nil {
 		// Lazily allocate pushed to avoid an allocation for Types without children.
-		po.pushed = make(map[Type]struct{})
+		po.pushed = make(typeMap[struct{}])
 	}
 
-	po.pushed[*t] = struct{}{}
+	po.pushed.Set(*t, struct{}{})
 	po.types.Push(t)
 	po.walked.Push(false)
 }

--- a/btf/type_map.go
+++ b/btf/type_map.go
@@ -44,7 +44,8 @@ func newTypeKey(t Type) typeKey {
 		// same pointer. Since Void is zero sized, we may end up with multiple
 		// entries for a void type.
 		//
-		// Instead, we use the pointer to the reflect.Type as the ID.
+		// Instead, we use the pointer to the reflect.Type as the ID. This also
+		// removes the distinction between Type((*Void)(nil)) and Type(&Void{}).
 		return voidTypeID
 	default:
 		// This assumes that all implementations of Type use pointer receivers.

--- a/btf/type_map.go
+++ b/btf/type_map.go
@@ -1,0 +1,53 @@
+package btf
+
+import (
+	"reflect"
+	"unsafe"
+)
+
+// typeMap is a faster alternative to a map[Type]V.
+//
+// Using an interface as the key to a map is quite slow, so we use unsafe tricks
+// to only use the pointer part of a Type interface as the key. This way we
+// benefit from 64 bit key optimizations in the runtime map implementation.
+type typeMap[V any] map[typeKey]V
+
+func (tm typeMap[V]) Set(k Type, v V) {
+	tm[newTypeKey(k)] = v
+}
+
+func (tm typeMap[V]) Get(k Type) (V, bool) {
+	v, ok := tm[newTypeKey(k)]
+	return v, ok
+}
+
+type typeKey struct {
+	// A pointer which uniquely identifies a value that implements Type. This is
+	// not always a pointer to a value, see newTypeKey.
+	//
+	// YOU MUST NOT CAST THIS TO A TYPE.
+	ptr unsafe.Pointer
+}
+
+var voidTypeID = typeKey{reflect.ValueOf(reflect.TypeOf(&Void{})).UnsafePointer()}
+
+func newTypeKey(t Type) typeKey {
+	switch t.(type) {
+	case *Void:
+		// We assume that the address of a Type value is unique, and can therefore
+		// be used as a key. There is one minor hitch:
+		//
+		//     Two distinct zero-size variables may have the same address in memory.
+		//     https://go.dev/ref/spec#Size_and_alignment_guarantees
+		//
+		// A variable with a zero sized type is not required to always have the
+		// same pointer. Since Void is zero sized, we may end up with multiple
+		// entries for a void type.
+		//
+		// Instead, we use the pointer to the reflect.Type as the ID.
+		return voidTypeID
+	default:
+		// This assumes that all implementations of Type use pointer receivers.
+		return typeKey{reflect.ValueOf(t).UnsafePointer()}
+	}
+}

--- a/btf/type_map_test.go
+++ b/btf/type_map_test.go
@@ -1,0 +1,67 @@
+package btf
+
+import "testing"
+
+func TestTypeMap(t *testing.T) {
+	m := make(typeMap[int])
+
+	a := new(Int)
+	b := new(Int)
+
+	m.Set(a, 42)
+	if v, ok := m.Get(a); !ok {
+		t.Error("Expected a to be present")
+	} else if v != 42 {
+		t.Error("Expected a to be 42, got", v)
+	}
+
+	if _, ok := m.Get(b); ok {
+		t.Error("Expected b to be absent")
+	}
+
+	m.Set(b, 23)
+	if v, ok := m.Get(b); !ok {
+		t.Error("Expected b to be present")
+	} else if v != 23 {
+		t.Error("Expected b to be 23, got", v)
+	}
+
+	if v, _ := m.Get(a); v != 42 {
+		t.Error("Expected a to be 42 after setting b, got", v)
+	}
+}
+
+func BenchmarkTypeMapGet(b *testing.B) {
+	types := make([]Type, 100000)
+	for i := range types {
+		types[i] = new(Int)
+	}
+
+	typ := types[0]
+
+	b.Run("typeMap", func(b *testing.B) {
+		m := make(typeMap[struct{}])
+		for _, t := range types {
+			m.Set(t, struct{}{})
+		}
+
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			m.Get(typ)
+		}
+	})
+
+	b.Run("map[Type]", func(b *testing.B) {
+		m := make(map[Type]struct{})
+		for _, t := range types {
+			m[t] = struct{}{}
+		}
+
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			_, _ = m[typ]
+		}
+	})
+}

--- a/btf/type_map_test.go
+++ b/btf/type_map_test.go
@@ -31,6 +31,17 @@ func TestTypeMap(t *testing.T) {
 	}
 }
 
+func TestTypeMapVoid(t *testing.T) {
+	m := make(typeMap[int])
+
+	m.Set(&Void{}, 23)
+	if v, ok := m.Get((*Void)(nil)); !ok {
+		t.Fatal("(*Void)(nil) is not treated the same as &Void{}")
+	} else if v != 23 {
+		t.Fatal("Expected value 23, got", v)
+	}
+}
+
 func BenchmarkTypeMapGet(b *testing.B) {
 	types := make([]Type, 100000)
 	for i := range types {

--- a/btf/types_test.go
+++ b/btf/types_test.go
@@ -169,6 +169,9 @@ func TestType(t *testing.T) {
 			if diff := cmp.Diff(a, b, compareTypes); diff != "" {
 				t.Errorf("Walk mismatch (-want +got):\n%s", diff)
 			}
+
+			// Make sure nothing panics here.
+			_ = newTypeKey(typ)
 		})
 	}
 }


### PR DESCRIPTION
This PR improves marshaling vmlinux BTF. I tried to benchmark `NewCollection` as well, but that causes oomkills due to some weird kernel interaction. I've not replaced all occurrences of `map[Type]` with `typeMap`, since it only makes sense in a few places I think.

I think it's also OK to decide that the speedup is not worth it.

btf: add typeMap
    
    Add a specialised map that has a Type as its key. Using an interface as
    map key has two downsides:
    
    1. An interface is two pointers, one for type information the other
       for actual data.
    2. Comparing an interface key is slower than comparing a uint64 key
    
    Replace the interface with typeKey, which is just a wrapper around
    an unsafe pointer. That pointer is usually the data pointer of the
    interface value.
    
    Special care needs to be taken for Void, since it is a zero sized
    type. Instead of using the interface's data pointer we use the type
    information pointer as the key.
    
    This makes lookups roughly 10% faster and saves some memory since
    we only have to store one instead of two pointers. It also
    gracefully deals with Void, which removes some corner cases.
    
    The downside is that keys become meaningless: it's not possible
    to iterate a typeMap and retrieve the Type from the key.
    
        BenchmarkTypeMapGet/typeMap-4       158417788  7.582 ns/op
        BenchmarkTypeMapGet/map[Type]-4     141518359  8.253 ns/op

btf: use typeMap for postorder traversal
    
    name                                      old time/op    new time/op    delta
    PostorderTraversal/single_type-4            18.5ns ± 0%    18.5ns ± 0%     ~     (p=0.514 n=4+4)
    PostorderTraversal/cycle(1)-4                197ns ± 1%     184ns ± 1%   -7.05%  (p=0.029 n=4+4)
    PostorderTraversal/cycle(10)-4              1.03µs ± 0%    0.94µs ± 0%   -8.54%  (p=0.029 n=4+4)
    PostorderTraversal/gov_update_cpu_data-4     923µs ± 0%     829µs ± 0%  -10.21%  (p=0.029 n=4+4)
    
    name                                      old alloc/op   new alloc/op   delta
    PostorderTraversal/single_type-4             0.00B          0.00B          ~     (all equal)
    PostorderTraversal/cycle(1)-4                 264B ± 0%      200B ± 0%  -24.24%  (p=0.029 n=4+4)
    PostorderTraversal/cycle(10)-4                716B ± 0%      515B ± 0%  -28.07%  (p=0.029 n=4+4)
    PostorderTraversal/gov_update_cpu_data-4     364kB ± 0%     211kB ± 0%  -42.15%  (p=0.029 n=4+4)
    
    name                                      old allocs/op  new allocs/op  delta
    PostorderTraversal/single_type-4              0.00           0.00          ~     (all equal)
    PostorderTraversal/cycle(1)-4                 4.00 ± 0%      4.00 ± 0%     ~     (all equal)
    PostorderTraversal/cycle(10)-4                7.00 ± 0%      7.00 ± 0%     ~     (all equal)
    PostorderTraversal/gov_update_cpu_data-4       152 ± 0%       133 ± 0%  -12.79%  (p=0.029 n=4+4)

btf: use typeMap when marshaling BTF
    
    Use typeMap to store allocated IDs. I had to run benchmarks with swap
    and the GC disabled to get reliable timings. I therefore expect the
    real-life impact of this change to be larger than what the benchmark
    indicates.
    
        name            old time/op    new time/op    delta
        BuildVmlinux-4    69.9ms ± 0%    66.3ms ± 1%   -5.16%  (p=0.029 n=4+4)
    
        name            old alloc/op   new alloc/op   delta
        BuildVmlinux-4    37.8MB ± 0%    33.1MB ± 0%  -12.58%  (p=0.029 n=4+4)
    
        name            old allocs/op  new allocs/op  delta
        BuildVmlinux-4      436k ± 0%      436k ± 0%   -0.01%  (p=0.029 n=4+4)

btf: use typeMap to store TypeID in Spec
    
    Replace map[Type]TypeID with typeMap[TypeID]. The primary benefit is that we
    can drop the explicit check for Void in TypeID() since typeMap correctly
    handles that type.
