### PR TITLE
elf_reader: check if ELF is for BPF data

### DIFF
--- a/elf_reader.go
+++ b/elf_reader.go
@@ -51,6 +51,12 @@ func LoadCollectionSpecFromReader(rd io.ReaderAt) (*CollectionSpec, error) {
 		return nil, err
 	}
 
+	// Checks if the ELF file is for BPF data.
+	// Old LLVM versions set e_machine to EM_NONE.
+	if f.File.Machine != unix.EM_NONE && f.File.Machine != elf.EM_BPF {
+		return nil, fmt.Errorf("unexpected machine type for BPF ELF: %s", f.File.Machine)
+	}
+
 	var (
 		licenseSection *elf.Section
 		versionSection *elf.Section

--- a/internal/unix/types_linux.go
+++ b/internal/unix/types_linux.go
@@ -75,6 +75,8 @@ const (
 	SIGPROF                   = linux.SIGPROF
 	SIG_BLOCK                 = linux.SIG_BLOCK
 	SIG_UNBLOCK               = linux.SIG_UNBLOCK
+	EM_NONE                   = linux.EM_NONE
+	EM_BPF                    = linux.EM_BPF
 )
 
 type Statfs_t = linux.Statfs_t

--- a/internal/unix/types_other.go
+++ b/internal/unix/types_other.go
@@ -79,6 +79,8 @@ const (
 	SIGPROF
 	SIG_BLOCK
 	SIG_UNBLOCK
+	EM_NONE
+	EM_BPF
 )
 
 type Statfs_t struct {


### PR DESCRIPTION
Signed-off-by: Florian Lehner <dev@der-flo.net>

Perfom a basic check on the given ELF. This change adopts the check that is happening also in other loader:

https://github.com/libbpf/libbpf/blob/c97b16d96c8b1771973dba1596477f7d7e9ba201/src/libbpf.c#L1380-L1385