### PR TITLE
asm: add .WithMetadata() for conveniently replacing individual Instructions

### DIFF
--- a/asm/instruction.go
+++ b/asm/instruction.go
@@ -354,6 +354,13 @@ func (ins Instruction) Size() uint64 {
 	return uint64(InstructionSize * ins.OpCode.rawInstructions())
 }
 
+// WithMetadata sets the given Metadata on the Instruction. e.g. to copy
+// Metadata from another Instruction when replacing it.
+func (ins Instruction) WithMetadata(meta Metadata) Instruction {
+	ins.Metadata = meta
+	return ins
+}
+
 type symbolMeta struct{}
 
 // WithSymbol marks the Instruction as a Symbol, which other Instructions

--- a/asm/instruction_test.go
+++ b/asm/instruction_test.go
@@ -177,6 +177,19 @@ func TestInstructionsRewriteMapPtr(t *testing.T) {
 	}
 }
 
+func TestInstructionWithMetadata(t *testing.T) {
+	ins := LoadImm(R0, 123, DWord).WithSymbol("abc")
+	ins2 := LoadImm(R0, 567, DWord).WithMetadata(ins.Metadata)
+
+	if want, got := "abc", ins2.Symbol(); want != got {
+		t.Fatalf("unexpected Symbol value on ins2: want: %s, got: %s", want, got)
+	}
+
+	if want, got := ins.Metadata, ins2.Metadata; want != got {
+		t.Fatal("expected ins and isn2 Metadata to match")
+	}
+}
+
 // You can use format flags to change the way an eBPF
 // program is stringified.
 func ExampleInstructions_Format() {


### PR DESCRIPTION
When replacing an Instruction in an Instructions parsed from an ELF, preserving Metadata is important, so this patch adds a convenient method for in-line assignment of Metadata from other instructions.

With func_info and line_info marshaling being driven by Metadata, accidentally stripping a func_info from the first Instruction will result in the following verifier error:

`invalid argument: missing bpf_line_info for func#0`

The verifier rejects line_infos for subprogs that don't start with a func_info.

cc @rgo3 