### PR TITLE
Allow specifying the tracefs prefix in options

### DIFF
--- a/link/kprobe_test.go
+++ b/link/kprobe_test.go
@@ -227,6 +227,16 @@ func TestKprobeTraceFS(t *testing.T) {
 	// Compare the kprobes' tracefs IDs.
 	c.Assert(k1.tracefsID, qt.Not(qt.CmpEquals()), k2.tracefsID)
 
+	// Expect an error when supplying an invalid custom group name
+	_, err = tracefsKprobe(probeArgs{symbol: ksym, group: "/"})
+	c.Assert(err, qt.Not(qt.IsNil))
+
+	cg := "customgroup"
+	k3, err := tracefsKprobe(probeArgs{symbol: ksym, group: cg})
+	c.Assert(err, qt.IsNil)
+	defer k3.Close()
+	c.Assert(k3.group, qt.Matches, `customgroup_[a-f0-9]{16}`)
+
 	// Prepare probe args.
 	args := probeArgs{group: "testgroup", symbol: "symbol"}
 

--- a/link/uprobe.go
+++ b/link/uprobe.go
@@ -70,6 +70,10 @@ type UprobeOptions struct {
 	//
 	// Needs kernel 5.15+.
 	Cookie uint64
+	// Prefix used for the event name if the uprobe must be attached using tracefs.
+	// The group name will be formatted as `<prefix>_<randomstr>`.
+	// The default empty string is equivalent to "ebpf" as the prefix.
+	TraceFSPrefix string
 }
 
 // To open a new Executable, use:
@@ -289,6 +293,7 @@ func (ex *Executable) uprobe(symbol string, prog *ebpf.Program, opts *UprobeOpti
 		refCtrOffset: opts.RefCtrOffset,
 		ret:          ret,
 		cookie:       opts.Cookie,
+		group:        opts.TraceFSPrefix,
 	}
 
 	// Use uprobe PMU if the kernel has it available.

--- a/link/uprobe_test.go
+++ b/link/uprobe_test.go
@@ -242,6 +242,17 @@ func TestUprobeTraceFS(t *testing.T) {
 
 	// Compare the uprobes' tracefs IDs.
 	c.Assert(u1.tracefsID, qt.Not(qt.CmpEquals()), u2.tracefsID)
+
+	// Expect an error when supplying an invalid custom group name
+	args.group = "/"
+	_, err = tracefsUprobe(args)
+	c.Assert(err, qt.Not(qt.IsNil))
+
+	args.group = "customgroup"
+	u3, err := tracefsUprobe(args)
+	c.Assert(err, qt.IsNil)
+	defer u3.Close()
+	c.Assert(u3.group, qt.Matches, `customgroup_[a-f0-9]{16}`)
 }
 
 // Test u(ret)probe creation writing directly to <tracefs>/uprobe_events.


### PR DESCRIPTION
In support of #284 this seemed like the most flexible option.

~~Note: If you supply a custom group name, you cannot attach to the same symbol twice.~~ I'm wondering if we should be using the program name instead of a sanitized symbol name, for the portion of the tracefs event name after the group.

Currently:
`<type>:<group>/<sanitized_symbol> <symbol>`
Proposed:
`<type>:<group>/<sanitized_program_name> <symbol>`