### PR TITLE
Set Program.name when constructing from file descriptor

### DIFF
--- a/prog.go
+++ b/prog.go
@@ -400,7 +400,7 @@ func newProgramFromFD(fd *sys.FD) (*Program, error) {
 		return nil, fmt.Errorf("discover program type: %w", err)
 	}
 
-	return &Program{"", fd, "", "", info.Type}, nil
+	return &Program{"", fd, info.Name, "", info.Type}, nil
 }
 
 func (p *Program) String() string {

--- a/prog_test.go
+++ b/prog_test.go
@@ -617,6 +617,15 @@ func TestProgramFromFD(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Name and type are supposed to be copied from program info.
+	if haveObjName() == nil && prog2.name != "test" {
+		t.Errorf("Expected program to have name test, got '%s'", prog2.name)
+	}
+
+	if prog2.typ != SocketFilter {
+		t.Errorf("Expected program to have type SocketFilter, got '%s'", prog2.typ)
+	}
+
 	// Both programs refer to the same fd now. Closing either of them will
 	// release the fd to the OS, which then might re-use that fd for another
 	// test. Once we close the second map we might close the re-used fd


### PR DESCRIPTION
When a Program is constructed from a file descriptor, only the file descriptor and the program type are set. This results in the name not being present for `.String()`. Because of this the resulting string is different depending on how the Program was constructed.

As the program info is used in `newProgramFromFD()` already anyway, it can be used for setting the name as well.

