### PR TITLE
program: return unwrapped VerifierError

### DIFF
--- a/btf/btf.go
+++ b/btf/btf.go
@@ -694,7 +694,7 @@ func newHandleFromRawBTF(btf []byte) (*Handle, error) {
 	// the BTF blob is correct, a log was requested, and the provided buffer
 	// is too small.
 	_, ve := sys.BtfLoad(attr)
-	return nil, internal.ErrorWithLog(err, logBuf, errors.Is(ve, unix.ENOSPC))
+	return nil, internal.ErrorWithLog("load btf", err, logBuf, errors.Is(ve, unix.ENOSPC))
 }
 
 // NewHandleFromID returns the BTF handle for a given id.

--- a/prog.go
+++ b/prog.go
@@ -173,7 +173,7 @@ type Program struct {
 
 // NewProgram creates a new Program.
 //
-// See NewProgramWithOptions for details.
+// See [NewProgramWithOptions] for details.
 func NewProgram(spec *ProgramSpec) (*Program, error) {
 	return NewProgramWithOptions(spec, ProgramOptions{})
 }
@@ -183,7 +183,7 @@ func NewProgram(spec *ProgramSpec) (*Program, error) {
 // Loading a program for the first time will perform
 // feature detection by loading small, temporary programs.
 //
-// Returns a wrapped [VerifierError] if the program is rejected by the kernel.
+// Returns a [VerifierError] if the program is rejected by the kernel.
 func NewProgramWithOptions(spec *ProgramSpec, opts ProgramOptions) (*Program, error) {
 	if spec == nil {
 		return nil, errors.New("can't load a program from a nil spec")
@@ -242,8 +242,7 @@ func newProgramWithOptions(spec *ProgramSpec, opts ProgramOptions) (*Program, er
 	copy(insns, spec.Instructions)
 
 	handle, fib, lib, err := btf.MarshalExtInfos(insns)
-	btfDisabled := errors.Is(err, btf.ErrNotSupported)
-	if err != nil && !btfDisabled {
+	if err != nil && !errors.Is(err, btf.ErrNotSupported) {
 		return nil, fmt.Errorf("load ext_infos: %w", err)
 	}
 	if handle != nil {
@@ -358,11 +357,7 @@ func newProgramWithOptions(spec *ProgramSpec, opts ProgramOptions) (*Program, er
 	}
 
 	truncated := errors.Is(err, unix.ENOSPC) || errors.Is(err2, unix.ENOSPC)
-	err = internal.ErrorWithLog(err, logBuf, truncated)
-	if btfDisabled {
-		return nil, fmt.Errorf("load program: %w (kernel without BTF support)", err)
-	}
-	return nil, fmt.Errorf("load program: %w", err)
+	return nil, internal.ErrorWithLog("load program", err, logBuf, truncated)
 }
 
 // NewProgramFromFD creates a program from a raw fd.

--- a/prog_test.go
+++ b/prog_test.go
@@ -361,13 +361,14 @@ func TestProgramVerifierOutputOnError(t *testing.T) {
 		t.Fatal("Expected program to be invalid")
 	}
 
-	var ve *VerifierError
-	if !errors.As(err, &ve) {
-		t.Fatal("Error does not contain a VerifierError")
+	ve, ok := err.(*VerifierError)
+	if !ok {
+		t.Fatal("NewProgram does return an unwrapped VerifierError")
 	}
 
 	if !strings.Contains(ve.Error(), "R0 !read_ok") {
-		t.Error("Unexpected verifier error contents:", ve)
+		t.Logf("%+v", ve)
+		t.Error("Missing verifier log in error summary")
 	}
 }
 


### PR DESCRIPTION
Multiple users have been confused as to how to get at the full verifier log. Due to how error wrapping with %w works, callers have to use errors.As to retrieve a VerifierError before being able to format with %+v to get the full log. This confusing exists even though we've tried to document how to deal with it.

Try to make the problem less pressing by returning an unwrapped VerifierError, which the user can then directly format using %+v or similar.