### PR TITLE
map: export MapSpec.Compatible

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -409,7 +409,7 @@ func newCollectionLoader(coll *CollectionSpec, opts *CollectionOptions) (*collec
 			return nil, fmt.Errorf("replacement map %s not found in CollectionSpec", name)
 		}
 
-		if err := spec.checkCompatibility(m); err != nil {
+		if err := spec.Compatible(m); err != nil {
 			return nil, fmt.Errorf("using replacement map %s: %w", spec.Name, err)
 		}
 	}

--- a/map.go
+++ b/map.go
@@ -154,7 +154,11 @@ type MapKV struct {
 	Value interface{}
 }
 
-func (ms *MapSpec) checkCompatibility(m *Map) error {
+// Compatible returns nil if an existing map may be used instead of creating
+// one from the spec.
+//
+// Returns an error wrapping [ErrMapIncompatible] otherwise.
+func (ms *MapSpec) Compatible(m *Map) error {
 	switch {
 	case m.typ != ms.Type:
 		return fmt.Errorf("expected type %v, got %v: %w", ms.Type, m.typ, ErrMapIncompatible)
@@ -277,7 +281,7 @@ func newMapWithOptions(spec *MapSpec, opts MapOptions) (_ *Map, err error) {
 		}
 		defer closeOnError(m)
 
-		if err := spec.checkCompatibility(m); err != nil {
+		if err := spec.Compatible(m); err != nil {
 			return nil, fmt.Errorf("use pinned map %s: %w", spec.Name, err)
 		}
 


### PR DESCRIPTION
Adding IsCompatibleWith function to export spec.checkCompatibility function.

Suggested-by: Lorenz Bauer <lmb@cloudflare.com>
Signed-off-by: Jiri Olsa <jolsa@kernel.org>