### PR TITLE
btf: do Datasec fixup on inflated types

### DIFF
--- a/btf/btf.go
+++ b/btf/btf.go
@@ -93,10 +93,7 @@ func LoadSpecFromReader(rd io.ReaderAt) (*Spec, error) {
 	file, err := internal.NewSafeELFFile(rd)
 	if err != nil {
 		if bo := guessRawBTFByteOrder(rd); bo != nil {
-			// Try to parse a naked BTF blob. This will return an error if
-			// we encounter a Datasec, since we can't fix it up.
-			spec, err := loadRawSpec(io.NewSectionReader(rd, 0, math.MaxInt64), bo, nil, nil)
-			return spec, err
+			return loadRawSpec(io.NewSectionReader(rd, 0, math.MaxInt64), bo, nil, nil)
 		}
 
 		return nil, err
@@ -200,17 +197,17 @@ func loadSpecFromELF(file *internal.SafeELFFile) (*Spec, error) {
 		return nil, fmt.Errorf("compressed BTF is not supported")
 	}
 
-	rawTypes, rawStrings, err := parseBTF(btfSection.ReaderAt, file.ByteOrder, nil)
+	spec, err := loadRawSpec(btfSection.ReaderAt, file.ByteOrder, nil, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	err = fixupDatasec(rawTypes, rawStrings, sectionSizes, offsets)
+	err = fixupDatasec(spec.types, sectionSizes, offsets)
 	if err != nil {
 		return nil, err
 	}
 
-	return inflateSpec(rawTypes, rawStrings, file.ByteOrder, nil)
+	return spec, nil
 }
 
 func loadRawSpec(btf io.ReaderAt, bo binary.ByteOrder,
@@ -220,12 +217,6 @@ func loadRawSpec(btf io.ReaderAt, bo binary.ByteOrder,
 	if err != nil {
 		return nil, err
 	}
-
-	return inflateSpec(rawTypes, rawStrings, bo, baseTypes)
-}
-
-func inflateSpec(rawTypes []rawType, rawStrings *stringTable, bo binary.ByteOrder,
-	baseTypes types) (*Spec, error) {
 
 	types, err := inflateRawTypes(rawTypes, baseTypes, rawStrings)
 	if err != nil {
@@ -393,50 +384,33 @@ type symbol struct {
 	name    string
 }
 
-func fixupDatasec(rawTypes []rawType, rawStrings *stringTable, sectionSizes map[string]uint32, offsets map[symbol]uint32) error {
-	for i, rawType := range rawTypes {
-		if rawType.Kind() != kindDatasec {
+func fixupDatasec(types []Type, sectionSizes map[string]uint32, offsets map[symbol]uint32) error {
+	for _, typ := range types {
+		ds, ok := typ.(*Datasec)
+		if !ok {
 			continue
 		}
 
-		name, err := rawStrings.Lookup(rawType.NameOff)
-		if err != nil {
-			return err
-		}
-
+		name := ds.Name
 		if name == ".kconfig" || name == ".ksyms" {
 			return fmt.Errorf("reference to %s: %w", name, ErrNotSupported)
 		}
 
-		if rawTypes[i].SizeType != 0 {
+		if ds.Size != 0 {
 			continue
 		}
 
-		size, ok := sectionSizes[name]
+		ds.Size, ok = sectionSizes[name]
 		if !ok {
 			return fmt.Errorf("data section %s: missing size", name)
 		}
 
-		rawTypes[i].SizeType = size
-
-		secinfos := rawType.data.([]btfVarSecinfo)
-		for j, secInfo := range secinfos {
-			id := int(secInfo.Type - 1)
-			if id >= len(rawTypes) {
-				return fmt.Errorf("data section %s: invalid type id %d for variable %d", name, id, j)
-			}
-
-			varName, err := rawStrings.Lookup(rawTypes[id].NameOff)
-			if err != nil {
-				return fmt.Errorf("data section %s: can't get name for type %d: %w", name, id, err)
-			}
-
-			offset, ok := offsets[symbol{name, varName}]
+		for i := range ds.Vars {
+			symName := ds.Vars[i].Type.TypeName()
+			ds.Vars[i].Offset, ok = offsets[symbol{name, symName}]
 			if !ok {
-				return fmt.Errorf("data section %s: missing offset for symbol %s", name, varName)
+				return fmt.Errorf("data section %s: missing offset for symbol %s", name, symName)
 			}
-
-			secinfos[j].Offset = offset
 		}
 	}
 

--- a/btf/format.go
+++ b/btf/format.go
@@ -293,7 +293,11 @@ func (gf *GoFormatter) writeDatasecLit(ds *Datasec, depth int) error {
 
 	prevOffset := uint32(0)
 	for i, vsi := range ds.Vars {
-		v := vsi.Type.(*Var)
+		v, ok := vsi.Type.(*Var)
+		if !ok {
+			return fmt.Errorf("can't format %s as part of data section", vsi.Type)
+		}
+
 		if v.Linkage != GlobalVar {
 			// Ignore static, extern, etc. for now.
 			continue

--- a/btf/types.go
+++ b/btf/types.go
@@ -487,6 +487,7 @@ func (ds *Datasec) copy() Type {
 //
 // It is not a valid Type.
 type VarSecinfo struct {
+	// Var or Func.
 	Type   Type
 	Offset uint32
 	Size   uint32
@@ -972,9 +973,7 @@ func inflateRawTypes(rawTypes []rawType, baseTypes types, rawStrings *stringTabl
 				})
 			}
 			for i := range vars {
-				if err := fixupAndAssert(btfVars[i].Type, &vars[i].Type, reflect.TypeOf((*Var)(nil))); err != nil {
-					return nil, err
-				}
+				fixup(btfVars[i].Type, &vars[i].Type)
 			}
 			typ = &Datasec{name, raw.Size(), vars}
 

--- a/btf/types.go
+++ b/btf/types.go
@@ -738,10 +738,10 @@ func inflateRawTypes(rawTypes []rawType, baseTypes types, rawStrings *stringTabl
 	}
 
 	var fixups []fixupDef
-	fixup := func(id TypeID, typ *Type) {
+	fixup := func(id TypeID, typ *Type) bool {
 		if id < TypeID(len(baseTypes)) {
 			*typ = baseTypes[id]
-			return
+			return true
 		}
 
 		idx := id
@@ -751,26 +751,29 @@ func inflateRawTypes(rawTypes []rawType, baseTypes types, rawStrings *stringTabl
 		if idx < TypeID(len(types)) {
 			// We've already inflated this type, fix it up immediately.
 			*typ = types[idx]
-			return
+			return true
 		}
 		fixups = append(fixups, fixupDef{id, typ})
+		return false
 	}
 
 	type assertion struct {
+		id   TypeID
 		typ  *Type
 		want reflect.Type
 	}
 
 	var assertions []assertion
-	assert := func(typ *Type, want reflect.Type) error {
-		if *typ != nil {
-			// The type has already been fixed up, check the type immediately.
-			if reflect.TypeOf(*typ) != want {
-				return fmt.Errorf("expected %s, got %T", want, *typ)
-			}
+	fixupAndAssert := func(id TypeID, typ *Type, want reflect.Type) error {
+		if !fixup(id, typ) {
+			assertions = append(assertions, assertion{id, typ, want})
 			return nil
 		}
-		assertions = append(assertions, assertion{typ, want})
+
+		// The type has already been fixed up, check the type immediately.
+		if reflect.TypeOf(*typ) != want {
+			return fmt.Errorf("type ID %d: expected %s, got %T", id, want, *typ)
+		}
 		return nil
 	}
 
@@ -928,8 +931,7 @@ func inflateRawTypes(rawTypes []rawType, baseTypes types, rawStrings *stringTabl
 
 		case kindFunc:
 			fn := &Func{name, nil, raw.Linkage()}
-			fixup(raw.Type(), &fn.Type)
-			if err := assert(&fn.Type, reflect.TypeOf((*FuncProto)(nil))); err != nil {
+			if err := fixupAndAssert(raw.Type(), &fn.Type, reflect.TypeOf((*FuncProto)(nil))); err != nil {
 				return nil, err
 			}
 			typ = fn
@@ -970,8 +972,7 @@ func inflateRawTypes(rawTypes []rawType, baseTypes types, rawStrings *stringTabl
 				})
 			}
 			for i := range vars {
-				fixup(btfVars[i].Type, &vars[i].Type)
-				if err := assert(&vars[i].Type, reflect.TypeOf((*Var)(nil))); err != nil {
+				if err := fixupAndAssert(btfVars[i].Type, &vars[i].Type, reflect.TypeOf((*Var)(nil))); err != nil {
 					return nil, err
 				}
 			}
@@ -1044,7 +1045,7 @@ func inflateRawTypes(rawTypes []rawType, baseTypes types, rawStrings *stringTabl
 
 	for _, assertion := range assertions {
 		if reflect.TypeOf(*assertion.typ) != assertion.want {
-			return nil, fmt.Errorf("expected %s, got %T", assertion.want, *assertion.typ)
+			return nil, fmt.Errorf("type ID %d: expected %s, got %T", assertion.id, assertion.want, *assertion.typ)
 		}
 	}
 

--- a/collection.go
+++ b/collection.go
@@ -151,6 +151,10 @@ func (cs *CollectionSpec) RewriteConstants(consts map[string]interface{}) error 
 				continue
 			}
 
+			if _, ok := v.Type.(*btf.Var); !ok {
+				return fmt.Errorf("section %s: unexpected type %T for variable %s", name, v.Type, vname)
+			}
+
 			if replaced[vname] {
 				return fmt.Errorf("section %s: duplicate variable %s", name, vname)
 			}


### PR DESCRIPTION
Patch inflated Datasec instead of rawType. This wasn't possible earlier since we relied on writing out the rawType to the kernel.

Only perform the fixup when loading an ELF, since raw BTF doesn't have the necessary information.