### PR TITLE
perf: Add support for overwritable buffer.

### DIFF
--- a/internal/unix/types_linux.go
+++ b/internal/unix/types_linux.go
@@ -63,6 +63,11 @@ const (
 	PERF_EVENT_IOC_ENABLE     = linux.PERF_EVENT_IOC_ENABLE
 	PERF_EVENT_IOC_SET_BPF    = linux.PERF_EVENT_IOC_SET_BPF
 	PerfBitWatermark          = linux.PerfBitWatermark
+	// In C, struct perf_event_attr has a write_backward field which is a bit in a
+	// 64-length bitfield.
+	// In Golang, there is a Bits field which 64 bits long.
+	// From C, we can deduce write_backward is the is the 27th bit.
+	PerfBitWriteBackward      = linux.CBitFieldMaskBit27
 	PERF_SAMPLE_RAW           = linux.PERF_SAMPLE_RAW
 	PERF_FLAG_FD_CLOEXEC      = linux.PERF_FLAG_FD_CLOEXEC
 	RLIM_INFINITY             = linux.RLIM_INFINITY

--- a/perf/reader.go
+++ b/perf/reader.go
@@ -53,7 +53,7 @@ type Record struct {
 // Read a record from a reader and tag it as being from the given CPU.
 //
 // buf must be at least perfEventHeaderSize bytes long.
-func readRecord(rd io.Reader, rec *Record, buf []byte) error {
+func readRecord(rd io.Reader, rec *Record, buf []byte, overWritable bool) error {
 	// Assert that the buffer is large enough.
 	buf = buf[:perfEventHeaderSize]
 	_, err := io.ReadFull(rd, buf)
@@ -82,6 +82,9 @@ func readRecord(rd io.Reader, rec *Record, buf []byte) error {
 		return err
 
 	default:
+		if overWritable && header.Type == 0 && header.Misc == 0 && header.Size == 0 {
+			return errEOR
+		}
 		return &unknownEventError{header.Type}
 	}
 }
@@ -111,7 +114,7 @@ type perfEventSample struct {
 func readRawSample(rd io.Reader, buf, sampleBuf []byte) ([]byte, error) {
 	buf = buf[:perfEventSampleSize]
 	if _, err := io.ReadFull(rd, buf); err != nil {
-		return nil, fmt.Errorf("read sample size: %v", err)
+		return nil, fmt.Errorf("read sample size: %w", err)
 	}
 
 	sample := perfEventSample{
@@ -126,7 +129,7 @@ func readRawSample(rd io.Reader, buf, sampleBuf []byte) ([]byte, error) {
 	}
 
 	if _, err := io.ReadFull(rd, data); err != nil {
-		return nil, fmt.Errorf("read sample: %v", err)
+		return nil, fmt.Errorf("read sample: %w", err)
 	}
 	return data, nil
 }
@@ -155,6 +158,9 @@ type Reader struct {
 	// Read calls, which would otherwise need to be interrupted.
 	pauseMu  sync.Mutex
 	pauseFds []int
+
+	paused       bool
+	overWritable bool
 }
 
 // ReaderOptions control the behaviour of the user
@@ -163,7 +169,9 @@ type ReaderOptions struct {
 	// The number of written bytes required in any per CPU buffer before
 	// Read will process data. Must be smaller than PerCPUBuffer.
 	// The default is to start processing as soon as data is available.
-	Watermark int
+	Watermark     int
+	// This perf ring buffer will be written from backward and over writable.
+	OverWritable bool
 }
 
 // NewReader creates a new reader with default options.
@@ -211,7 +219,7 @@ func NewReaderWithOptions(array *ebpf.Map, perCPUBuffer int, opts ReaderOptions)
 	// but doesn't allow using a wildcard like -1 to specify "all CPUs".
 	// Hence we have to create a ring for each CPU.
 	for i := 0; i < nCPU; i++ {
-		ring, err := newPerfEventRing(i, perCPUBuffer, opts.Watermark)
+		ring, err := newPerfEventRing(i, perCPUBuffer, opts.Watermark, opts.OverWritable)
 		if errors.Is(err, unix.ENODEV) {
 			// The requested CPU is currently offline, skip it.
 			rings = append(rings, nil)
@@ -236,14 +244,15 @@ func NewReaderWithOptions(array *ebpf.Map, perCPUBuffer int, opts ReaderOptions)
 	}
 
 	pr = &Reader{
-		array:       array,
-		rings:       rings,
-		poller:      poller,
-		deadline:    time.Time{},
-		epollEvents: make([]unix.EpollEvent, len(rings)),
-		epollRings:  make([]*perfEventRing, 0, len(rings)),
-		eventHeader: make([]byte, perfEventHeaderSize),
-		pauseFds:    pauseFds,
+		array:        array,
+		rings:        rings,
+		poller:       poller,
+		deadline:     time.Time{},
+		epollEvents:  make([]unix.EpollEvent, len(rings)),
+		epollRings:   make([]*perfEventRing, 0, len(rings)),
+		eventHeader:  make([]byte, perfEventHeaderSize),
+		pauseFds:     pauseFds,
+		overWritable: opts.OverWritable,
 	}
 	if err = pr.Resume(); err != nil {
 		return nil, err
@@ -307,6 +316,7 @@ func (pr *Reader) SetDeadline(t time.Time) {
 // Returns os.ErrDeadlineExceeded if a deadline was set.
 func (pr *Reader) Read() (Record, error) {
 	var r Record
+
 	return r, pr.ReadInto(&r)
 }
 
@@ -315,25 +325,43 @@ func (pr *Reader) ReadInto(rec *Record) error {
 	pr.mu.Lock()
 	defer pr.mu.Unlock()
 
+	if pr.overWritable && !pr.paused {
+		return fmt.Errorf("perf ringbuffer: must have been paused before reading overwritable buffer")
+	}
+
 	if pr.rings == nil {
 		return fmt.Errorf("perf ringbuffer: %w", ErrClosed)
 	}
 
 	for {
 		if len(pr.epollRings) == 0 {
-			nEvents, err := pr.poller.Wait(pr.epollEvents, pr.deadline)
-			if err != nil {
-				return err
-			}
+			if pr.overWritable {
+				// Since we have paused the buffer, we cannot wait for it, as if no
+				// event are available, we will wait forever.
+				for _, ring := range pr.rings {
+					if ring == nil {
+						continue
+					}
 
-			for _, event := range pr.epollEvents[:nEvents] {
-				ring := pr.rings[cpuForEvent(&event)]
-				pr.epollRings = append(pr.epollRings, ring)
+					pr.epollRings = append(pr.epollRings, ring)
 
-				// Read the current head pointer now, not every time
-				// we read a record. This prevents a single fast producer
-				// from keeping the reader busy.
-				ring.loadHead()
+					ring.loadHead()
+				}
+			} else {
+				nEvents, err := pr.poller.Wait(pr.epollEvents, pr.deadline)
+				if err != nil {
+					return err
+				}
+
+				for _, event := range pr.epollEvents[:nEvents] {
+					ring := pr.rings[cpuForEvent(&event)]
+					pr.epollRings = append(pr.epollRings, ring)
+
+					// Read the current head pointer now, not every time
+					// we read a record. This prevents a single fast producer
+					// from keeping the reader busy.
+					ring.loadHead()
+				}
 			}
 		}
 
@@ -345,6 +373,11 @@ func (pr *Reader) ReadInto(rec *Record) error {
 			// We've emptied the current ring buffer, process
 			// the next one.
 			pr.epollRings = pr.epollRings[:len(pr.epollRings)-1]
+
+			if pr.overWritable && len(pr.epollRings) == 0 {
+				return io.EOF
+			}
+
 			continue
 		}
 
@@ -372,6 +405,8 @@ func (pr *Reader) Pause() error {
 		}
 	}
 
+	pr.paused = true
+
 	return nil
 }
 
@@ -396,15 +431,21 @@ func (pr *Reader) Resume() error {
 		}
 	}
 
+	pr.paused = false
+
 	return nil
 }
 
 // NB: Has to be preceded by a call to ring.loadHead.
 func (pr *Reader) readRecordFromRing(rec *Record, ring *perfEventRing) error {
-	defer ring.writeTail()
+	// tail is read only for overwritable perf buffer and the kernel makes no use
+	// of it.
+	if !pr.overWritable {
+		defer ring.writeTail()
+	}
 
 	rec.CPU = ring.cpu
-	return readRecord(ring, rec, pr.eventHeader)
+	return readRecord(ring, rec, pr.eventHeader, pr.overWritable)
 }
 
 type unknownEventError struct {

--- a/perf/reader_test.go
+++ b/perf/reader_test.go
@@ -5,10 +5,12 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"syscall"
 	"testing"
 	"time"
+	"unsafe"
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/asm"
@@ -263,6 +265,305 @@ func TestPerfReaderLostSample(t *testing.T) {
 	}
 }
 
+func outputSamplesProgOverWritable(sampleSizes ...int) (*ebpf.Program, *ebpf.Map, error) {
+	const bpfFCurrentCPU = 0xffffffff
+
+	events, err := ebpf.NewMap(&ebpf.MapSpec{
+		Type: ebpf.PerfEventArray,
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var maxSampleSize int
+	for _, sampleSize := range sampleSizes {
+		if sampleSize > maxSampleSize {
+			maxSampleSize = sampleSize
+		}
+	}
+
+	// Stash context somewhere
+	insns := asm.Instructions{
+		asm.LoadImm(asm.R0, 0, asm.DWord),
+		asm.Mov.Reg(asm.R9, asm.R1),
+	}
+
+	bufDwords := (maxSampleSize / 8) + 1
+	for i := 0; i < bufDwords; i++ {
+		insns = append(insns,
+			asm.StoreMem(asm.RFP, int16(i+1)*-8, asm.R0, asm.DWord),
+		)
+	}
+
+	for i, sampleSize := range sampleSizes {
+		insns = append(insns,
+			asm.Mov.Reg(asm.R1, asm.R9),
+			asm.LoadMapPtr(asm.R2, events.FD()),
+			asm.LoadImm(asm.R3, bpfFCurrentCPU, asm.DWord),
+			asm.LoadImm(asm.R0, int64(i), asm.DWord),
+			asm.StoreMem(asm.RFP, int16(bufDwords*-8), asm.R0, asm.DWord),
+			asm.Mov.Reg(asm.R4, asm.RFP),
+			asm.Add.Imm(asm.R4, int32(bufDwords*-8)),
+			asm.Mov.Imm(asm.R5, int32(sampleSize)),
+			asm.FnPerfEventOutput.Call(),
+		)
+	}
+
+	insns = append(insns, asm.Return())
+
+	prog, err := ebpf.NewProgram(&ebpf.ProgramSpec{
+		License:      "GPL",
+		Type:         ebpf.XDP,
+		Instructions: insns,
+	})
+	if err != nil {
+		events.Close()
+		return nil, nil, err
+	}
+
+	return prog, events, nil
+}
+
+func mustOutputSamplesProgOverWritable(tb testing.TB, sampleSizes ...int) (*ebpf.Program, *ebpf.Map) {
+	tb.Helper()
+
+	// Requires at least 4.10 (9ecda41acb97 "perf/core: Add ::write_backward attribute to perf event")
+	testutils.SkipOnOldKernel(tb, "4.10", "overwritable perf events support")
+
+	prog, events, err := outputSamplesProgOverWritable(sampleSizes...)
+	var errVerifier *ebpf.VerifierError
+	if errors.As(err, &errVerifier) {
+		fmt.Printf("loading ebpf program:\n%+v", errVerifier)
+	}
+	if err != nil {
+		tb.Fatal(err)
+	}
+	tb.Cleanup(func() {
+		prog.Close()
+		events.Close()
+	})
+
+	return prog, events
+}
+
+func TestPerfReaderOverWritable(t *testing.T) {
+	const (
+		eventSize = 192
+	)
+
+	var (
+		pageSize  = os.Getpagesize()
+		maxEvents = (pageSize / eventSize)
+	)
+	if remainder := pageSize % eventSize; remainder != 64 && remainder != 128 {
+		// Page size isn't 2^(6+m), m >= 0
+		t.Fatal("unsupported page size:", pageSize)
+	}
+
+	var sampleSizes []int
+	for i := 0; i < maxEvents; i++ {
+		sampleSizes = append(sampleSizes, 180)
+	}
+
+	prog, events := mustOutputSamplesProgOverWritable(t, sampleSizes...)
+
+	rd, err := NewReaderWithOptions(events, pageSize, ReaderOptions{OverWritable: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rd.Close()
+
+	ret, _, err := prog.Test(internal.EmptyBPFContext)
+	testutils.SkipIfNotSupported(t, err)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if errno := syscall.Errno(-int32(ret)); errno != 0 {
+		t.Fatal("Expected 0 as return value, got", errno)
+	}
+
+	err = rd.Pause()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	readSamples := make([]int32, 0)
+	for _, sampleSize := range sampleSizes {
+		record, err := rd.Read()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			} else {
+				t.Fatal(err)
+			}
+		}
+		size := len(record.RawSample)
+		if size != sampleSize {
+			t.Fatalf("Expected %d as sample size got %d", sampleSize, size)
+		}
+		value := *(*int32)(unsafe.Pointer(&record.RawSample[0]))
+		readSamples = append(readSamples, value)
+	}
+
+	err = rd.Resume()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// At this time, readSamples should contain the following:
+	// [20 19 18 17 16 15 14 13 12 11 10 9 8 7 6 5 4 3 2 1 0]
+	sampleNr := len(sampleSizes)
+	if len(readSamples) != sampleNr {
+		t.Fatalf("Expected %d events but got %d", sampleNr, len(readSamples))
+	}
+
+	for i, value := range readSamples {
+		expected := int32(sampleNr - i - 1)
+		if value != expected {
+			t.Fatalf("Expected value %d got %d", expected, value)
+		}
+	}
+}
+
+func TestPerfReaderOverWritableOverWritten(t *testing.T) {
+	const (
+		eventSize = 192
+	)
+
+	var (
+		pageSize  = os.Getpagesize()
+		maxEvents = (pageSize / eventSize)
+	)
+	if remainder := pageSize % eventSize; remainder != 64 && remainder != 128 {
+		// Page size isn't 2^(6+m), m >= 0
+		t.Fatal("unsupported page size:", pageSize)
+	}
+
+	var sampleSizes []int
+	// Fill the ring with the maximum number of output_large events that will fit,
+	// and generate a lost event by writing an additional event.
+	for i := 0; i < maxEvents+1; i++ {
+		sampleSizes = append(sampleSizes, 180)
+	}
+
+	prog, events := mustOutputSamplesProgOverWritable(t, sampleSizes...)
+
+	rd, err := NewReaderWithOptions(events, pageSize, ReaderOptions{OverWritable: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rd.Close()
+
+	ret, _, err := prog.Test(internal.EmptyBPFContext)
+	testutils.SkipIfNotSupported(t, err)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if errno := syscall.Errno(-int32(ret)); errno != 0 {
+		t.Fatal("Expected 0 as return value, got", errno)
+	}
+
+	err = rd.Pause()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	readSamples := make([]int32, 0)
+	for _, sampleSize := range sampleSizes {
+		record, err := rd.Read()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			} else {
+				t.Fatal(err)
+			}
+		}
+		size := len(record.RawSample)
+		if size != sampleSize {
+			t.Fatalf("Expected %d as sample size got %d", sampleSize, size)
+		}
+		value := *(*int32)(unsafe.Pointer(&record.RawSample[0]))
+		readSamples = append(readSamples, value)
+	}
+
+	err = rd.Resume()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// At this time, readSamples should contain the following:
+	// [21 20 19 18 17 16 15 14 13 12 11 10 9 8 7 6 5 4 3 2 1]
+	// Value 0 is not present because it was overwritten by value 21.
+	// As a consequence, readSamples contains one value less than what was
+	// written to the perf buffer.
+
+	sampleNr := len(sampleSizes)
+	if len(readSamples) != sampleNr - 1 {
+		t.Fatalf("Expected %d events but got %d", sampleNr - 1, len(readSamples))
+	}
+
+	for i, value := range readSamples {
+		expected := int32(sampleNr - i - 1)
+		if value != expected {
+			t.Fatalf("Expected value %d got %d", expected, value)
+		}
+	}
+}
+
+func TestPerfReaderOverWritableEmpty(t *testing.T) {
+	const (
+		eventSize = 192
+	)
+
+	var (
+		pageSize  = os.Getpagesize()
+	)
+
+	if remainder := pageSize % eventSize; remainder != 64 && remainder != 128 {
+		// Page size isn't 2^(6+m), m >= 0
+		t.Fatal("unsupported page size:", pageSize)
+	}
+
+	var sampleSizes []int
+	prog, events := mustOutputSamplesProgOverWritable(t, sampleSizes...)
+	rd, err := NewReaderWithOptions(events, pageSize, ReaderOptions{OverWritable: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rd.Close()
+
+	ret, _, err := prog.Test(internal.EmptyBPFContext)
+	testutils.SkipIfNotSupported(t, err)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if errno := syscall.Errno(-int32(ret)); errno != 0 {
+		t.Fatal("Expected 0 as return value, got", errno)
+	}
+
+	err = rd.Pause()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = rd.Read()
+	if err == nil {
+		t.Fatal("Buffer is empty it should have return io.EOF")
+	}
+
+	if !errors.Is(err, io.EOF) {
+		t.Fatalf("Buffer is empty, expected %s as error, got %s", io.EOF, err)
+	}
+
+	err = rd.Resume()
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestPerfReaderClose(t *testing.T) {
 	_, events := mustOutputSamplesProg(t, 5)
 
@@ -304,7 +605,7 @@ func TestPerfReaderClose(t *testing.T) {
 }
 
 func TestCreatePerfEvent(t *testing.T) {
-	fd, err := createPerfEvent(0, 1)
+	fd, err := createPerfEvent(0, 1, false)
 	if err != nil {
 		t.Fatal("Can't create perf event:", err)
 	}
@@ -320,7 +621,7 @@ func TestReadRecord(t *testing.T) {
 	}
 
 	var rec Record
-	err = readRecord(&buf, &rec, make([]byte, perfEventHeaderSize))
+	err = readRecord(&buf, &rec, make([]byte, perfEventHeaderSize), false)
 	if !IsUnknownEvent(err) {
 		t.Error("readRecord should return unknown event error, got", err)
 	}

--- a/perf/ring_test.go
+++ b/perf/ring_test.go
@@ -45,7 +45,7 @@ func TestRingBufferReader(t *testing.T) {
 	}
 }
 
-func makeRing(size, offset int) *ringReader {
+func makeRing(size, offset int) ringReader {
 	if size != 0 && (size&(size-1)) != 0 {
 		panic("size must be power of two")
 	}
@@ -61,17 +61,17 @@ func makeRing(size, offset int) *ringReader {
 		Data_size: uint64(len(ring)),
 	}
 
-	return newRingReader(&meta, ring)
+	return newRingReader(&meta, ring, false)
 }
 
 func TestPerfEventRing(t *testing.T) {
-	check := func(buffer, watermark int) {
-		ring, err := newPerfEventRing(0, buffer, watermark)
+	check := func(buffer, watermark int, overWritable bool) {
+		ring, err := newPerfEventRing(0, buffer, watermark, overWritable)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		size := len(ring.ringReader.ring)
+		size := len(ring.getRing())
 
 		// Ring size should be at least as big as buffer
 		if size < buffer {
@@ -89,20 +89,30 @@ func TestPerfEventRing(t *testing.T) {
 	}
 
 	// watermark > buffer
-	_, err := newPerfEventRing(0, 8192, 8193)
+	_, err := newPerfEventRing(0, 8192, 8193, false)
+	if err == nil {
+		t.Fatal("watermark > buffer allowed")
+	}
+	_, err = newPerfEventRing(0, 8192, 8193, true)
 	if err == nil {
 		t.Fatal("watermark > buffer allowed")
 	}
 
 	// watermark == buffer
-	_, err = newPerfEventRing(0, 8192, 8192)
+	_, err = newPerfEventRing(0, 8192, 8192, false)
+	if err == nil {
+		t.Fatal("watermark == buffer allowed")
+	}
+	_, err = newPerfEventRing(0, 8192, 8192, true)
 	if err == nil {
 		t.Fatal("watermark == buffer allowed")
 	}
 
 	// buffer not a power of two, watermark < buffer
-	check(8193, 8192)
+	check(8193, 8192, false)
+	check(8193, 8192, true)
 
 	// large buffer not a multiple of page size at all (prime)
-	check(65537, 8192)
+	check(65537, 8192, false)
+	check(65537, 8192, true)
 }


### PR DESCRIPTION
Hi.


This PR supersedes #814.
Compared to conventionnal perf buffer, an overwritable perf buffer never stops writing.
Instead, the oldest data are overwritten by the newest.

As a consequence, the `ReaderOptions` was modified to add a new boolean to indicate if perf buffer is overwritable.
To read these buffers, a new function `ReadCallback()` was introduced. This function reads the buffer from the current head until it wraps the buffer (or there are no more data to read).
For each read record, the callback is called.

This PR also adds test which validates the new function is working.
You can also find an example of this feature usage in [Inspektor Gadget code](https://github.com/inspektor-gadget/inspektor-gadget/blob/8c925785c17200557985136b80d2953955b3e8bd/pkg/gadgets/traceloop/tracer/tracer.go#L283) (not upstreamed at the moment).

If you see any way to improve this contribution, feel free to share.


Best regards and thank you in advance.