### PR TITLE
btf: Remove deprecated {Map,Program}Spec.BTF field

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -442,10 +442,6 @@ func (cl *collectionLoader) loadMap(mapName string) (*Map, error) {
 		return nil, fmt.Errorf("missing map %s", mapName)
 	}
 
-	if mapSpec.BTF != nil && cl.coll.Types != mapSpec.BTF {
-		return nil, fmt.Errorf("map %s: BTF doesn't match collection", mapName)
-	}
-
 	if replaceMap, ok := cl.opts.MapReplacements[mapName]; ok {
 		// Clone the map to avoid closing user's map later on.
 		m, err := replaceMap.Clone()

--- a/elf_reader.go
+++ b/elf_reader.go
@@ -314,7 +314,6 @@ func (ec *elfCode) loadProgramSections() (map[string]*ProgramSpec, error) {
 				KernelVersion: ec.version,
 				Instructions:  insns,
 				ByteOrder:     ec.ByteOrder,
-				BTF:           ec.btf,
 			}
 
 			// Function names must be unique within a single ELF blob.
@@ -912,7 +911,6 @@ func mapSpecFromBTF(es *elfSection, vs *btf.VarSecinfo, def *btf.Struct, spec *b
 		Flags:      flags,
 		Key:        key,
 		Value:      value,
-		BTF:        spec,
 		Pinning:    pinType,
 		InnerMap:   innerMapSpec,
 		Contents:   contents,
@@ -1057,7 +1055,6 @@ func (ec *elfCode) loadDataSections(maps map[string]*MapSpec) error {
 			var ds *btf.Datasec
 			if ec.btf.TypeByName(sec.Name, &ds) == nil {
 				// Assign the spec's key and BTF only if the Datasec lookup was successful.
-				mapSpec.BTF = ec.btf
 				mapSpec.Key = &btf.Void{}
 				mapSpec.Value = ds
 			}

--- a/map.go
+++ b/map.go
@@ -77,11 +77,6 @@ type MapSpec struct {
 
 	// The key and value type of this map. May be nil.
 	Key, Value btf.Type
-
-	// The BTF associated with this map.
-	//
-	// Deprecated: use [CollectionSpec.Types] instead.
-	BTF *btf.Spec
 }
 
 func (ms *MapSpec) String() string {

--- a/prog.go
+++ b/prog.go
@@ -123,11 +123,6 @@ type ProgramSpec struct {
 	// detect this value automatically.
 	KernelVersion uint32
 
-	// The BTF associated with this program.
-	//
-	// Deprecated: use [CollectionSpec.Types] instead.
-	BTF *btf.Spec
-
 	// The byte order this program was compiled for, may be nil.
 	ByteOrder binary.ByteOrder
 }


### PR DESCRIPTION
Setting ProgramSpec.BTF to nil was a convenient way of making prog loads execute without func/lineinfos with the introduction of Instruction.Metadata.

For example, in case instructions are added at the start of Instructions, the caller would need to make sure to move the Func to the 'new' first instruction to set up a valid function boundary. Clearing ProgramSpec.BTF was a convenient hack to load without BTF if your program type didn't need it.

Unfortunately, since adding full BTF marshaling, the {Map,Program}Spec.BTF field was no longer checked while loading BTF. Callers nilling the field had their code happily compile and fall over loading a program in production.

This commit removes these .BTF fields to make this a compile-time error.

cc @willfindlay 