### PR TITLE
map: include generated pin path in newMapWithOptions error

### DIFF
--- a/map.go
+++ b/map.go
@@ -320,7 +320,7 @@ func newMapWithOptions(spec *MapSpec, opts MapOptions) (_ *Map, err error) {
 	if spec.Pinning == PinByName {
 		path := filepath.Join(opts.PinPath, spec.Name)
 		if err := m.Pin(path); err != nil {
-			return nil, fmt.Errorf("pin map: %w", err)
+			return nil, fmt.Errorf("pin map to %s: %w", path, err)
 		}
 	}
 


### PR DESCRIPTION
When attempting to create a new map with the Pinned field set, a pin path is automatically generated based on MapOptions.PinPath and the map's name.

This makes it cumbersome for the caller to figure out what the final path was that was used in the pin operation, with vague errors like:

'pin map: no such file or directory'

Wrap the error message with the final pin path.