### PR TITLE
cs.RewriteConstants: define error MissingConstantsError

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -107,6 +107,12 @@ func (cs *CollectionSpec) RewriteMaps(maps map[string]*Map) error {
 	return nil
 }
 
+type MissingConstantsError struct{ Constants []string }
+
+func (m *MissingConstantsError) Error() string {
+	return fmt.Sprintf("spec is missing one or more constants: %s", strings.Join(m.Constants, ", "))
+}
+
 // RewriteConstants replaces the value of multiple constants.
 //
 // The constant must be defined like so in the C program:
@@ -120,7 +126,7 @@ func (cs *CollectionSpec) RewriteMaps(maps map[string]*Map) error {
 //
 // From Linux 5.5 the verifier will use constants to eliminate dead code.
 //
-// Returns an error if a constant doesn't exist.
+// Returns an error of type MissingConstantsError if a constant doesn't exist.
 func (cs *CollectionSpec) RewriteConstants(consts map[string]interface{}) error {
 	replaced := make(map[string]bool)
 
@@ -184,7 +190,7 @@ func (cs *CollectionSpec) RewriteConstants(consts map[string]interface{}) error 
 	}
 
 	if len(missing) != 0 {
-		return fmt.Errorf("spec is missing one or more constants: %s", strings.Join(missing, ","))
+		return &MissingConstantsError{Constants: missing}
 	}
 
 	return nil

--- a/collection_test.go
+++ b/collection_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/cilium/ebpf/asm"
@@ -325,6 +326,58 @@ func TestCollectionSpecMapReplacements_SpecMismatch(t *testing.T) {
 	}
 	if !errors.Is(err, ErrMapIncompatible) {
 		t.Fatalf("Overriding a map with a mismatching spec failed with the wrong error")
+	}
+}
+
+func TestCollectionRewriteConstants(t *testing.T) {
+	cs := &CollectionSpec{
+		Maps: map[string]*MapSpec{
+			".rodata": {
+				Type:       Array,
+				KeySize:    4,
+				ValueSize:  4,
+				MaxEntries: 1,
+				Value: &btf.Datasec{
+					Vars: []btf.VarSecinfo{
+						{
+							Type: &btf.Var{
+								Name: "the_constant",
+								Type: &btf.Int{Size: 4},
+							},
+							Offset: 0,
+							Size:   4,
+						},
+					},
+				},
+				Contents: []MapKV{
+					MapKV{Key: uint32(0), Value: []byte{1, 1, 1, 1}},
+				},
+			},
+		},
+	}
+
+	err := cs.RewriteConstants(map[string]interface{}{
+		"fake_constant_one": uint32(1),
+		"fake_constant_two": uint32(2),
+	})
+	if err == nil {
+		t.Fatal("RewriteConstants did not fail")
+	}
+	if !strings.HasSuffix(err.Error(), "fake_constant_one, fake_constant_two") {
+		t.Fatalf("RewriteConstants error is not well explained: %q", err)
+	}
+	var mErr *MissingConstantsError
+	if !errors.As(err, &mErr) {
+		t.Fatal(err)
+	}
+	err = cs.RewriteConstants(map[string]interface{}{
+		"the_constant": uint32(0x42424242),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual([]byte{0x42, 0x42, 0x42, 0x42}, cs.Maps[".rodata"].Contents[0].Value) {
+		t.Fatalf("RewriteConstants did not rewrite correctly: %+v", cs.Maps[".rodata"].Contents[0].Value)
 	}
 }
 


### PR DESCRIPTION
RewriteConstants can return the error "spec is missing one or more
constants" if the constant given as parameter does not exist. This patch
defines the error as a specific type so it can be tested with:
```
    var mErr *MissingConstantsError
    if !errors.As(err, &mErr) {
```
New unit tests are added, for both the success and failure cases.

Tested with:
```
    go test -exec sudo -run TestCollectionRewriteCon  ./...
```
Signed-off-by: Alban Crequy <albancrequy@linux.microsoft.com>

---

This PR was suggested by @mauriciovasquezbernal in https://github.com/inspektor-gadget/inspektor-gadget/pull/1201#discussion_r1053515224 to avoid testing with
```
strings.Contains(err.Error(), "spec is missing one or more constants")
```
