### PR TITLE
cs.RewriteConstants: define error MissingConstantsError

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -107,6 +107,16 @@ func (cs *CollectionSpec) RewriteMaps(maps map[string]*Map) error {
 	return nil
 }
 
+// MissingConstantsError is returned by [CollectionSpec.RewriteConstants].
+type MissingConstantsError struct {
+	// The constants missing from .rodata.
+	Constants []string
+}
+
+func (m *MissingConstantsError) Error() string {
+	return fmt.Sprintf("some constants are missing from .rodata: %s", strings.Join(m.Constants, ", "))
+}
+
 // RewriteConstants replaces the value of multiple constants.
 //
 // The constant must be defined like so in the C program:
@@ -120,7 +130,7 @@ func (cs *CollectionSpec) RewriteMaps(maps map[string]*Map) error {
 //
 // From Linux 5.5 the verifier will use constants to eliminate dead code.
 //
-// Returns an error if a constant doesn't exist.
+// Returns an error wrapping [MissingConstantsError] if a constant doesn't exist.
 func (cs *CollectionSpec) RewriteConstants(consts map[string]interface{}) error {
 	replaced := make(map[string]bool)
 
@@ -184,7 +194,7 @@ func (cs *CollectionSpec) RewriteConstants(consts map[string]interface{}) error 
 	}
 
 	if len(missing) != 0 {
-		return fmt.Errorf("spec is missing one or more constants: %s", strings.Join(missing, ","))
+		return fmt.Errorf("rewrite constants: %w", &MissingConstantsError{Constants: missing})
 	}
 
 	return nil


### PR DESCRIPTION
RewriteConstants can return the error "spec is missing one or more constants" if the constant given as parameter does not exist. This patch defines the error as a specific type so it can be tested with:
```
    var mErr *MissingConstantsError
    if !errors.As(err, &mErr) {
```
New unit tests are added, for both the success and failure cases.

Tested with:
```
    go test -exec sudo -run TestCollectionRewriteCon  ./...
```
Signed-off-by: Alban Crequy <albancrequy@linux.microsoft.com>

-----

This PR was suggested by @mauriciovasquezbernal in https://github.com/inspektor-gadget/inspektor-gadget/pull/1201#discussion_r1053515224 to avoid testing with
```
strings.Contains(err.Error(), "spec is missing one or more constants")
```

-----

Supersedes https://github.com/cilium/ebpf/pull/902