### PR TITLE
sys: overhaul Pointer constructors

### DIFF
--- a/btf/btf.go
+++ b/btf/btf.go
@@ -702,8 +702,8 @@ var haveBTF = internal.NewFeatureTest("BTF", "4.18", func() error {
 	btf := marshalBTF(&types, strings, internal.NativeEndian)
 
 	fd, err := sys.BtfLoad(&sys.BtfLoadAttr{
-		Btf:     sys.NewSlicePointer(btf),
-		BtfSize: uint32(len(btf)),
+		Btf:     sys.SlicePointer(btf),
+		BtfSize: sys.SliceLen(btf),
 	})
 	if errors.Is(err, unix.EINVAL) || errors.Is(err, unix.EPERM) {
 		return internal.ErrNotSupported
@@ -741,8 +741,8 @@ var haveMapBTF = internal.NewFeatureTest("Map BTF (Var/Datasec)", "5.2", func() 
 	btf := marshalBTF(&types, strings, internal.NativeEndian)
 
 	fd, err := sys.BtfLoad(&sys.BtfLoadAttr{
-		Btf:     sys.NewSlicePointer(btf),
-		BtfSize: uint32(len(btf)),
+		Btf:     sys.SlicePointer(btf),
+		BtfSize: sys.SliceLen(btf),
 	})
 	if errors.Is(err, unix.EINVAL) || errors.Is(err, unix.EPERM) {
 		// Treat both EINVAL and EPERM as not supported: creating the map may still
@@ -781,8 +781,8 @@ var haveProgBTF = internal.NewFeatureTest("Program BTF (func/line_info)", "5.0",
 	btf := marshalBTF(&types, strings, internal.NativeEndian)
 
 	fd, err := sys.BtfLoad(&sys.BtfLoadAttr{
-		Btf:     sys.NewSlicePointer(btf),
-		BtfSize: uint32(len(btf)),
+		Btf:     sys.SlicePointer(btf),
+		BtfSize: sys.SliceLen(btf),
 	})
 	if errors.Is(err, unix.EINVAL) || errors.Is(err, unix.EPERM) {
 		return internal.ErrNotSupported
@@ -817,8 +817,8 @@ var haveFuncLinkage = internal.NewFeatureTest("BTF func linkage", "5.6", func() 
 	btf := marshalBTF(&types, strings, internal.NativeEndian)
 
 	fd, err := sys.BtfLoad(&sys.BtfLoadAttr{
-		Btf:     sys.NewSlicePointer(btf),
-		BtfSize: uint32(len(btf)),
+		Btf:     sys.SlicePointer(btf),
+		BtfSize: sys.SliceLen(btf),
 	})
 	if errors.Is(err, unix.EINVAL) {
 		return internal.ErrNotSupported

--- a/btf/handle.go
+++ b/btf/handle.go
@@ -53,8 +53,8 @@ func newHandleFromRawBTF(btf []byte) (*Handle, error) {
 	}
 
 	attr := &sys.BtfLoadAttr{
-		Btf:     sys.NewSlicePointer(btf),
-		BtfSize: uint32(len(btf)),
+		Btf:     sys.SlicePointer(btf),
+		BtfSize: sys.SliceLen(btf),
 	}
 
 	fd, err := sys.BtfLoad(attr)
@@ -67,8 +67,8 @@ func newHandleFromRawBTF(btf []byte) (*Handle, error) {
 	}
 
 	logBuf := make([]byte, 64*1024)
-	attr.BtfLogBuf = sys.NewSlicePointer(logBuf)
-	attr.BtfLogSize = uint32(len(logBuf))
+	attr.BtfLogBuf = sys.SlicePointer(logBuf)
+	attr.BtfLogSize = sys.SliceLen(logBuf)
 	attr.BtfLogLevel = 1
 
 	// Up until at least kernel 6.0, the BTF verifier does not return ENOSPC
@@ -105,9 +105,11 @@ func NewHandleFromID(id ID) (*Handle, error) {
 
 // Spec parses the kernel BTF into Go types.
 func (h *Handle) Spec() (*Spec, error) {
-	var btfInfo sys.BtfInfo
 	btfBuffer := make([]byte, h.size)
-	btfInfo.Btf, btfInfo.BtfSize = sys.NewSlicePointerLen(btfBuffer)
+	btfInfo := sys.BtfInfo{
+		Btf:     sys.SlicePointer(btfBuffer),
+		BtfSize: sys.SliceLen(btfBuffer),
+	}
 
 	if err := sys.ObjInfo(h.fd, &btfInfo); err != nil {
 		return nil, err
@@ -187,7 +189,8 @@ func newHandleInfoFromFD(fd *sys.FD) (*HandleInfo, error) {
 	btfInfo.BtfSize = 0
 
 	nameBuffer := make([]byte, btfInfo.NameLen)
-	btfInfo.Name, btfInfo.NameLen = sys.NewSlicePointerLen(nameBuffer)
+	btfInfo.Name = sys.SlicePointer(nameBuffer)
+	btfInfo.NameLen = sys.SliceLen(nameBuffer)
 	if err := sys.ObjInfo(fd, &btfInfo); err != nil {
 		return nil, err
 	}

--- a/info.go
+++ b/info.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"syscall"
 	"time"
-	"unsafe"
 
 	"github.com/cilium/ebpf/asm"
 	"github.com/cilium/ebpf/btf"
@@ -128,14 +127,14 @@ func newProgramInfoFromFd(fd *sys.FD) (*ProgramInfo, error) {
 
 	if info.NrMapIds > 0 {
 		pi.maps = make([]MapID, info.NrMapIds)
-		info2.NrMapIds = info.NrMapIds
-		info2.MapIds = sys.NewPointer(unsafe.Pointer(&pi.maps[0]))
+		info2.NrMapIds = sys.SliceLen(pi.maps)
+		info2.MapIds = sys.SlicePointer(pi.maps)
 	}
 
 	if info.XlatedProgLen > 0 {
 		pi.insns = make([]byte, info.XlatedProgLen)
-		info2.XlatedProgLen = info.XlatedProgLen
-		info2.XlatedProgInsns = sys.NewSlicePointer(pi.insns)
+		info2.XlatedProgLen = sys.SliceLen(pi.insns)
+		info2.XlatedProgInsns = sys.SlicePointer(pi.insns)
 	}
 
 	if info.NrMapIds > 0 || info.XlatedProgLen > 0 {

--- a/internal/sys/ptr.go
+++ b/internal/sys/ptr.go
@@ -1,43 +1,57 @@
 package sys
 
 import (
+	"math"
 	"unsafe"
 
 	"github.com/cilium/ebpf/internal/unix"
 )
 
-// NewPointer creates a 64-bit pointer from an unsafe Pointer.
-func NewPointer(ptr unsafe.Pointer) Pointer {
+// UnsafePointer creates a 64-bit pointer from an unsafe Pointer.
+func UnsafePointer(ptr unsafe.Pointer) Pointer {
 	return Pointer{ptr: ptr}
 }
 
-// NewSlicePointer creates a 64-bit pointer from a byte slice.
-func NewSlicePointer(buf []byte) Pointer {
-	if len(buf) == 0 {
+// SlicePointer creates a 64-bit pointer from a slice.
+func SlicePointer[E any](slice []E) Pointer {
+	if len(slice) == 0 {
 		return Pointer{}
 	}
 
-	return Pointer{ptr: unsafe.Pointer(&buf[0])}
+	return Pointer{ptr: unsafe.Pointer(&slice[0])}
 }
 
-// NewSlicePointer creates a 64-bit pointer from a byte slice.
+// SliceLen returns the length of a slice as a uint32.
 //
-// Useful to assign both the pointer and the length in one go.
-func NewSlicePointerLen(buf []byte) (Pointer, uint32) {
-	return NewSlicePointer(buf), uint32(len(buf))
+// Returns zero if the length of the slice exceeds uint32.
+func SliceLen[E any](slice []E) uint32 {
+	return SliceElems(slice, 1)
 }
 
-// NewStringPointer creates a 64-bit pointer from a string.
+// SliceElems returns the number of equal sized elements in a slice.
+//
+// Returns zero if the number of elements exceeds uint32.
+func SliceElems[E any](slice []E, elemSize int) uint32 {
+	n := len(slice) / elemSize
+	if int64(n) > math.MaxUint32 {
+		return 0
+	}
+
+	return uint32(n)
+}
+
+// NewStringPointer allocates a null-terminated backing slice for str and returns
+// a pointer to it.
 func NewStringPointer(str string) Pointer {
-	p, err := unix.BytePtrFromString(str)
+	s, err := unix.ByteSliceFromString(str)
 	if err != nil {
 		return Pointer{}
 	}
 
-	return Pointer{ptr: unsafe.Pointer(p)}
+	return SlicePointer(s)
 }
 
-// NewStringSlicePointer allocates an array of Pointers to each string in the
+// NewStringSlicePointer allocates an array of Pointers for each string in the
 // given slice of strings and returns a 64-bit pointer to the start of the
 // resulting array.
 //
@@ -48,5 +62,5 @@ func NewStringSlicePointer(strings []string) Pointer {
 		sp = append(sp, NewStringPointer(s))
 	}
 
-	return Pointer{ptr: unsafe.Pointer(&sp[0])}
+	return SlicePointer(sp)
 }

--- a/internal/sys/syscall.go
+++ b/internal/sys/syscall.go
@@ -85,7 +85,7 @@ func ObjInfo(fd *FD, info Info) error {
 	err := ObjGetInfoByFd(&ObjGetInfoByFdAttr{
 		BpfFd:   fd.Uint(),
 		InfoLen: len,
-		Info:    NewPointer(ptr),
+		Info:    UnsafePointer(ptr),
 	})
 	runtime.KeepAlive(fd)
 	return err

--- a/internal/unix/types_linux.go
+++ b/internal/unix/types_linux.go
@@ -165,8 +165,8 @@ func Tgkill(tgid int, tid int, sig syscall.Signal) (err error) {
 	return linux.Tgkill(tgid, tid, sig)
 }
 
-func BytePtrFromString(s string) (*byte, error) {
-	return linux.BytePtrFromString(s)
+func ByteSliceFromString(s string) ([]byte, error) {
+	return linux.ByteSliceFromString(s)
 }
 
 func ByteSliceToString(s []byte) string {

--- a/internal/unix/types_other.go
+++ b/internal/unix/types_other.go
@@ -245,7 +245,7 @@ func Tgkill(tgid int, tid int, sig syscall.Signal) (err error) {
 	return errNonLinux
 }
 
-func BytePtrFromString(s string) (*byte, error) {
+func ByteSliceFromString(s string) ([]byte, error) {
 	return nil, errNonLinux
 }
 

--- a/link/iter.go
+++ b/link/iter.go
@@ -46,7 +46,7 @@ func AttachIter(opts IterOptions) (*Iter, error) {
 	attr := sys.LinkCreateIterAttr{
 		ProgFd:      uint32(progFd),
 		AttachType:  sys.AttachType(ebpf.AttachTraceIter),
-		IterInfo:    sys.NewPointer(unsafe.Pointer(&info)),
+		IterInfo:    sys.UnsafePointer(unsafe.Pointer(&info)),
 		IterInfoLen: uint32(unsafe.Sizeof(info)),
 	}
 

--- a/link/kprobe_multi.go
+++ b/link/kprobe_multi.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"unsafe"
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/asm"
@@ -68,9 +67,9 @@ func kprobeMulti(prog *ebpf.Program, opts KprobeMultiOptions, flags uint32) (Lin
 		return nil, errors.New("cannot attach a nil program")
 	}
 
-	syms := uint32(len(opts.Symbols))
-	addrs := uint32(len(opts.Addresses))
-	cookies := uint32(len(opts.Cookies))
+	syms := sys.SliceLen(opts.Symbols)
+	addrs := sys.SliceLen(opts.Addresses)
+	cookies := sys.SliceLen(opts.Cookies)
 
 	if syms == 0 && addrs == 0 {
 		return nil, fmt.Errorf("one of Symbols or Addresses is required: %w", errInvalidInput)
@@ -99,11 +98,11 @@ func kprobeMulti(prog *ebpf.Program, opts KprobeMultiOptions, flags uint32) (Lin
 
 	case addrs != 0:
 		attr.Count = addrs
-		attr.Addrs = sys.NewPointer(unsafe.Pointer(&opts.Addresses[0]))
+		attr.Addrs = sys.SlicePointer(opts.Addresses)
 	}
 
 	if cookies != 0 {
-		attr.Cookies = sys.NewPointer(unsafe.Pointer(&opts.Cookies[0]))
+		attr.Cookies = sys.SlicePointer(opts.Cookies)
 	}
 
 	fd, err := sys.LinkCreateKprobeMulti(attr)

--- a/link/perf_event.go
+++ b/link/perf_event.go
@@ -256,11 +256,11 @@ func attachPerfEventLink(pe *perfEvent, prog *ebpf.Program) (*perfEventLink, err
 
 // unsafeStringPtr returns an unsafe.Pointer to a NUL-terminated copy of str.
 func unsafeStringPtr(str string) (unsafe.Pointer, error) {
-	p, err := unix.BytePtrFromString(str)
+	p, err := unix.ByteSliceFromString(str)
 	if err != nil {
 		return nil, err
 	}
-	return unsafe.Pointer(p), nil
+	return unsafe.Pointer(&p[0]), nil
 }
 
 // getTraceEventID reads a trace event's ID from tracefs given its group and name.

--- a/link/query.go
+++ b/link/query.go
@@ -3,7 +3,6 @@ package link
 import (
 	"fmt"
 	"os"
-	"unsafe"
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/internal/sys"
@@ -52,8 +51,8 @@ func QueryPrograms(opts QueryOptions) ([]ebpf.ProgramID, error) {
 
 	// we have at least one prog, so we query again
 	progIds := make([]ebpf.ProgramID, attr.ProgCount)
-	attr.ProgIds = sys.NewPointer(unsafe.Pointer(&progIds[0]))
-	attr.ProgCount = uint32(len(progIds))
+	attr.ProgIds = sys.SlicePointer(progIds)
+	attr.ProgCount = sys.SliceLen(progIds)
 	if err := sys.ProgQuery(&attr); err != nil {
 		return nil, fmt.Errorf("can't query program IDs: %w", err)
 	}

--- a/marshalers.go
+++ b/marshalers.go
@@ -22,7 +22,7 @@ import (
 // unsafe.Pointer.
 func marshalPtr(data interface{}, length int) (sys.Pointer, error) {
 	if ptr, ok := data.(unsafe.Pointer); ok {
-		return sys.NewPointer(ptr), nil
+		return sys.UnsafePointer(ptr), nil
 	}
 
 	buf, err := marshalBytes(data, length)
@@ -30,7 +30,7 @@ func marshalPtr(data interface{}, length int) (sys.Pointer, error) {
 		return sys.Pointer{}, err
 	}
 
-	return sys.NewSlicePointer(buf), nil
+	return sys.SlicePointer(buf), nil
 }
 
 // marshalBytes converts an arbitrary value into a byte buffer.
@@ -76,11 +76,11 @@ func marshalBytes(data interface{}, length int) (buf []byte, err error) {
 
 func makeBuffer(dst interface{}, length int) (sys.Pointer, []byte) {
 	if ptr, ok := dst.(unsafe.Pointer); ok {
-		return sys.NewPointer(ptr), nil
+		return sys.UnsafePointer(ptr), nil
 	}
 
 	buf := make([]byte, length)
-	return sys.NewSlicePointer(buf), buf
+	return sys.SlicePointer(buf), buf
 }
 
 var bytesReaderPool = sync.Pool{
@@ -189,7 +189,7 @@ func marshalPerCPUValue(slice interface{}, elemLength int) (sys.Pointer, error) 
 		copy(buf[offset:offset+elemLength], elemBytes)
 	}
 
-	return sys.NewSlicePointer(buf), nil
+	return sys.SlicePointer(buf), nil
 }
 
 // unmarshalPerCPUValue decodes a buffer into a slice containing one value per

--- a/prog.go
+++ b/prog.go
@@ -246,12 +246,12 @@ func newProgramWithOptions(spec *ProgramSpec, opts ProgramOptions) (*Program, er
 		attr.ProgBtfFd = uint32(handle.FD())
 
 		attr.FuncInfoRecSize = btf.FuncInfoSize
-		attr.FuncInfoCnt = uint32(len(fib)) / btf.FuncInfoSize
-		attr.FuncInfo = sys.NewSlicePointer(fib)
+		attr.FuncInfoCnt = sys.SliceElems(fib, int(btf.FuncInfoSize))
+		attr.FuncInfo = sys.SlicePointer(fib)
 
 		attr.LineInfoRecSize = btf.LineInfoSize
-		attr.LineInfoCnt = uint32(len(lib)) / btf.LineInfoSize
-		attr.LineInfo = sys.NewSlicePointer(lib)
+		attr.LineInfoCnt = sys.SliceElems(lib, int(btf.LineInfoSize))
+		attr.LineInfo = sys.SlicePointer(lib)
 	}
 
 	if err := applyRelocations(insns, opts.KernelTypes, spec.ByteOrder); err != nil {
@@ -269,8 +269,8 @@ func newProgramWithOptions(spec *ProgramSpec, opts ProgramOptions) (*Program, er
 	}
 
 	bytecode := buf.Bytes()
-	attr.Insns = sys.NewSlicePointer(bytecode)
-	attr.InsnCnt = uint32(len(bytecode) / asm.InstructionSize)
+	attr.Insns = sys.SlicePointer(bytecode)
+	attr.InsnCnt = sys.SliceElems(bytecode, asm.InstructionSize)
 
 	if spec.AttachTarget != nil {
 		targetID, err := findTargetInProgram(spec.AttachTarget, spec.AttachTo, spec.Type, spec.AttachType)
@@ -305,8 +305,8 @@ func newProgramWithOptions(spec *ProgramSpec, opts ProgramOptions) (*Program, er
 	if !opts.LogDisabled && opts.LogLevel != 0 {
 		logBuf = make([]byte, opts.LogSize)
 		attr.LogLevel = opts.LogLevel
-		attr.LogSize = uint32(len(logBuf))
-		attr.LogBuf = sys.NewSlicePointer(logBuf)
+		attr.LogSize = sys.SliceLen(logBuf)
+		attr.LogBuf = sys.SlicePointer(logBuf)
 	}
 
 	fd, err := sys.ProgLoad(attr)
@@ -323,8 +323,8 @@ func newProgramWithOptions(spec *ProgramSpec, opts ProgramOptions) (*Program, er
 	if !opts.LogDisabled && opts.LogLevel == 0 {
 		logBuf = make([]byte, opts.LogSize)
 		attr.LogLevel = LogLevelBranch
-		attr.LogSize = uint32(len(logBuf))
-		attr.LogBuf = sys.NewSlicePointer(logBuf)
+		attr.LogSize = sys.SliceLen(logBuf)
+		attr.LogBuf = sys.SlicePointer(logBuf)
 
 		_, err2 = sys.ProgLoad(attr)
 	}
@@ -620,8 +620,8 @@ var haveProgRun = internal.NewFeatureTest("BPF_PROG_RUN", "4.12", func() error {
 	in := internal.EmptyBPFContext
 	attr := sys.ProgRunAttr{
 		ProgFd:     uint32(prog.FD()),
-		DataSizeIn: uint32(len(in)),
-		DataIn:     sys.NewSlicePointer(in),
+		DataSizeIn: sys.SliceLen(in),
+		DataIn:     sys.SlicePointer(in),
 	}
 
 	err = sys.ProgRun(&attr)
@@ -670,15 +670,15 @@ func (p *Program) run(opts *RunOptions) (uint32, time.Duration, error) {
 
 	attr := sys.ProgRunAttr{
 		ProgFd:      p.fd.Uint(),
-		DataSizeIn:  uint32(len(opts.Data)),
-		DataSizeOut: uint32(len(opts.DataOut)),
-		DataIn:      sys.NewSlicePointer(opts.Data),
-		DataOut:     sys.NewSlicePointer(opts.DataOut),
+		DataSizeIn:  sys.SliceLen(opts.Data),
+		DataSizeOut: sys.SliceLen(opts.DataOut),
+		DataIn:      sys.SlicePointer(opts.Data),
+		DataOut:     sys.SlicePointer(opts.DataOut),
 		Repeat:      uint32(opts.Repeat),
-		CtxSizeIn:   uint32(len(ctxBytes)),
-		CtxSizeOut:  uint32(len(ctxOut)),
-		CtxIn:       sys.NewSlicePointer(ctxBytes),
-		CtxOut:      sys.NewSlicePointer(ctxOut),
+		CtxSizeIn:   sys.SliceLen(ctxBytes),
+		CtxSizeOut:  sys.SliceLen(ctxOut),
+		CtxIn:       sys.SlicePointer(ctxBytes),
+		CtxOut:      sys.SlicePointer(ctxOut),
 		Flags:       opts.Flags,
 		Cpu:         opts.CPU,
 	}

--- a/syscalls.go
+++ b/syscalls.go
@@ -42,8 +42,8 @@ func progLoad(insns asm.Instructions, typ ProgramType, license string) (*sys.FD,
 	return sys.ProgLoad(&sys.ProgLoadAttr{
 		ProgType: sys.ProgType(typ),
 		License:  sys.NewStringPointer(license),
-		Insns:    sys.NewSlicePointer(bytecode),
-		InsnCnt:  uint32(len(bytecode) / asm.InstructionSize),
+		Insns:    sys.SlicePointer(bytecode),
+		InsnCnt:  sys.SliceElems(bytecode, asm.InstructionSize),
 	})
 }
 


### PR DESCRIPTION
Use generics to make the Pointer constructors more useful. Also remove the "New" prefix from constructors that do not allocate.

Introduce SliceLen and SliceElems which return 0 if the length of a slice exceeds uint32. This will make it much more obvious when a buffer is too large to be passed to a syscall, since passing a pointer with zero length will cause EFAULT or similar.

Signed-off-by: Lorenz Bauer <oss@lmb.io>