### PR TITLE
sys: introduce TypeID

### DIFF
--- a/btf/types.go
+++ b/btf/types.go
@@ -9,12 +9,13 @@ import (
 
 	"github.com/cilium/ebpf/asm"
 	"github.com/cilium/ebpf/internal"
+	"github.com/cilium/ebpf/internal/sys"
 )
 
 const maxTypeDepth = 32
 
 // TypeID identifies a type in a BTF section.
-type TypeID uint32
+type TypeID = sys.TypeID
 
 // Type represents a type described by BTF.
 type Type interface {

--- a/btf/types.go
+++ b/btf/types.go
@@ -1138,10 +1138,7 @@ func formatType(f fmt.State, verb rune, t formattableType, extra ...interface{})
 		return
 	}
 
-	// This is the same as %T, but elides the package name. Assumes that
-	// formattableType is implemented by a pointer receiver.
-	goTypeName := reflect.TypeOf(t).Elem().Name()
-	_, _ = io.WriteString(f, goTypeName)
+	_, _ = io.WriteString(f, internal.GoTypeName(t))
 
 	if name := t.TypeName(); name != "" {
 		// Output BTF type name if present.

--- a/internal/cmd/gentypes/main.go
+++ b/internal/cmd/gentypes/main.go
@@ -64,6 +64,7 @@ func generateTypes(spec *btf.Spec) ([]byte, error) {
 	objName := &btf.Array{Nelems: 16, Type: &btf.Int{Encoding: btf.Char, Size: 1}}
 	linkID := &btf.Int{Size: 4}
 	btfID := &btf.Int{Size: 4}
+	typeID := &btf.Int{Size: 4}
 	pointer := &btf.Int{Size: 8}
 	logLevel := &btf.Int{Size: 4}
 	mapFlags := &btf.Int{Size: 4}
@@ -73,6 +74,7 @@ func generateTypes(spec *btf.Spec) ([]byte, error) {
 			objName:  internal.GoTypeName(sys.ObjName{}),
 			linkID:   internal.GoTypeName(sys.LinkID(0)),
 			btfID:    internal.GoTypeName(sys.BTFID(0)),
+			typeID:   internal.GoTypeName(sys.TypeID(0)),
 			pointer:  internal.GoTypeName(sys.Pointer{}),
 			logLevel: internal.GoTypeName(sys.LogLevel(0)),
 			mapFlags: internal.GoTypeName(sys.MapFlags(0)),
@@ -156,6 +158,7 @@ import (
 				replace(objName, "name"),
 				replace(pointer, "xlated_prog_insns"),
 				replace(pointer, "map_ids"),
+				replace(btfID, "btf_id"),
 			},
 		},
 		{
@@ -163,6 +166,7 @@ import (
 			[]patch{
 				replace(objName, "name"),
 				replace(mapFlags, "map_flags"),
+				replace(typeID, "btf_vmlinux_value_type_id", "btf_key_type_id", "btf_value_type_id"),
 			},
 		},
 		{
@@ -225,6 +229,7 @@ import (
 				replace(objName, "map_name"),
 				replace(enumTypes["MapType"], "map_type"),
 				replace(mapFlags, "map_flags"),
+				replace(typeID, "btf_vmlinux_value_type_id", "btf_key_type_id", "btf_value_type_id"),
 			},
 		},
 		{
@@ -286,6 +291,7 @@ import (
 					"fd_array",
 					"core_relos",
 				),
+				replace(typeID, "attach_btf_id"),
 				choose(20, "attach_btf_obj_fd"),
 			},
 		},
@@ -363,7 +369,11 @@ import (
 		},
 		{
 			"LinkCreate", retFd, "link_create", "BPF_LINK_CREATE",
-			[]patch{replace(enumTypes["AttachType"], "attach_type")},
+			[]patch{
+				replace(enumTypes["AttachType"], "attach_type"),
+				choose(4, "target_btf_id"),
+				replace(typeID, "target_btf_id"),
+			},
 		},
 		{
 			"LinkCreateIter", retFd, "link_create", "BPF_LINK_CREATE",
@@ -484,7 +494,10 @@ import (
 		{"IterLinkInfo", "iter", []patch{replace(pointer, "target_name"), truncateAfter("target_name_len")}},
 		{"NetNsLinkInfo", "netns", []patch{replace(enumTypes["AttachType"], "attach_type")}},
 		{"RawTracepointLinkInfo", "raw_tracepoint", []patch{replace(pointer, "tp_name")}},
-		{"TracingLinkInfo", "tracing", []patch{replace(enumTypes["AttachType"], "attach_type")}},
+		{"TracingLinkInfo", "tracing", []patch{
+			replace(enumTypes["AttachType"], "attach_type"),
+			replace(typeID, "target_btf_id")},
+		},
 		{"XDPLinkInfo", "xdp", nil},
 	}
 

--- a/internal/cmd/gentypes/main.go
+++ b/internal/cmd/gentypes/main.go
@@ -68,24 +68,14 @@ func generateTypes(spec *btf.Spec) ([]byte, error) {
 	logLevel := &btf.Int{Size: 4}
 	mapFlags := &btf.Int{Size: 4}
 
-	// Pre-declare handwritten types so that generated types can refer to them.
-	var (
-		_ sys.ObjName
-		_ sys.LinkID
-		_ sys.BTFID
-		_ sys.Pointer
-		_ sys.LogLevel
-		_ sys.MapFlags
-	)
-
 	gf := &btf.GoFormatter{
 		Names: map[btf.Type]string{
-			objName:  "ObjName",
-			linkID:   "LinkID",
-			btfID:    "BTFID",
-			pointer:  "Pointer",
-			logLevel: "LogLevel",
-			mapFlags: "MapFlags",
+			objName:  internal.GoTypeName(sys.ObjName{}),
+			linkID:   internal.GoTypeName(sys.LinkID(0)),
+			btfID:    internal.GoTypeName(sys.BTFID(0)),
+			pointer:  internal.GoTypeName(sys.Pointer{}),
+			logLevel: internal.GoTypeName(sys.LogLevel(0)),
+			mapFlags: internal.GoTypeName(sys.MapFlags(0)),
 		},
 		Identifier: internal.Identifier,
 		EnumIdentifier: func(name, element string) string {

--- a/internal/output.go
+++ b/internal/output.go
@@ -6,6 +6,7 @@ import (
 	"go/format"
 	"go/scanner"
 	"io"
+	"reflect"
 	"strings"
 	"unicode"
 )
@@ -81,4 +82,16 @@ func WriteFormatted(src []byte, out io.Writer) error {
 	}
 
 	return nel
+}
+
+// GoTypeName is like %T, but elides the package name.
+//
+// Pointers to a type are peeled off.
+func GoTypeName(t any) string {
+	rT := reflect.TypeOf(t)
+	for rT.Kind() == reflect.Pointer {
+		rT = rT.Elem()
+	}
+	// Doesn't return the correct Name for generic types due to https://github.com/golang/go/issues/55924
+	return rT.Name()
 }

--- a/internal/output_test.go
+++ b/internal/output_test.go
@@ -2,6 +2,8 @@ package internal
 
 import (
 	"testing"
+
+	qt "github.com/frankban/quicktest"
 )
 
 func TestIdentifier(t *testing.T) {
@@ -25,4 +27,15 @@ func TestIdentifier(t *testing.T) {
 			t.Errorf("Expected %q as output of %q, got %q", tc.out, tc.in, have)
 		}
 	}
+}
+
+func TestGoTypeName(t *testing.T) {
+	type foo struct{}
+	type bar[T any] struct{}
+	qt.Assert(t, GoTypeName(foo{}), qt.Equals, "foo")
+	qt.Assert(t, GoTypeName(new(foo)), qt.Equals, "foo")
+	qt.Assert(t, GoTypeName(new(*foo)), qt.Equals, "foo")
+	qt.Assert(t, GoTypeName(bar[int]{}), qt.Equals, "bar[int]")
+	// Broken in the stdlib, see GoTypeName for details.
+	// qt.Assert(t, GoTypeName(bar[qt.C]{}), qt.Equals, "bar[quicktest.C]")
 }

--- a/internal/sys/syscall.go
+++ b/internal/sys/syscall.go
@@ -117,6 +117,9 @@ type LinkID uint32
 // BTFID uniquely identifies a BTF blob loaded into the kernel.
 type BTFID uint32
 
+// TypeID identifies a type in a BTF blob.
+type TypeID uint32
+
 // MapFlags control map behaviour.
 type MapFlags uint32
 

--- a/internal/sys/types.go
+++ b/internal/sys/types.go
@@ -477,12 +477,12 @@ type MapInfo struct {
 	MapFlags              MapFlags
 	Name                  ObjName
 	Ifindex               uint32
-	BtfVmlinuxValueTypeId BtfTypeId
+	BtfVmlinuxValueTypeId TypeID
 	NetnsDev              uint64
 	NetnsIno              uint64
 	BtfId                 uint32
-	BtfKeyTypeId          BtfTypeId
-	BtfValueTypeId        BtfTypeId
+	BtfKeyTypeId          TypeID
+	BtfValueTypeId        TypeID
 	_                     [4]byte
 	MapExtra              uint64
 }
@@ -616,7 +616,7 @@ type LinkCreateAttr struct {
 	TargetFd    uint32
 	AttachType  AttachType
 	Flags       uint32
-	TargetBtfId BTFID
+	TargetBtfId TypeID
 	_           [28]byte
 }
 
@@ -706,9 +706,9 @@ type MapCreateAttr struct {
 	MapName               ObjName
 	MapIfindex            uint32
 	BtfFd                 uint32
-	BtfKeyTypeId          BtfTypeId
-	BtfValueTypeId        BtfTypeId
-	BtfVmlinuxValueTypeId BtfTypeId
+	BtfKeyTypeId          TypeID
+	BtfValueTypeId        TypeID
+	BtfVmlinuxValueTypeId TypeID
 	MapExtra              uint64
 }
 
@@ -986,7 +986,7 @@ type ProgLoadAttr struct {
 	LineInfoRecSize    uint32
 	LineInfo           Pointer
 	LineInfoCnt        uint32
-	AttachBtfId        BTFID
+	AttachBtfId        TypeID
 	AttachBtfObjFd     uint32
 	CoreReloCnt        uint32
 	FdArray            Pointer
@@ -1081,7 +1081,7 @@ type RawTracepointLinkInfo struct {
 type TracingLinkInfo struct {
 	AttachType  AttachType
 	TargetObjId uint32
-	TargetBtfId BtfTypeId
+	TargetBtfId TypeID
 }
 
 type XDPLinkInfo struct{ Ifindex uint32 }

--- a/internal/sys/types.go
+++ b/internal/sys/types.go
@@ -477,12 +477,12 @@ type MapInfo struct {
 	MapFlags              MapFlags
 	Name                  ObjName
 	Ifindex               uint32
-	BtfVmlinuxValueTypeId uint32
+	BtfVmlinuxValueTypeId BtfTypeId
 	NetnsDev              uint64
 	NetnsIno              uint64
 	BtfId                 uint32
-	BtfKeyTypeId          uint32
-	BtfValueTypeId        uint32
+	BtfKeyTypeId          BtfTypeId
+	BtfValueTypeId        BtfTypeId
 	_                     [4]byte
 	MapExtra              uint64
 }
@@ -508,7 +508,7 @@ type ProgInfo struct {
 	NrJitedFuncLens      uint32
 	JitedKsyms           uint64
 	JitedFuncLens        uint64
-	BtfId                uint32
+	BtfId                BTFID
 	FuncInfoRecSize      uint32
 	FuncInfo             uint64
 	NrFuncInfo           uint32
@@ -616,7 +616,7 @@ type LinkCreateAttr struct {
 	TargetFd    uint32
 	AttachType  AttachType
 	Flags       uint32
-	TargetBtfId uint32
+	TargetBtfId BTFID
 	_           [28]byte
 }
 
@@ -706,9 +706,9 @@ type MapCreateAttr struct {
 	MapName               ObjName
 	MapIfindex            uint32
 	BtfFd                 uint32
-	BtfKeyTypeId          uint32
-	BtfValueTypeId        uint32
-	BtfVmlinuxValueTypeId uint32
+	BtfKeyTypeId          BtfTypeId
+	BtfValueTypeId        BtfTypeId
+	BtfVmlinuxValueTypeId BtfTypeId
 	MapExtra              uint64
 }
 
@@ -986,7 +986,7 @@ type ProgLoadAttr struct {
 	LineInfoRecSize    uint32
 	LineInfo           Pointer
 	LineInfoCnt        uint32
-	AttachBtfId        uint32
+	AttachBtfId        BTFID
 	AttachBtfObjFd     uint32
 	CoreReloCnt        uint32
 	FdArray            Pointer
@@ -1081,7 +1081,7 @@ type RawTracepointLinkInfo struct {
 type TracingLinkInfo struct {
 	AttachType  AttachType
 	TargetObjId uint32
-	TargetBtfId uint32
+	TargetBtfId BtfTypeId
 }
 
 type XDPLinkInfo struct{ Ifindex uint32 }

--- a/link/link.go
+++ b/link/link.go
@@ -172,7 +172,7 @@ func AttachRawLink(opts RawLinkOptions) (*RawLink, error) {
 		TargetFd:    uint32(opts.Target),
 		ProgFd:      uint32(progFd),
 		AttachType:  sys.AttachType(opts.Attach),
-		TargetBtfId: uint32(opts.BTF),
+		TargetBtfId: opts.BTF,
 		Flags:       opts.Flags,
 	}
 	fd, err := sys.LinkCreate(&attr)

--- a/map.go
+++ b/map.go
@@ -430,8 +430,8 @@ func (spec *MapSpec) createMap(inner *sys.FD, opts MapOptions) (_ *Map, err erro
 
 			// Use BTF k/v during map creation.
 			attr.BtfFd = uint32(handle.FD())
-			attr.BtfKeyTypeId = uint32(keyTypeID)
-			attr.BtfValueTypeId = uint32(valueTypeID)
+			attr.BtfKeyTypeId = keyTypeID
+			attr.BtfValueTypeId = valueTypeID
 		}
 	}
 

--- a/prog.go
+++ b/prog.go
@@ -278,7 +278,7 @@ func newProgramWithOptions(spec *ProgramSpec, opts ProgramOptions) (*Program, er
 			return nil, fmt.Errorf("attach %s/%s: %w", spec.Type, spec.AttachType, err)
 		}
 
-		attr.AttachBtfId = uint32(targetID)
+		attr.AttachBtfId = targetID
 		attr.AttachBtfObjFd = uint32(spec.AttachTarget.FD())
 		defer runtime.KeepAlive(spec.AttachTarget)
 	} else if spec.AttachTo != "" {
@@ -289,7 +289,7 @@ func newProgramWithOptions(spec *ProgramSpec, opts ProgramOptions) (*Program, er
 			return nil, fmt.Errorf("attach %s/%s: %w", spec.Type, spec.AttachType, err)
 		}
 
-		attr.AttachBtfId = uint32(targetID)
+		attr.AttachBtfId = targetID
 		if module != nil {
 			attr.AttachBtfObjFd = uint32(module.FD())
 			defer module.Close()


### PR DESCRIPTION
Add an exported type for BTF type IDs to `sys`. Use the opportunity to make `gentypes` a little bit nicer.