### PR TITLE
link: make KprobeMultiOptions.Addresses a []uintptr

### DIFF
--- a/link/kprobe_multi.go
+++ b/link/kprobe_multi.go
@@ -28,7 +28,7 @@ type KprobeMultiOptions struct {
 	// limits the attach point to the function entry or return.
 	//
 	// Mutually exclusive with Symbols.
-	Addresses []uint64
+	Addresses []uintptr
 
 	// Cookies specifies arbitrary values that can be fetched from an eBPF
 	// program via `bpf_get_attach_cookie()`.

--- a/link/kprobe_multi_test.go
+++ b/link/kprobe_multi_test.go
@@ -2,7 +2,6 @@ package link
 
 import (
 	"errors"
-	"math"
 	"os"
 	"testing"
 
@@ -40,7 +39,7 @@ func TestKprobeMultiInput(t *testing.T) {
 	// Symbols and Addresses are mutually exclusive.
 	_, err = KprobeMulti(prog, KprobeMultiOptions{
 		Symbols:   []string{"foo"},
-		Addresses: []uint64{1},
+		Addresses: []uintptr{1},
 	})
 	if !errors.Is(err, errInvalidInput) {
 		t.Fatalf("expected errInvalidInput, got: %v", err)
@@ -70,7 +69,7 @@ func TestKprobeMultiErrors(t *testing.T) {
 	// Only have a negative test for addresses as it would be hard to maintain a
 	// proper one.
 	if _, err := KprobeMulti(prog, KprobeMultiOptions{
-		Addresses: []uint64{math.MaxUint64},
+		Addresses: []uintptr{^uintptr(0)},
 	}); !errors.Is(err, unix.EINVAL) {
 		t.Fatalf("expected EINVAL, got: %s", err)
 	}


### PR DESCRIPTION
The kernel expects kprobe_multi.addrs to point at an array of unsigned long. The size of unsigned long is compiler or platform dependent, so using uint64 is incorrect on 32-bit arches.

uintptr seems like the closest analog to C's unsigned long, although I've not been able to figure out how uintptr is really defined.

See https://elixir.bootlin.com/linux/v6.1.7/source/kernel/trace/bpf_trace.c#L2671

Signed-off-by: Lorenz Bauer <oss@lmb.io>