### PR TITLE
link: close perfEventLink.fd before perf event in Close()

### DIFF
--- a/link/kprobe_test.go
+++ b/link/kprobe_test.go
@@ -72,25 +72,22 @@ func TestKprobeOffset(t *testing.T) {
 
 func TestKretprobeMaxActive(t *testing.T) {
 	prog := mustLoadProgram(t, ebpf.Kprobe, 0, "")
+	defer prog.Close()
 
-	k, err := Kprobe("do_sys_open", prog, &KprobeOptions{RetprobeMaxActive: 4096})
+	_, err := Kprobe("do_sys_open", prog, &KprobeOptions{RetprobeMaxActive: 4096})
 	if !errors.Is(err, errInvalidMaxActive) {
 		t.Fatal("Expected errInvalidMaxActive, got", err)
 	}
-	if k != nil {
-		k.Close()
-	}
 
-	k, err = Kretprobe("__put_task_struct", prog, &KprobeOptions{RetprobeMaxActive: 4096})
-	if testutils.IsKernelLessThan(t, "4.12") {
-		if !errors.Is(err, ErrNotSupported) {
-			t.Fatal("Expected ErrNotSupported, got", err)
-		}
-	} else if err != nil {
+	k, err := Kretprobe("__put_task_struct", prog, &KprobeOptions{RetprobeMaxActive: 4096})
+	if testutils.IsKernelLessThan(t, "4.12") && errors.Is(err, ErrNotSupported) {
+		t.Skip("Kernel doesn't support maxactive")
+	}
+	if err != nil {
 		t.Fatal("Kretprobe with maxactive returned an error:", err)
 	}
-	if k != nil {
-		k.Close()
+	if err := k.Close(); err != nil {
+		t.Fatal("Closing kretprobe:", err)
 	}
 }
 

--- a/link/perf_event.go
+++ b/link/perf_event.go
@@ -136,10 +136,14 @@ func (pl *perfEventLink) Unpin() error {
 }
 
 func (pl *perfEventLink) Close() error {
-	if err := pl.pe.Close(); err != nil {
-		return fmt.Errorf("perf event link close: %w", err)
+	if err := pl.fd.Close(); err != nil {
+		return fmt.Errorf("perf link close: %w", err)
 	}
-	return pl.fd.Close()
+
+	if err := pl.pe.Close(); err != nil {
+		return fmt.Errorf("perf event close: %w", err)
+	}
+	return nil
 }
 
 func (pl *perfEventLink) Update(prog *ebpf.Program) error {


### PR DESCRIPTION
If a Kretprobe is created with RetprobeMaxActive > 0 on a kernel supporting bpf_link, a bpf_link is created based on a tracefs-backed perf event.

perfEventLink.Close() would try to remove the tracefs entry first, resulting in EBUSY because of the open link. This error, in turn, leaked the bpf_link fd. This also caused perf events to never be removed from tracefs/kprobe_events.

This commit closes the link and the perf event in the correct order.

Found by the fd tracer in https://github.com/cilium/ebpf/pull/732.

---

Unfortunately, this also means pinning a retprobe link with maxactive set means tracefs entries will leak by design. The only real solution I see is https://github.com/cilium/ebpf/pull/842.