### PR TITLE
link: use strings.Map in sanitizeSymbol

### DIFF
--- a/link/uprobe.go
+++ b/link/uprobe.go
@@ -323,26 +323,23 @@ func tracefsUprobe(args probeArgs) (*perfEvent, error) {
 // sanitizeSymbol replaces every invalid character for the tracefs api with an underscore.
 // It is equivalent to calling regexp.MustCompile("[^a-zA-Z0-9]+").ReplaceAllString("_").
 func sanitizeSymbol(s string) string {
-	var b strings.Builder
-	b.Grow(len(s))
 	var skip bool
-	for _, c := range []byte(s) {
+	return strings.Map(func(c rune) rune {
 		switch {
 		case c >= 'a' && c <= 'z',
 			c >= 'A' && c <= 'Z',
 			c >= '0' && c <= '9':
 			skip = false
-			b.WriteByte(c)
+			return c
+
+		case skip:
+			return -1
 
 		default:
-			if !skip {
-				b.WriteByte('_')
-				skip = true
-			}
+			skip = true
+			return '_'
 		}
-	}
-
-	return b.String()
+	}, s)
 }
 
 // uprobeToken creates the PATH:OFFSET(REF_CTR_OFFSET) token for the tracefs api.


### PR DESCRIPTION
strings.Map has a fast path in case a string doesn't contain any characters that have to be replaced. Use it instead of manually allocating a strings.Builder.

Signed-off-by: Lorenz Bauer <oss@lmb.io>