### PR TITLE
elf_reader: Add "usdt" prefix support

### DIFF
--- a/elf_reader.go
+++ b/elf_reader.go
@@ -1086,6 +1086,7 @@ func getProgType(sectionName string) (ProgramType, AttachType, uint32, string) {
 		{"uprobe/", Kprobe, AttachNone, 0},
 		{"kretprobe/", Kprobe, AttachNone, 0},
 		{"uretprobe/", Kprobe, AttachNone, 0},
+		{"usdt/", Kprobe, AttachNone, 0},
 		{"tc", SchedCLS, AttachNone, 0},
 		{"classifier", SchedCLS, AttachNone, 0},
 		{"action", SchedACT, AttachNone, 0},


### PR DESCRIPTION
Linux 5.19 supports the "usdt" section.

https://github.com/torvalds/linux/commit/2e4913e0#diff-333e3796217dda054b006e3cfe59f542121cf8a07f67f21c6ab7851ecf0c02e1R8674

Signed-off-by: haining.cao <haining.cao@daocloud.io>