### PR TITLE
program: set name from object info for pinned file

### DIFF
--- a/prog.go
+++ b/prog.go
@@ -783,7 +783,14 @@ func LoadPinnedProgram(fileName string, opts *LoadPinOptions) (*Program, error) 
 		return nil, fmt.Errorf("info for %s: %w", fileName, err)
 	}
 
-	return &Program{"", fd, filepath.Base(fileName), fileName, info.Type}, nil
+	var progName string
+	if haveObjName() == nil {
+		progName = info.Name
+	} else {
+		progName = filepath.Base(fileName)
+	}
+
+	return &Program{"", fd, progName, fileName, info.Type}, nil
 }
 
 // SanitizeName replaces all invalid characters in name with replacement.

--- a/prog_test.go
+++ b/prog_test.go
@@ -298,6 +298,16 @@ func TestProgramPin(t *testing.T) {
 		t.Error("Expected pinned program to have type SocketFilter, but got", prog.Type())
 	}
 
+	if haveObjName() == nil {
+		if prog.name != "test" {
+			t.Errorf("Expected program to have object name 'test', got '%s'", prog.name)
+		}
+	} else {
+		if prog.name != "program" {
+			t.Errorf("Expected program to have file name 'program', got '%s'", prog.name)
+		}
+	}
+
 	if !prog.IsPinned() {
 		t.Error("Expected IsPinned to be true")
 	}


### PR DESCRIPTION
When loading a program from a pinned file, the program name is set from the file name instead from the object info.

This commit adds a test that expects the program name to be set from the object info and changes the procedure to set the name from the object info, which is present already and used to set the program type.

Signed-off-by: Tobias Böhm <code@aibor.de>