### PR TITLE
docs: update various bits of documentation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,7 +1,18 @@
 Architecture of the library
 ===
 
-    ELF -> Specifications -> Objects -> Links
+```mermaid
+graph RL
+    Program --> ProgramSpec --> ELF
+    Map --> MapSpec --> ELF
+    Links --> Map & Program
+    subgraph Collection
+        Program & Map
+    end
+    subgraph CollectionSpec
+        ProgramSpec & MapSpec
+    end
+```
 
 ELF
 ---
@@ -11,7 +22,7 @@ an ELF file which contains program byte code (aka BPF), but also metadata for
 maps used by the program. The metadata follows the conventions set by libbpf
 shipped with the kernel. Certain ELF sections have special meaning
 and contain structures defined by libbpf. Newer versions of clang emit
-additional metadata in BPF Type Format (aka BTF).
+additional metadata in [BPF Type Format](#BTF).
 
 The library aims to be compatible with libbpf so that moving from a C toolchain
 to a Go one creates little friction. To that end, the [ELF reader](elf_reader.go)
@@ -20,41 +31,32 @@ if possible.
 
 The output of the ELF reader is a `CollectionSpec` which encodes
 all of the information contained in the ELF in a form that is easy to work with
-in Go.
-
-### BTF
-
-The BPF Type Format describes more than just the types used by a BPF program. It
-includes debug aids like which source line corresponds to which instructions and
-what global variables are used.
-
-[BTF parsing](internal/btf/) lives in a separate internal package since exposing
-it would mean an additional maintenance burden, and because the API still
-has sharp corners. The most important concept is the `btf.Type` interface, which
-also describes things that aren't really types like `.rodata` or `.bss` sections.
-`btf.Type`s can form cyclical graphs, which can easily lead to infinite loops if
-one is not careful. Hopefully a safe pattern to work with `btf.Type` emerges as
-we write more code that deals with it.
+in Go. The returned `CollectionSpec` should be deterministic: reading the same ELF
+file on different systems must produce the same output.
+As a corollary, any changes that depend on the runtime environment like the
+current kernel version must happen when creating [Objects](#Objects).
 
 Specifications
 ---
 
-`CollectionSpec`, `ProgramSpec` and `MapSpec` are blueprints for in-kernel
-objects and contain everything necessary to execute the relevant `bpf(2)`
-syscalls. Since the ELF reader outputs a `CollectionSpec` it's possible to
-modify clang-compiled BPF code, for example to rewrite constants. At the same
-time the [asm](asm/) package provides an assembler that can be used to generate
-`ProgramSpec` on the fly.
+`CollectionSpec` is a very simple container for `ProgramSpec` and `MapSpec`. Avoid
+adding functionality to it if possible.
 
-Creating a spec should never require any privileges or be restricted in any way,
-for example by only allowing programs in native endianness. This ensures that
-the library stays flexible.
+`ProgramSpec` and `MapSpec` are blueprints for in-kernel
+objects and contain everything necessary to execute the relevant `bpf(2)`
+syscalls. 
+
+The [asm](asm/) package provides an assembler that can be used to generate
+`ProgramSpec` on the fly.
 
 Objects
 ---
 
-`Program` and `Map` are the result of loading specs into the kernel. Sometimes
-loading a spec will fail because the kernel is too old, or a feature is not
+`Program` and `Map` are the result of loading specifications into the kernel.
+Features that depend on knowledge of the current system (e.g kernel version)
+are implemented at this point.
+
+Sometimes loading a spec will fail because the kernel is too old, or a feature is not
 enabled. There are multiple ways the library deals with that:
 
 * Fallback: older kernels don't allow naming programs and maps. The library
@@ -73,7 +75,7 @@ useful when our higher-level API doesn't support a particular use case.
 Links
 ---
 
-BPF can be attached to many different points in the kernel and newer BPF hooks
+Programs can be attached to many different points in the kernel and newer BPF hooks
 tend to use bpf_link to do so. Older hooks unfortunately use a combination of
 syscalls, netlink messages, etc. Adding support for a new link type should not
 pull in large dependencies like netlink, so XDP programs or tracepoints are

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,15 +5,12 @@ the form of pull requests and issues reporting bugs or suggesting new features
 are welcome. Please take a look at [the architecture](ARCHITECTURE.md) to get
 a better understanding for the high-level goals.
 
-New features must be accompanied by tests. Before starting work on any large
-feature, please [join](https://ebpf.io/slack) the
-[#ebpf-go](https://cilium.slack.com/messages/ebpf-go) channel on Slack to
-discuss the design first.
+## Adding a new feature
 
-When submitting pull requests, consider writing details about what problem you
-are solving and why the proposed approach solves that problem in commit messages
-and/or pull request description to help future library users and maintainers to
-reason about the proposed changes.
+1. [Join](https://ebpf.io/slack) the
+[#ebpf-go](https://cilium.slack.com/messages/ebpf-go) channel to discuss your requirements and how the feature can be implemented. The most important part is figuring out how much new exported API is necessary. **The less new API is required the easier it will be to land the feature.**
+2. (*optional*) Create a draft PR if you want to discuss the implementation or have hit a problem. It's fine if this doesn't compile or contains debug statements.
+3. Create a PR that is ready to merge. This must pass CI and have tests.
 
 ## Running the tests
 
@@ -35,6 +32,6 @@ Examples:
 ./run-tests.sh 5.4
 
 # Run a subset of tests:
-./run-tests.sh 5.4 go test ./link
+./run-tests.sh 5.4 ./link
 ```
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ ecosystem.
 A small collection of Go and eBPF programs that serve as examples for building
 your own tools can be found under [examples/](examples/).
 
-Contributions are highly encouraged, as they highlight certain use cases of
+[Contributions](CONTRIBUTING.md) are highly encouraged, as they highlight certain use cases of
 eBPF and the library, and help shape the future of the project.
 
 ## Getting Help
@@ -53,6 +53,7 @@ This library includes the following packages:
   of `bpftool feature probe` for discovering BPF-related kernel features using native Go.
 * [rlimit](https://pkg.go.dev/github.com/cilium/ebpf/rlimit) provides a convenient API to lift
   the `RLIMIT_MEMLOCK` constraint on kernels before 5.11.
+* [btf](https://pkg.go.dev/github.com/cilium/ebpf/btf) allows reading the BPF Type Format.
 
 ## Requirements
 


### PR DESCRIPTION
Adds a diagram to ARCHITECTURE.md and gets rid of the BTF section, which is orthogonal to how the library is architected. It existed mainly to explaint why the package wasn't exported, but that is now moot.

Make CONTRIBUTING.md shorter (do people read these things?) and give a list of steps how to contribute a feature.

Update README.md to mention the btf package.