### PR TITLE
btf: copy Spec lazily

### DIFF
--- a/btf/btf.go
+++ b/btf/btf.go
@@ -34,8 +34,10 @@ type ID = sys.BTFID
 // kernel.
 type Spec struct {
 	// All types contained by the spec, not including types from the base in
-	// case the spec was parsed from split BTF.
-	types []Type
+	// case the spec was parsed from split BTF. Types are copied lazily, avoid
+	// accessing the slice directly.
+	_types []Type
+	copies copier
 
 	// Type IDs indexed by type.
 	typeIDs map[Type]TypeID
@@ -84,6 +86,7 @@ func (h *btfHeader) stringStart() int64 {
 func NewSpec() *Spec {
 	return &Spec{
 		[]Type{(*Void)(nil)},
+		nil,
 		map[Type]TypeID{(*Void)(nil): 0},
 		0,
 		0,
@@ -136,7 +139,7 @@ func LoadSpecAndExtInfosFromReader(rd io.ReaderAt) (*Spec, *ExtInfos, error) {
 		return nil, nil, err
 	}
 
-	extInfos, err := loadExtInfosFromELF(file, spec.types, spec.strings)
+	extInfos, err := loadExtInfosFromELF(file, spec.types(), spec.strings)
 	if err != nil && !errors.Is(err, ErrNotFound) {
 		return nil, nil, err
 	}
@@ -221,7 +224,7 @@ func loadSpecFromELF(file *internal.SafeELFFile) (*Spec, error) {
 		return nil, err
 	}
 
-	err = fixupDatasec(spec.types, sectionSizes, offsets)
+	err = fixupDatasec(spec.types(), sectionSizes, offsets)
 	if err != nil {
 		return nil, err
 	}
@@ -246,7 +249,7 @@ func loadRawSpec(btf io.ReaderAt, bo binary.ByteOrder,
 	return &Spec{
 		namedTypes:  typesByName,
 		typeIDs:     typeIDs,
-		types:       types,
+		_types:      types,
 		firstTypeID: TypeID(len(baseTypes)),
 		lastTypeID:  lastTypeID,
 		strings:     rawStrings,
@@ -491,19 +494,38 @@ func fixupDatasec(types []Type, sectionSizes map[string]uint32, offsets map[symb
 
 // Copy creates a copy of Spec.
 func (s *Spec) Copy() *Spec {
-	types := copyTypes(s.types, nil)
-	typeIDs, typesByName, lastTypeID := indexTypes(types, s.firstTypeID)
+	// This performs a very shallow copy of the spec. We rely on
+	// calling Spec.types below to perform a full copy at
+	// the right times.
+	cpy := *s
+	cpy.copies = make(copier)
+	return &cpy
+}
 
-	// NB: Other parts of spec are not copied since they are immutable.
-	return &Spec{
-		types,
-		typeIDs,
-		s.firstTypeID,
-		lastTypeID,
-		typesByName,
-		s.strings,
-		s.byteOrder,
+// makeWritable performs a deep copy of the spec if necessary.
+//
+// After the call, _types, typeIDs and namedTypes can be safely modified.
+func (s *Spec) makeWritable() {
+	if s.copies == nil {
+		return
 	}
+
+	types := make([]Type, len(s._types))
+	for i := range types {
+		types[i] = s.copies.copy(s._types[i], nil)
+	}
+
+	s.typeIDs, s.namedTypes, _ = indexTypes(types, s.firstTypeID)
+	s._types = types
+	s.copies = nil
+}
+
+// types returns the list of types contained in the spec.
+//
+// May perform a deep copy of the spec.
+func (s *Spec) types() []Type {
+	s.makeWritable()
+	return s._types
 }
 
 type sliceWriter []byte
@@ -535,8 +557,10 @@ func (s *Spec) Add(typ Type) (TypeID, error) {
 		return 0, fmt.Errorf("type ID overflow")
 	}
 
+	s.makeWritable()
+
 	s.typeIDs[typ] = id
-	s.types = append(s.types, typ)
+	s._types = append(s._types, typ)
 	s.lastTypeID = id
 
 	if name := newEssentialName(typ.TypeName()); name != "" {
@@ -555,7 +579,7 @@ func (s *Spec) TypeByID(id TypeID) (Type, error) {
 		return nil, fmt.Errorf("expected type ID between %d and %d, got %d: %w", s.firstTypeID, s.lastTypeID, id, ErrNotFound)
 	}
 
-	return s.types[id-s.firstTypeID], nil
+	return s.copies.copy(s._types[id-s.firstTypeID], nil), nil
 }
 
 // TypeID returns the ID for a given Type.
@@ -594,7 +618,7 @@ func (s *Spec) AnyTypesByName(name string) ([]Type, error) {
 		// Match against the full name, not just the essential one
 		// in case the type being looked up is a struct flavor.
 		if t.TypeName() == name {
-			result = append(result, t)
+			result = append(result, s.copies.copy(t, nil))
 		}
 	}
 	return result, nil
@@ -685,7 +709,7 @@ func LoadSplitSpecFromReader(r io.ReaderAt, base *Spec) (*Spec, error) {
 		return nil, fmt.Errorf("parse split BTF: base must be loaded from an ELF")
 	}
 
-	return loadRawSpec(r, internal.NativeEndian, base.types, base.strings)
+	return loadRawSpec(r, internal.NativeEndian, base.types(), base.strings)
 }
 
 // TypesIterator iterates over types of a given spec.
@@ -700,7 +724,7 @@ type TypesIterator struct {
 func (s *Spec) Iterate() *TypesIterator {
 	// We share the backing array of types with the Spec. This is safe since
 	// we don't allow deletion or shuffling of types.
-	return &TypesIterator{types: s.types, index: 0}
+	return &TypesIterator{types: s.types(), index: 0}
 }
 
 // Next returns true as long as there are any remaining types.

--- a/btf/ext_info.go
+++ b/btf/ext_info.go
@@ -185,7 +185,7 @@ marshal:
 	buf := getBuffer()
 	defer putBuffer(buf)
 
-	if err := marshalTypes(buf, spec.types, stb, kernelMarshalOptions); err != nil {
+	if err := marshalTypes(buf, spec.types(), stb, kernelMarshalOptions); err != nil {
 		return nil, nil, nil, fmt.Errorf("marshal BTF: %w", err)
 	}
 

--- a/btf/fuzz_test.go
+++ b/btf/fuzz_test.go
@@ -38,7 +38,7 @@ func FuzzSpec(f *testing.F) {
 			t.Fatal("spec is nil")
 		}
 
-		for _, typ := range spec.types {
+		for _, typ := range spec.types() {
 			fmt.Fprintf(io.Discard, "%+10v", typ)
 		}
 	})

--- a/btf/handle.go
+++ b/btf/handle.go
@@ -45,7 +45,7 @@ func NewHandle(spec *Spec) (*Handle, error) {
 		stb = newStringTableBuilder(spec.strings.Num())
 	}
 
-	err := marshalTypes(buf, spec.types, stb, kernelMarshalOptions)
+	err := marshalTypes(buf, spec.types(), stb, kernelMarshalOptions)
 	if err != nil {
 		return nil, fmt.Errorf("marshal BTF: %w", err)
 	}
@@ -133,7 +133,7 @@ func (h *Handle) Spec() (*Spec, error) {
 		return nil, fmt.Errorf("can't load split BTF without access to /sys")
 	}
 
-	return loadRawSpec(bytes.NewReader(btfBuffer), internal.NativeEndian, base.types, base.strings)
+	return loadRawSpec(bytes.NewReader(btfBuffer), internal.NativeEndian, base.types(), base.strings)
 }
 
 // Close destroys the handle.

--- a/btf/handle.go
+++ b/btf/handle.go
@@ -30,7 +30,7 @@ func NewHandle(spec *Spec) (*Handle, error) {
 		return nil, fmt.Errorf("can't load %s BTF on %s", spec.byteOrder, internal.NativeEndian)
 	}
 
-	if spec.firstTypeID() != 0 {
+	if spec.firstTypeID != 0 {
 		return nil, fmt.Errorf("split BTF can't be loaded into the kernel")
 	}
 

--- a/btf/marshal_test.go
+++ b/btf/marshal_test.go
@@ -32,11 +32,11 @@ func TestBuild(t *testing.T) {
 
 	have, err := loadRawSpec(bytes.NewReader(buf.Bytes()), internal.NativeEndian, nil, nil)
 	qt.Assert(t, err, qt.IsNil, qt.Commentf("Couldn't parse BTF"))
-	qt.Assert(t, have.types, qt.DeepEquals, want)
+	qt.Assert(t, have.types(), qt.DeepEquals, want)
 }
 
 func TestRoundtripVMlinux(t *testing.T) {
-	types := vmlinuxSpec(t).types
+	types := vmlinuxSpec(t).types()
 
 	// Randomize the order to force different permutations of walking the type
 	// graph. Keep Void at index 0.
@@ -77,7 +77,7 @@ limitTypes:
 	rebuilt, err := loadRawSpec(bytes.NewReader(buf.Bytes()), binary.LittleEndian, nil, nil)
 	qt.Assert(t, err, qt.IsNil, qt.Commentf("round tripping BTF failed"))
 
-	if n := len(rebuilt.types); n > math.MaxUint16 {
+	if n := len(rebuilt.types()); n > math.MaxUint16 {
 		t.Logf("Rebuilt BTF contains %d types which exceeds uint16, test may fail on older kernels", n)
 	}
 
@@ -88,7 +88,7 @@ limitTypes:
 }
 
 func BenchmarkBuildVmlinux(b *testing.B) {
-	types := vmlinuxTestdataSpec(b).types
+	types := vmlinuxTestdataSpec(b).types()
 
 	b.ReportAllocs()
 	b.ResetTimer()

--- a/btf/types.go
+++ b/btf/types.go
@@ -681,30 +681,18 @@ type Transformer func(Type) Type
 // to be copied type, and the returned value is copied instead.
 func Copy(typ Type, transform Transformer) Type {
 	copies := make(copier)
-	copies.copy(&typ, transform)
-	return typ
-}
-
-// copy a slice of Types recursively.
-//
-// See Copy for the semantics.
-func copyTypes(types []Type, transform Transformer) []Type {
-	result := make([]Type, len(types))
-	copy(result, types)
-
-	copies := make(copier)
-	for i := range result {
-		copies.copy(&result[i], transform)
-	}
-
-	return result
+	return copies.copy(typ, transform)
 }
 
 type copier map[Type]Type
 
-func (c copier) copy(typ *Type, transform Transformer) {
+func (c copier) copy(typ Type, transform Transformer) Type {
+	if c == nil {
+		return typ
+	}
+
 	var work typeDeque
-	for t := typ; t != nil; t = work.Pop() {
+	for t := &typ; t != nil; t = work.Pop() {
 		// *t is the identity of the type.
 		if cpy := c[*t]; cpy != nil {
 			*t = cpy
@@ -724,6 +712,8 @@ func (c copier) copy(typ *Type, transform Transformer) {
 		// Mark any nested types for copying.
 		walkType(cpy, work.Push)
 	}
+
+	return typ
 }
 
 type typeDeque = internal.Deque[*Type]


### PR DESCRIPTION
This is an attempt to fix the problem pointed out in #920: calling LoadKernelSpec is very slow since it copies __all__ types contained within the kernel. I've tried optimizing `Spec.Copy` but that yielded only a 10% speedup, with total time still on the order of 10s of milliseconds.

Options I've considered:

1. Never copy in LoadKernelSpec and document that callers must take care to not modify the spec. This is bad because it'll lead to hard to diagnose bugs: buggy code in one package will affect non-buggy code in another.
2. Copy for external callers of LoadKernelSpec, don't copy inside of the library. Nice and simple! This is difficult because of circular imports: we need to access the internal Spec in `ebpf.findTargetInKernel` but can't put a getter in `btf` without exposing it to other users. We also need access to the internal spec in `btf`. I think this option doesn't work without some code duplication.
3. Make copying a Spec a very shallow operation. Instead of copying all types when `Spec.Copy` is invoked, only do so when necessary. This is "optimal" in the sense that we spend the least time copying, but it's the fiddliest to maintain going forward.

This PR implements option 3. During `Spec.Copy` almost no actual copying happens. I tried an approach where `Spec.Copy` does a shallo copy of `Spec.types`, etc. but that is also too slow.

I also have a PoC of option 2 somewhere which I'll try to dig up.