### PR TITLE
btf: work around kernel Datasec bug

### DIFF
--- a/btf/marshal.go
+++ b/btf/marshal.go
@@ -319,10 +319,13 @@ func (e *encoder) deflateType(typ Type) (err error) {
 
 	case *declTag:
 		raw.SetKind(kindDeclTag)
+		raw.SetType(e.id(v.Type))
 		raw.data = &btfDeclTag{uint32(v.Index)}
+		raw.NameOff, err = e.strings.Add(v.Value)
 
 	case *typeTag:
 		raw.SetKind(kindTypeTag)
+		raw.SetType(e.id(v.Type))
 		raw.NameOff, err = e.strings.Add(v.Value)
 
 	default:

--- a/btf/marshal.go
+++ b/btf/marshal.go
@@ -449,6 +449,12 @@ func MarshalMapKV(key, value Type) (_ *Handle, keyID, valueID TypeID, err error)
 	}
 
 	if value != nil {
+		if ds, ok := value.(*Datasec); ok {
+			if err := datasecResolveWorkaround(spec, ds); err != nil {
+				return nil, 0, 0, err
+			}
+		}
+
 		valueID, err = spec.Add(value)
 		if err != nil {
 			return nil, 0, 0, fmt.Errorf("add value type: %w", err)

--- a/btf/workarounds.go
+++ b/btf/workarounds.go
@@ -1,0 +1,24 @@
+package btf
+
+// datasecResolveWorkaround ensures that certain vars in a Datasec are added
+// to a Spec before the Datasec. This avoids a bug in kernel BTF validation.
+//
+// See https://lore.kernel.org/bpf/20230302123440.1193507-1-lmb@isovalent.com/
+func datasecResolveWorkaround(spec *Spec, ds *Datasec) error {
+	for _, vsi := range ds.Vars {
+		v, ok := vsi.Type.(*Var)
+		if !ok {
+			continue
+		}
+
+		switch v.Type.(type) {
+		case *Typedef, *Volatile, *Const, *Restrict, *typeTag:
+			_, err := spec.Add(v.Type)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/btf/workarounds_test.go
+++ b/btf/workarounds_test.go
@@ -1,0 +1,71 @@
+package btf
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/cilium/ebpf/internal"
+	"github.com/cilium/ebpf/internal/testutils"
+)
+
+func TestDatasecResolveWorkaround(t *testing.T) {
+	testutils.SkipOnOldKernel(t, "5.2", "BTF_KIND_DATASEC")
+
+	i := &Int{Size: 1}
+
+	for _, typ := range []Type{
+		&Typedef{"foo", i},
+		&Volatile{i},
+		&Const{i},
+		&Restrict{i},
+		&typeTag{i, "foo"},
+	} {
+		t.Run(fmt.Sprint(typ), func(t *testing.T) {
+			if _, ok := typ.(*typeTag); ok {
+				testutils.SkipOnOldKernel(t, "5.17", "BTF_KIND_TYPE_TAG")
+			}
+
+			ds := &Datasec{
+				Name: "a",
+				Size: 2,
+				Vars: []VarSecinfo{
+					{
+						Size:   1,
+						Offset: 0,
+						// struct, union, pointer, array will trigger the bug.
+						Type: &Var{Name: "a", Type: &Pointer{i}},
+					},
+					{
+						Size:   1,
+						Offset: 1,
+						Type: &Var{
+							Name: "b",
+							Type: typ,
+						},
+					},
+				},
+			}
+
+			spec := NewSpec()
+			if err := datasecResolveWorkaround(spec, ds); err != nil {
+				t.Fatal(err)
+			}
+
+			_, err := spec.Add(ds)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			h, err := NewHandle(spec)
+			var ve *internal.VerifierError
+			if errors.As(err, &ve) {
+				t.Fatalf("%+v\n", ve)
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			h.Close()
+		})
+	}
+}


### PR DESCRIPTION
btf: work around kernel Datasec bug
    
    The kernel erroneously rejects Datasec where a Typedef, Volatile, Const,
    Restrict or typeTag follows a Pointer, Struct, Union or Array. Work
    around this by explicitly adding such types to the Spec first.
    
    The workaround only applies to BTF generated via Map.Value.
    Manually crafting a Datasec is not covered.
    
    Fixes #921
    
    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>

btf: fix marshaling of typeTag and declTag
    
    Marshaling of typeTag and declTag is currently broken. This is because
    we rely on marshaling vmlinux BTF for test coverage, which doesn't
    contain tags since we don't compile with clang.
    
    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>

cc @alban @mauriciovasquezbernal 