### PR TITLE
btf: preserve member order during marshaling

### DIFF
--- a/btf/core.go
+++ b/btf/core.go
@@ -885,8 +885,8 @@ func coreAreTypesCompatible(localType Type, targetType Type) error {
 
 		case *Pointer, *Array:
 			depth++
-			walkType(localType, localTs.Push)
-			walkType(targetType, targetTs.Push)
+			walkType(localType, localTs.Push, false)
+			walkType(targetType, targetTs.Push, false)
 
 		case *FuncProto:
 			tv := targetType.(*FuncProto)
@@ -895,8 +895,8 @@ func coreAreTypesCompatible(localType Type, targetType Type) error {
 			}
 
 			depth++
-			walkType(localType, localTs.Push)
-			walkType(targetType, targetTs.Push)
+			walkType(localType, localTs.Push, false)
+			walkType(targetType, targetTs.Push, false)
 
 		default:
 			return fmt.Errorf("unsupported type %T", localType)

--- a/btf/traversal_test.go
+++ b/btf/traversal_test.go
@@ -40,6 +40,21 @@ func TestPostorderTraversal(t *testing.T) {
 	}
 	qt.Assert(t, seen[arr], qt.IsTrue)
 	qt.Assert(t, seen[i], qt.IsTrue)
+
+	t.Run("member order", func(t *testing.T) {
+		a := &Int{Name: "a"}
+		b := &Int{Name: "b"}
+		str := &Struct{
+			Members: []Member{{Type: a}, {Type: b}},
+		}
+
+		iter := postorderTraversal(str, nil)
+		for i, want := range []Type{a, b, str} {
+			qt.Assert(t, iter.Next(), qt.IsTrue, qt.Commentf("type %d", i))
+			qt.Assert(t, iter.Type, qt.Equals, want)
+		}
+	})
+
 }
 
 func TestPostorderTraversalVmlinux(t *testing.T) {
@@ -68,7 +83,7 @@ func TestPostorderTraversalVmlinux(t *testing.T) {
 
 			walkType(typ, func(child *Type) {
 				qt.Check(t, seen[*child], qt.IsTrue, qt.Commentf("missing child %s", *child))
-			})
+			}, false)
 		})
 	}
 }

--- a/btf/types.go
+++ b/btf/types.go
@@ -722,7 +722,7 @@ func (c copier) copy(typ *Type, transform Transformer) {
 		*t = cpy
 
 		// Mark any nested types for copying.
-		walkType(cpy, work.Push)
+		walkType(cpy, work.Push, false)
 	}
 }
 

--- a/btf/types_test.go
+++ b/btf/types_test.go
@@ -155,7 +155,7 @@ func TestType(t *testing.T) {
 			}
 
 			var a []*Type
-			walkType(typ, func(t *Type) { a = append(a, t) })
+			walkType(typ, func(t *Type) { a = append(a, t) }, false)
 
 			if _, ok := typ.(*cycle); !ok {
 				if n := countChildren(t, reflect.TypeOf(typ)); len(a) < n {
@@ -164,7 +164,7 @@ func TestType(t *testing.T) {
 			}
 
 			var b []*Type
-			walkType(typ, func(t *Type) { b = append(b, t) })
+			walkType(typ, func(t *Type) { b = append(b, t) }, false)
 
 			if diff := cmp.Diff(a, b, compareTypes); diff != "" {
 				t.Errorf("Walk mismatch (-want +got):\n%s", diff)
@@ -394,7 +394,7 @@ func BenchmarkWalk(b *testing.B) {
 
 			for i := 0; i < b.N; i++ {
 				var dq typeDeque
-				walkType(typ, dq.Push)
+				walkType(typ, dq.Push, false)
 			}
 		})
 	}


### PR DESCRIPTION
Currently, we will marshal members of a composite type like Datasec, Struct, etc. in reverse order. The BTF ends up looking like this:

  [1] DATASEC a size=2 vlen=2
    type_id=7 offset=0 size=1
    type_id=4 offset=1 size=1

The types necessary for Datasec.Vars[1] are marshaled before the ones for Datasec.Vars[0]. Change the implementation so that the order is reversed. The resulting BTF is now:

  [1] DATASEC a size=2 vlen=2
    type_id=4 offset=0 size=1
    type_id=7 offset=1 size=1