### PR TITLE
collection: ensure LINUX_KERNEL_VERSION variable is a btf.Int.

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -598,15 +598,11 @@ func resolveKconfig(m *MapSpec) error {
 	data := make([]byte, ds.Size)
 	for _, vsi := range ds.Vars {
 		v := vsi.Type.(*btf.Var)
-		s, err := btf.Sizeof(v.Type)
-		if err != nil {
-			return fmt.Errorf("variable %s: getting size: %w", v.Name, err)
-		}
 
 		switch n := v.TypeName(); n {
 		case "LINUX_KERNEL_VERSION":
-			if s != 4 {
-				return fmt.Errorf("variable %s must be u32, got %d", n, s)
+			if integer, ok := v.Type.(*btf.Int); !ok || integer.Size != 4 {
+				return fmt.Errorf("variable %s must be a 32 bits integer, got %s", n, v.Type)
 			}
 
 			kv, err := internal.KernelVersion()


### PR DESCRIPTION
Hi.


In this PR, I added a check to ensure `LINUX_KERNEL_VERSION` variable is a `btf.Int`.
I did not check the encoding, because it seems both signed and unsigned are possible:
https://github.com/iovisor/bcc/blob/a8949790c501560a589e52e8994d64e4f3d66dc4/libbpf-tools/capable.bpf.c#L15
https://github.com/iovisor/bcc/blob/a8949790c501560a589e52e8994d64e4f3d66dc4/libbpf-tools/biosnoop.bpf.c#L17


Best regards.