### PR TITLE
add tests for FSType and getTracefsPath

### DIFF
--- a/internal/statfs_test.go
+++ b/internal/statfs_test.go
@@ -1,0 +1,23 @@
+package internal
+
+import (
+	"testing"
+
+	"github.com/cilium/ebpf/internal/unix"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestFSType(t *testing.T) {
+	for _, fs := range []struct {
+		path  string
+		magic int64
+	}{
+		{"/sys/kernel/tracing", unix.TRACEFS_MAGIC},
+		{"/sys/fs/bpf", unix.BPF_FS_MAGIC},
+	} {
+		fst, err := FSType(fs.path)
+		qt.Assert(t, err, qt.IsNil)
+		qt.Assert(t, fst, qt.Equals, fs.magic)
+	}
+}

--- a/link/perf_event_test.go
+++ b/link/perf_event_test.go
@@ -57,6 +57,11 @@ func TestTraceValidID(t *testing.T) {
 	}
 }
 
+func TestGetTracefsPath(t *testing.T) {
+	_, err := getTracefsPath()
+	qt.Assert(t, err, qt.IsNil)
+}
+
 func TestHaveBPFLinkPerfEvent(t *testing.T) {
 	testutils.CheckFeatureTest(t, haveBPFLinkPerfEvent)
 }


### PR DESCRIPTION
@brycekahle I brought back your test for FSType, slightly modified.

link: add a test for getTracefsPath
    
    Assert that we can find a suitable tracefs path on CI.
    
    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>

internal: add test for FSType
    
    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>
    Co-authored-by: Bryce Kahle <bryce.kahle@datadoghq.com>