### PR TITLE
perf: use the min value of maxentries and possibles cpus to create ring

### DIFF
--- a/perf/reader.go
+++ b/perf/reader.go
@@ -188,6 +188,14 @@ func NewReaderWithOptions(array *ebpf.Map, perCPUBuffer int, opts ReaderOptions)
 		pauseFds = make([]int, 0, nCPU)
 	)
 
+	n, err := internal.PossibleCPUs()
+	if err != nil {
+		return nil, err
+	}
+	if n < nCPU {
+		nCPU = n
+	}
+
 	poller, err := epoll.New()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
When bpf program is static compiled, the perf map located in the obj file should use a static value as its max_elem value. If this value is bigger than the number of possible cpus, create a new reader will fail when calling unix.PerfEventOpen.