### PR TITLE
Add error case for creating unspecified map type.

### DIFF
--- a/map.go
+++ b/map.go
@@ -454,6 +454,9 @@ func (spec *MapSpec) createMap(inner *sys.FD, opts MapOptions) (_ *Map, err erro
 		if errors.Is(err, unix.EINVAL) && attr.MaxEntries == 0 {
 			return nil, fmt.Errorf("map create: %w (MaxEntries may be incorrectly set to zero)", err)
 		}
+		if errors.Is(err, unix.EINVAL) && spec.Type == UnspecifiedMap {
+			return nil, fmt.Errorf("map create: cannot use type %s", UnspecifiedMap)
+		}
 		if attr.BtfFd == 0 {
 			return nil, fmt.Errorf("map create: %w (without BTF k/v)", err)
 		}


### PR DESCRIPTION
When creating a new map, if the the map type is unspecified (i.e. BPF_MAP_TYPE_UNSPEC) then the call to create the map will fail with EINVAL and the following Go error is returned due to the btf file descriptor being zerod out:

...: map create: ... (without BTF k/v)

Instead, upon failure to create me, this will now check if the map type was set to unspecified and return a relevant error.