### PR TITLE
Allow debugfs fstype for /sys/kernel/debug/tracing

### DIFF
--- a/internal/unix/types_linux.go
+++ b/internal/unix/types_linux.go
@@ -82,6 +82,7 @@ const (
 	EM_BPF                    = linux.EM_BPF
 	BPF_FS_MAGIC              = linux.BPF_FS_MAGIC
 	TRACEFS_MAGIC             = linux.TRACEFS_MAGIC
+	DEBUGFS_MAGIC             = linux.DEBUGFS_MAGIC
 )
 
 type Statfs_t = linux.Statfs_t

--- a/internal/unix/types_other.go
+++ b/internal/unix/types_other.go
@@ -86,6 +86,7 @@ const (
 	EM_BPF
 	BPF_FS_MAGIC
 	TRACEFS_MAGIC
+	DEBUGFS_MAGIC
 )
 
 type Statfs_t struct {

--- a/link/perf_event.go
+++ b/link/perf_event.go
@@ -450,6 +450,8 @@ var getTracefsPath = internal.Memoize(func() (string, error) {
 	}{
 		{"/sys/kernel/tracing", unix.TRACEFS_MAGIC},
 		{"/sys/kernel/debug/tracing", unix.TRACEFS_MAGIC},
+		// RHEL/CentOS
+		{"/sys/kernel/debug/tracing", unix.DEBUGFS_MAGIC},
 	} {
 		if fsType, err := internal.FSType(p.path); err == nil && fsType == p.fsType {
 			return p.path, nil


### PR DESCRIPTION
RHEL/CentOS support eBPF on 3.10 before tracefs was introduced, and thus have /sys/kernel/debug/tracing mounted with debugfs fstype.