### PR TITLE
update `platformPrefix` list with libbpf values

### DIFF
--- a/link/platform.go
+++ b/link/platform.go
@@ -6,17 +6,36 @@ import (
 )
 
 func platformPrefix(symbol string) string {
-
-	prefix := runtime.GOARCH
-
 	// per https://github.com/golang/go/blob/master/src/go/build/syslist.go
-	switch prefix {
+	// and https://github.com/libbpf/libbpf/blob/master/src/libbpf.c#L10047
+	var prefix string
+	switch runtime.GOARCH {
 	case "386":
 		prefix = "ia32"
 	case "amd64", "amd64p32":
 		prefix = "x64"
+
+	case "arm", "armbe":
+		prefix = "arm"
 	case "arm64", "arm64be":
 		prefix = "arm64"
+
+	case "mips", "mipsle", "mips64", "mips64le", "mips64p32", "mips64p32le":
+		prefix = "mips"
+
+	case "s390":
+		prefix = "s390"
+	case "s390x":
+		prefix = "s390x"
+
+	case "riscv", "riscv64":
+		prefix = "riscv"
+
+	case "ppc":
+		prefix = "powerpc"
+	case "ppc64", "ppc64le":
+		prefix = "powerpc64"
+
 	default:
 		return symbol
 	}


### PR DESCRIPTION
As a first step towards being able to compute a value for `LINUX_HAS_SYSCALL_WRAPPER`, this PR updates the platform prefix list with values from libbpf and go architecture list