### PR TITLE
elf: use per-instruction metadata for .kconfig references

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -533,12 +533,6 @@ func (cl *collectionLoader) populateMaps() error {
 			return fmt.Errorf("missing map spec %s", mapName)
 		}
 
-		if mapName == kconfigMap {
-			if err := resolveKconfig(mapSpec); err != nil {
-				return fmt.Errorf("resolving kconfig: %w", err)
-			}
-		}
-
 		// MapSpecs that refer to inner maps or programs within the same
 		// CollectionSpec do so using strings. These strings are used as the key
 		// to look up the respective object in the Maps or Programs fields.
@@ -585,11 +579,6 @@ func (cl *collectionLoader) populateMaps() error {
 // resolveKconfig resolves all variables declared in .kconfig and populates
 // m.Contents. Does nothing if the given m.Contents is non-empty.
 func resolveKconfig(m *MapSpec) error {
-	// Allow caller to manually populate .kconfig contents for testing purposes.
-	if len(m.Contents) != 0 {
-		return nil
-	}
-
 	ds, ok := m.Value.(*btf.Datasec)
 	if !ok {
 		return errors.New("map value is not a Datasec")

--- a/elf_reader.go
+++ b/elf_reader.go
@@ -18,7 +18,12 @@ import (
 	"github.com/cilium/ebpf/internal/unix"
 )
 
-const kconfigMap = ".kconfig"
+type kconfigMetaKey struct{}
+
+type kconfigMeta struct {
+	Map    *MapSpec
+	Offset uint32
+}
 
 type kfuncMeta struct{}
 
@@ -33,6 +38,7 @@ type elfCode struct {
 	extInfo  *btf.ExtInfos
 	maps     map[string]*MapSpec
 	kfuncs   map[string]*btf.Func
+	kconfig  *MapSpec
 }
 
 // LoadCollectionSpec parses an ELF file into a CollectionSpec.
@@ -593,7 +599,6 @@ func (ec *elfCode) relocateInstruction(ins *asm.Instruction, rel elf.Symbol) err
 			return fmt.Errorf("asm relocation: %s: unsupported type %s", name, typ)
 		}
 
-		kc := ec.maps[kconfigMap]
 		kf := ec.kfuncs[name]
 		switch {
 		// If a Call instruction is found and the datasec has a btf.Func with a Name
@@ -611,25 +616,18 @@ func (ec *elfCode) relocateInstruction(ins *asm.Instruction, rel elf.Symbol) err
 		// rewritten to pseudo map loads from .kconfig. If the map is present,
 		// require it to contain the symbol to disambiguate between inline asm
 		// relos and kconfigs.
-		case kc != nil && ins.OpCode.IsDWordLoad():
-			var found bool
-			for _, vsi := range kc.Value.(*btf.Datasec).Vars {
+		case ec.kconfig != nil && ins.OpCode.IsDWordLoad():
+			for _, vsi := range ec.kconfig.Value.(*btf.Datasec).Vars {
 				if vsi.Type.(*btf.Var).Name != rel.Name {
 					continue
 				}
 
-				// Encode a map read at the offset of the var in the datasec.
-				ins.Constant = int64(uint64(vsi.Offset) << 32)
 				ins.Src = asm.PseudoMapValue
-				name = kconfigMap
-
-				found = true
-				break
+				ins.Metadata.Set(kconfigMetaKey{}, &kconfigMeta{ec.kconfig, vsi.Offset})
+				return nil
 			}
 
-			if !found {
-				return fmt.Errorf("kconfig %s not found in %s", rel.Name, kconfigMap)
-			}
+			return fmt.Errorf("kconfig %s not found in .kconfig", rel.Name)
 		}
 
 	default:
@@ -1134,7 +1132,7 @@ func (ec *elfCode) loadKconfigSection() error {
 	}
 
 	var ds *btf.Datasec
-	err := ec.btf.TypeByName(kconfigMap, &ds)
+	err := ec.btf.TypeByName(".kconfig", &ds)
 	if errors.Is(err, btf.ErrNotFound) {
 		return nil
 	}
@@ -1146,8 +1144,8 @@ func (ec *elfCode) loadKconfigSection() error {
 		return errors.New("zero-length .kconfig")
 	}
 
-	ec.maps[kconfigMap] = &MapSpec{
-		Name:       kconfigMap,
+	ec.kconfig = &MapSpec{
+		Name:       ".kconfig",
 		Type:       Array,
 		KeySize:    uint32(4),
 		ValueSize:  ds.Size,

--- a/linker.go
+++ b/linker.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"io"
 
 	"github.com/cilium/ebpf/asm"
 	"github.com/cilium/ebpf/btf"
@@ -181,8 +182,9 @@ func fixupAndValidate(insns asm.Instructions) error {
 		ins := iter.Ins
 
 		// Map load was tagged with a Reference, but does not contain a Map pointer.
-		if ins.IsLoadFromMap() && ins.Reference() != "" && ins.Map() == nil {
-			return fmt.Errorf("instruction %d: map %s: %w", iter.Index, ins.Reference(), asm.ErrUnsatisfiedMapReference)
+		needsMap := ins.Reference() != "" || ins.Metadata.Get(kconfigMetaKey{}) != nil
+		if ins.IsLoadFromMap() && needsMap && ins.Map() == nil {
+			return fmt.Errorf("instruction %d: %w", iter.Index, asm.ErrUnsatisfiedMapReference)
 		}
 
 		fixupProbeReadKernel(ins)
@@ -276,4 +278,64 @@ func fixupProbeReadKernel(ins *asm.Instruction) {
 	case asm.FnProbeReadKernelStr, asm.FnProbeReadUserStr:
 		ins.Constant = int64(asm.FnProbeReadStr)
 	}
+}
+
+// resolveKconfigReferences creates and populates a .kconfig map if necessary.
+//
+// Returns a nil Map and no error if no references exist.
+func resolveKconfigReferences(insns asm.Instructions) (_ *Map, err error) {
+	closeOnError := func(c io.Closer) {
+		if err != nil {
+			c.Close()
+		}
+	}
+
+	var spec *MapSpec
+	iter := insns.Iterate()
+	for iter.Next() {
+		meta, _ := iter.Ins.Metadata.Get(kconfigMetaKey{}).(*kconfigMeta)
+		if meta != nil {
+			spec = meta.Map
+			break
+		}
+	}
+
+	if spec == nil {
+		return nil, nil
+	}
+
+	cpy := spec.Copy()
+	if err := resolveKconfig(cpy); err != nil {
+		return nil, err
+	}
+
+	kconfig, err := NewMap(cpy)
+	if err != nil {
+		return nil, err
+	}
+	defer closeOnError(kconfig)
+
+	// Resolve all instructions which load from .kconfig map with actual map
+	// and offset inside it.
+	iter = insns.Iterate()
+	for iter.Next() {
+		meta, _ := iter.Ins.Metadata.Get(kconfigMetaKey{}).(*kconfigMeta)
+		if meta == nil {
+			continue
+		}
+
+		if meta.Map != spec {
+			return nil, fmt.Errorf("instruction %d: reference to multiple .kconfig maps is not allowed", iter.Index)
+		}
+
+		if err := iter.Ins.AssociateMap(kconfig); err != nil {
+			return nil, fmt.Errorf("instruction %d: %w", iter.Index, err)
+		}
+
+		// Encode a map read at the offset of the var in the datasec.
+		iter.Ins.Constant = int64(uint64(meta.Offset) << 32)
+		iter.Ins.Metadata.Set(kconfigMetaKey{}, nil)
+	}
+
+	return kconfig, nil
 }

--- a/prog.go
+++ b/prog.go
@@ -258,6 +258,12 @@ func newProgramWithOptions(spec *ProgramSpec, opts ProgramOptions) (*Program, er
 		return nil, fmt.Errorf("apply CO-RE relocations: %w", err)
 	}
 
+	kconfig, err := resolveKconfigReferences(insns)
+	if err != nil {
+		return nil, fmt.Errorf("resolve .kconfig: %w", err)
+	}
+	defer kconfig.Close()
+
 	if err := fixupAndValidate(insns); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
.kconfig support is currently implemented in the ELF loader, which does
a fix up of the relevant instructions to point at a ".kconfig" map. This
map is available in CollectionSpec.Maps. This is basically how constants
(aka references to .rodata) work today. Now that we have per-instruction
metadata this isn't necessary anymore.

Instead of using the generic WithReference, introduce a new kconfig
metadata and tag instructions with that. Right now the metadata just
contains the MapSpec for .kconfig as generated by the compiler. In
the future we can create the MapSpec on the fly, which would allow
referencing kconfig via ins.WithKconfig or similar.

Prevent ".kconfig" from being accessible via CollectionSpec.Maps.
This preserves our ability to change how kconfig references work
without having to retain the original MapSpec.