### PR TITLE
btf: clean up handling of split BTF in loadRawSpec and inflateRawTypes

### DIFF
--- a/btf/btf.go
+++ b/btf/btf.go
@@ -231,7 +231,6 @@ func loadSpecFromELF(file *internal.SafeELFFile) (*Spec, error) {
 func loadRawSpec(btf io.ReaderAt, bo binary.ByteOrder, base *Spec) (*Spec, error) {
 	var (
 		baseStrings *stringTable
-		baseTypes   []Type
 		firstTypeID TypeID
 		err         error
 	)
@@ -242,7 +241,6 @@ func loadRawSpec(btf io.ReaderAt, bo binary.ByteOrder, base *Spec) (*Spec, error
 		}
 
 		baseStrings = base.strings
-		baseTypes = base.types
 
 		firstTypeID, err = base.nextTypeID()
 		if err != nil {
@@ -255,7 +253,7 @@ func loadRawSpec(btf io.ReaderAt, bo binary.ByteOrder, base *Spec) (*Spec, error
 		return nil, err
 	}
 
-	types, err := inflateRawTypes(rawTypes, baseTypes, rawStrings)
+	types, err := inflateRawTypes(rawTypes, rawStrings, base)
 	if err != nil {
 		return nil, err
 	}

--- a/btf/types_test.go
+++ b/btf/types_test.go
@@ -387,7 +387,7 @@ func TestInflateLegacyBitfield(t *testing.T) {
 		{"struct after int", []rawType{rawInt, afterInt}},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			types, err := inflateRawTypes(test.raw, nil, emptyStrings)
+			types, err := inflateRawTypes(test.raw, emptyStrings, nil)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
btf: simplify split BTF handling in inflateRawTypes
    
    Pass a *Spec down into inflateRawTypes and refactor the function
    to make split BTF handling a bit more straightforward.
    
    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>

btf: account for split BTF in loadRawSpec
    
    The calculation for the first type id assumes that base.firstTypeID
    is zero. This is only true if base wasn't parsed from split BTF
    itself. Refuse split BTF as base but use base.lastTypeID as a
    defensive measure.
    
    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>
