### PR TITLE
elf: freeze .kconfig map

### DIFF
--- a/elf_reader.go
+++ b/elf_reader.go
@@ -1153,6 +1153,7 @@ func (ec *elfCode) loadKconfigSection() error {
 		ValueSize:  ds.Size,
 		MaxEntries: 1,
 		Flags:      unix.BPF_F_RDONLY_PROG | unix.BPF_F_MMAPABLE,
+		Freeze:     true,
 		Key:        &btf.Int{Size: 4},
 		Value:      ds,
 	}


### PR DESCRIPTION
The verifier will only treat .kconfig as constants if the map is frozen, since otherwise modification from user space is possible.

Always freeze the kconfig map.