### PR TITLE
btf: optimize Spec.Copy

### DIFF
--- a/btf/btf_test.go
+++ b/btf/btf_test.go
@@ -581,3 +581,12 @@ func TestFixupDatasecLayout(t *testing.T) {
 	qt.Assert(t, ds.Vars[4].Offset, qt.Equals, uint32(16))
 	qt.Assert(t, ds.Vars[5].Offset, qt.Equals, uint32(32))
 }
+
+func BenchmarkSpecCopy(b *testing.B) {
+	spec := vmlinuxTestdataSpec(b)
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		spec.Copy()
+	}
+}

--- a/btf/types.go
+++ b/btf/types.go
@@ -696,7 +696,7 @@ func copyTypes(types []Type, transform Transformer) []Type {
 	result := make([]Type, len(types))
 	copy(result, types)
 
-	copies := make(copier)
+	copies := make(copier, len(types))
 	for i := range result {
 		copies.copy(&result[i], transform)
 	}

--- a/btf/types.go
+++ b/btf/types.go
@@ -684,7 +684,7 @@ type Transformer func(Type) Type
 // typ may form a cycle. If transform is not nil, it is called with the
 // to be copied type, and the returned value is copied instead.
 func Copy(typ Type, transform Transformer) Type {
-	copies := make(copier)
+	copies := copier{copies: make(map[Type]Type)}
 	copies.copy(&typ, transform)
 	return typ
 }
@@ -696,7 +696,7 @@ func copyTypes(types []Type, transform Transformer) []Type {
 	result := make([]Type, len(types))
 	copy(result, types)
 
-	copies := make(copier, len(types))
+	copies := copier{copies: make(map[Type]Type, len(types))}
 	for i := range result {
 		copies.copy(&result[i], transform)
 	}
@@ -704,13 +704,15 @@ func copyTypes(types []Type, transform Transformer) []Type {
 	return result
 }
 
-type copier map[Type]Type
+type copier struct {
+	copies map[Type]Type
+	work   typeDeque
+}
 
-func (c copier) copy(typ *Type, transform Transformer) {
-	var work typeDeque
-	for t := typ; t != nil; t = work.Pop() {
+func (c *copier) copy(typ *Type, transform Transformer) {
+	for t := typ; t != nil; t = c.work.Pop() {
 		// *t is the identity of the type.
-		if cpy := c[*t]; cpy != nil {
+		if cpy := c.copies[*t]; cpy != nil {
 			*t = cpy
 			continue
 		}
@@ -722,11 +724,11 @@ func (c copier) copy(typ *Type, transform Transformer) {
 			cpy = (*t).copy()
 		}
 
-		c[*t] = cpy
+		c.copies[*t] = cpy
 		*t = cpy
 
 		// Mark any nested types for copying.
-		walkType(cpy, work.Push)
+		walkType(cpy, c.work.Push)
 	}
 }
 


### PR DESCRIPTION
btf: avoid allocating typeDeque in copier.copy
    
        goos: linux
        goarch: amd64
        pkg: github.com/cilium/ebpf/btf
        cpu: 12th Gen Intel(R) Core(TM) i7-1260P
                    │   old.txt   │              new.txt               │
                    │   sec/op    │   sec/op     vs base               │
        SpecCopy-16   37.76m ± 2%   33.27m ± 5%  -11.91% (p=0.002 n=6)
    
                    │   old.txt    │               new.txt               │
                    │     B/op     │     B/op      vs base               │
        SpecCopy-16   38.10Mi ± 0%   32.28Mi ± 0%  -15.27% (p=0.002 n=6)
    
                    │   old.txt   │              new.txt               │
                    │  allocs/op  │  allocs/op   vs base               │
        SpecCopy-16   294.7k ± 0%   203.2k ± 0%  -31.05% (p=0.002 n=6)
    
    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>

btf: pre-size copier
    
    Make sure copier has the appropriate size from the start.
    
        goos: linux
        goarch: amd64
        pkg: github.com/cilium/ebpf/btf
        cpu: 12th Gen Intel(R) Core(TM) i7-1260P
                    │   old.txt   │              new.txt               │
                    │   sec/op    │   sec/op     vs base               │
        SpecCopy-16   43.96m ± 8%   37.76m ± 2%  -14.10% (p=0.002 n=6)
    
                    │   old.txt    │               new.txt               │
                    │     B/op     │     B/op      vs base               │
        SpecCopy-16   48.44Mi ± 0%   38.10Mi ± 0%  -21.36% (p=0.002 n=6)
    
                    │   old.txt   │              new.txt              │
                    │  allocs/op  │  allocs/op   vs base              │
        SpecCopy-16   299.3k ± 0%   294.7k ± 0%  -1.56% (p=0.002 n=6)
    
    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>

btf: add Spec.Copy benchmark
    
    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>
