### PR TITLE
bpf2go: Fall back to default module name when debug.ReadBuildInfo is not available

### DIFF
--- a/cmd/bpf2go/main_test.go
+++ b/cmd/bpf2go/main_test.go
@@ -49,10 +49,7 @@ func TestRun(t *testing.T) {
 		}
 	}
 
-	module, err := currentModule()
-	if err != nil {
-		t.Fatal(err)
-	}
+	module := currentModule()
 
 	execInModule("go", "mod", "init", "bpf2go-test")
 

--- a/cmd/bpf2go/output.go
+++ b/cmd/bpf2go/output.go
@@ -112,10 +112,7 @@ func output(args outputArgs) error {
 		return err
 	}
 
-	module, err := currentModule()
-	if err != nil {
-		return err
-	}
+	module := currentModule()
 
 	gf := &btf.GoFormatter{
 		Names:      typeNames,

--- a/cmd/bpf2go/tools.go
+++ b/cmd/bpf2go/tools.go
@@ -83,11 +83,12 @@ func toUpperFirst(str string) string {
 	return string(unicode.ToUpper(first)) + str[n:]
 }
 
-func currentModule() (string, error) {
+func currentModule() string {
 	bi, ok := debug.ReadBuildInfo()
 	if !ok {
-		return "", fmt.Errorf("determine current module: missing build info")
+		// Fall back to constant since bazel doesn't support BuildInfo.
+		return "github.com/cilium/ebpf"
 	}
 
-	return bi.Main.Path, nil
+	return bi.Main.Path
 }


### PR DESCRIPTION
Since https://github.com/cilium/ebpf/commit/223b7d740c167a41a7ba82ad59f81c7ef375b843, bpf2go reads the module name from `debug.ReadBuildInfo()`. Unfortunately this fails when `bpf2go` is built with bazel which doesn't add the buildinfo (there is an open issue for it), causing a failure with `determine current module: missing build info`.

This change sets a default if BuildInfo is not available.