### PR TITLE
ProgramInfo provides CreatedByUid

### DIFF
--- a/info.go
+++ b/info.go
@@ -94,8 +94,10 @@ type ProgramInfo struct {
 	// Name as supplied by user space at load time. Available from 4.15.
 	Name string
 
-	btf   btf.ID
-	stats *programStats
+	createdByUID     uint32
+	haveCreatedByUID bool
+	btf              btf.ID
+	stats            *programStats
 
 	maps  []MapID
 	insns []byte
@@ -136,6 +138,12 @@ func newProgramInfoFromFd(fd *sys.FD) (*ProgramInfo, error) {
 	} else {
 		// The kernel doesn't report associated maps.
 		pi.maps = nil
+	}
+
+	// createdByUID and NrMapIds were introduced in the same kernel version.
+	if pi.maps != nil {
+		pi.createdByUID = info.CreatedByUid
+		pi.haveCreatedByUID = true
 	}
 
 	if info.XlatedProgLen > 0 {
@@ -179,6 +187,15 @@ func newProgramInfoFromProc(fd *sys.FD) (*ProgramInfo, error) {
 // The bool return value indicates whether this optional field is available.
 func (pi *ProgramInfo) ID() (ProgramID, bool) {
 	return pi.id, pi.id > 0
+}
+
+// CreatedByUID returns the Uid that created the program.
+//
+// Available from 4.15.
+//
+// The bool return value indicates whether this optional field is available.
+func (pi *ProgramInfo) CreatedByUID() (uint32, bool) {
+	return pi.createdByUID, pi.haveCreatedByUID
 }
 
 // BTFID returns the BTF ID associated with the program.

--- a/info_test.go
+++ b/info_test.go
@@ -3,6 +3,7 @@ package ebpf
 import (
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 
@@ -116,6 +117,19 @@ func TestProgramInfo(t *testing.T) {
 				t.Error("Expected a valid ID:", id)
 			} else if name == "proc" && ok {
 				t.Error("Expected ID to not be available")
+			}
+
+			if name == "proc" {
+				_, ok := info.CreatedByUID()
+				qt.Assert(t, ok, qt.IsFalse)
+			} else {
+				uid, ok := info.CreatedByUID()
+				if testutils.IsKernelLessThan(t, "4.15") {
+					qt.Assert(t, ok, qt.IsFalse)
+				} else {
+					qt.Assert(t, ok, qt.IsTrue)
+					qt.Assert(t, uid, qt.Equals, uint32(os.Getuid()))
+				}
 			}
 		})
 	}


### PR DESCRIPTION
The CreatedByUid provides some helpful context for the source of the BPF program. Making it public in ProgramInfo