### PR TITLE
btf: move LoadKernelSpec into separate package

### DIFF
--- a/btf/btf.go
+++ b/btf/btf.go
@@ -10,7 +10,6 @@ import (
 	"math"
 	"os"
 	"reflect"
-	"sync"
 
 	"github.com/cilium/ebpf/internal"
 	"github.com/cilium/ebpf/internal/sys"
@@ -296,107 +295,6 @@ func indexTypes(types []Type, firstTypeID TypeID) (map[Type]TypeID, map[essentia
 	}
 
 	return typeIDs, typesByName
-}
-
-// LoadKernelSpec returns the current kernel's BTF information.
-//
-// Defaults to /sys/kernel/btf/vmlinux and falls back to scanning the file system
-// for vmlinux ELFs. Returns an error wrapping ErrNotSupported if BTF is not enabled.
-func LoadKernelSpec() (*Spec, error) {
-	spec, _, err := kernelSpec()
-	if err != nil {
-		return nil, err
-	}
-	return spec.Copy(), nil
-}
-
-var kernelBTF struct {
-	sync.RWMutex
-	spec *Spec
-	// True if the spec was read from an ELF instead of raw BTF in /sys.
-	fallback bool
-}
-
-// FlushKernelSpec removes any cached kernel type information.
-func FlushKernelSpec() {
-	kernelBTF.Lock()
-	defer kernelBTF.Unlock()
-
-	kernelBTF.spec, kernelBTF.fallback = nil, false
-}
-
-func kernelSpec() (*Spec, bool, error) {
-	kernelBTF.RLock()
-	spec, fallback := kernelBTF.spec, kernelBTF.fallback
-	kernelBTF.RUnlock()
-
-	if spec == nil {
-		kernelBTF.Lock()
-		defer kernelBTF.Unlock()
-
-		spec, fallback = kernelBTF.spec, kernelBTF.fallback
-	}
-
-	if spec != nil {
-		return spec, fallback, nil
-	}
-
-	spec, fallback, err := loadKernelSpec()
-	if err != nil {
-		return nil, false, err
-	}
-
-	kernelBTF.spec, kernelBTF.fallback = spec, fallback
-	return spec, fallback, nil
-}
-
-func loadKernelSpec() (_ *Spec, fallback bool, _ error) {
-	fh, err := os.Open("/sys/kernel/btf/vmlinux")
-	if err == nil {
-		defer fh.Close()
-
-		spec, err := loadRawSpec(fh, internal.NativeEndian, nil)
-		return spec, false, err
-	}
-
-	file, err := findVMLinux()
-	if err != nil {
-		return nil, false, err
-	}
-	defer file.Close()
-
-	spec, err := loadSpecFromELF(file)
-	return spec, true, err
-}
-
-// findVMLinux scans multiple well-known paths for vmlinux kernel images.
-func findVMLinux() (*internal.SafeELFFile, error) {
-	release, err := internal.KernelRelease()
-	if err != nil {
-		return nil, err
-	}
-
-	// use same list of locations as libbpf
-	// https://github.com/libbpf/libbpf/blob/9a3a42608dbe3731256a5682a125ac1e23bced8f/src/btf.c#L3114-L3122
-	locations := []string{
-		"/boot/vmlinux-%s",
-		"/lib/modules/%s/vmlinux-%[1]s",
-		"/lib/modules/%s/build/vmlinux",
-		"/usr/lib/modules/%s/kernel/vmlinux",
-		"/usr/lib/debug/boot/vmlinux-%s",
-		"/usr/lib/debug/boot/vmlinux-%s.debug",
-		"/usr/lib/debug/lib/modules/%s/vmlinux",
-	}
-
-	for _, loc := range locations {
-		file, err := internal.OpenSafeELFFile(fmt.Sprintf(loc, release))
-		if errors.Is(err, os.ErrNotExist) {
-			continue
-		}
-		return file, err
-	}
-
-	return nil, fmt.Errorf("no BTF found for kernel version %s: %w", release, internal.ErrNotSupported)
 }
 
 // parseBTFHeader parses the header of the .BTF section.

--- a/btf/core.go
+++ b/btf/core.go
@@ -166,11 +166,8 @@ func (k coreKind) String() string {
 // for relos[i].
 func CORERelocate(relos []*CORERelocation, target *Spec, bo binary.ByteOrder) ([]COREFixup, error) {
 	if target == nil {
-		var err error
-		target, _, err = kernelSpec()
-		if err != nil {
-			return nil, fmt.Errorf("load kernel spec: %w", err)
-		}
+		// Explicitly check for nil here since the argument used to be optional.
+		return nil, fmt.Errorf("target must be provided")
 	}
 
 	if bo != target.byteOrder {

--- a/internal/linux/types.go
+++ b/internal/linux/types.go
@@ -1,0 +1,107 @@
+// Package linux provides type information for the current kernel.
+package linux
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"sync"
+
+	"github.com/cilium/ebpf/btf"
+	"github.com/cilium/ebpf/internal"
+)
+
+var kernelBTF struct {
+	sync.RWMutex
+	spec     *btf.Spec
+	fallback bool
+}
+
+// FlushCaches removes any cached kernel type information.
+func FlushCaches() {
+	kernelBTF.Lock()
+	defer kernelBTF.Unlock()
+
+	kernelBTF.spec, kernelBTF.fallback = nil, false
+}
+
+// TypesNoCopy returns type information for the current kernel.
+//
+// The returned Spec must not be modified.
+func TypesNoCopy() (*btf.Spec, error) {
+	kernelBTF.RLock()
+	spec := kernelBTF.spec
+	kernelBTF.RUnlock()
+
+	if spec != nil {
+		return spec, nil
+	}
+
+	spec, _, err := types()
+	return spec, err
+}
+
+func types() (*btf.Spec, bool, error) {
+	kernelBTF.Lock()
+	defer kernelBTF.Unlock()
+
+	if kernelBTF.spec != nil {
+		return kernelBTF.spec, kernelBTF.fallback, nil
+	}
+
+	fh, fallback, err := findVMLinuxBTF()
+	if err != nil {
+		return nil, false, err
+	}
+	defer fh.Close()
+
+	spec, err := btf.LoadSpecFromReader(fh)
+	if err != nil {
+		return nil, false, err
+	}
+
+	kernelBTF.spec, kernelBTF.fallback = spec, fallback
+	return spec, fallback, nil
+}
+
+const builtinVMLinuxBTFPath = "/sys/kernel/btf/vmlinux"
+
+// findVMLinuxBTF searches for the BTF that describes the current kernel.
+//
+// fallback is true if the file was read from a fallback location outside
+// of /sys/. This can happen on older kernels that have builtin BTF disabled.
+//
+// The caller is responsible for closing the returned file.
+func findVMLinuxBTF() (_ *os.File, fallback bool, _ error) {
+	fh, err := os.Open(builtinVMLinuxBTFPath)
+	if err == nil {
+		return fh, false, nil
+	}
+
+	release, err := internal.KernelRelease()
+	if err != nil {
+		return nil, false, err
+	}
+
+	// use same list of locations as libbpf
+	// https://github.com/libbpf/libbpf/blob/9a3a42608dbe3731256a5682a125ac1e23bced8f/src/btf.c#L3114-L3122
+	locations := []string{
+		"/boot/vmlinux-%s",
+		"/lib/modules/%s/vmlinux-%[1]s",
+		"/lib/modules/%s/build/vmlinux",
+		"/usr/lib/modules/%s/kernel/vmlinux",
+		"/usr/lib/debug/boot/vmlinux-%s",
+		"/usr/lib/debug/boot/vmlinux-%s.debug",
+		"/usr/lib/debug/lib/modules/%s/vmlinux",
+	}
+
+	for _, loc := range locations {
+		fh, err := os.Open(fmt.Sprintf(loc, release))
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+		return fh, true, err
+	}
+
+	return nil, false, fmt.Errorf("no BTF found for kernel version %s: %w", release, internal.ErrNotSupported)
+}

--- a/internal/linux/types_test.go
+++ b/internal/linux/types_test.go
@@ -1,0 +1,33 @@
+package linux
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/cilium/ebpf/internal"
+	"github.com/cilium/ebpf/internal/testutils"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestTypes(t *testing.T) {
+	types, err := TypesNoCopy()
+	testutils.SkipIfNotSupported(t, err)
+	qt.Assert(t, err, qt.IsNil)
+	qt.Assert(t, types, qt.Not(qt.IsNil))
+}
+
+func TestFindVMLinux(t *testing.T) {
+	file, fallback, err := findVMLinuxBTF()
+	if errors.Is(err, internal.ErrNotSupported) {
+		t.Skip("Not supported:", err)
+	}
+	if err != nil {
+		t.Fatal("Can't find vmlinux BTF:", err)
+	}
+	defer file.Close()
+
+	if file.Name() == builtinVMLinuxBTFPath && fallback {
+		t.Fatal(builtinVMLinuxBTFPath, "is classified as a fallback")
+	}
+}

--- a/linux/types.go
+++ b/linux/types.go
@@ -1,0 +1,24 @@
+// Package linux provides type information for the current kernel.
+package linux
+
+// This package must only ever re-export internal/linux.
+
+import (
+	"github.com/cilium/ebpf/btf"
+	"github.com/cilium/ebpf/internal/linux"
+)
+
+// FlushCaches removes any cached kernel type information.
+func FlushCaches() {
+	linux.FlushCaches()
+}
+
+// Types returns type information for the current kernel.
+func Types() (*btf.Spec, error) {
+	types, err := linux.TypesNoCopy()
+	if err != nil {
+		return nil, err
+	}
+
+	return types.Copy(), nil
+}

--- a/prog.go
+++ b/prog.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cilium/ebpf/asm"
 	"github.com/cilium/ebpf/btf"
 	"github.com/cilium/ebpf/internal"
+	"github.com/cilium/ebpf/internal/linux"
 	"github.com/cilium/ebpf/internal/sys"
 	"github.com/cilium/ebpf/internal/unix"
 )
@@ -904,7 +905,7 @@ func findProgramTargetInKernel(name string, progType ProgramType, attachType Att
 		return nil, 0, errUnrecognizedAttachType
 	}
 
-	spec, err := btf.LoadKernelSpec()
+	spec, err := linux.TypesNoCopy()
 	if err != nil {
 		return nil, 0, fmt.Errorf("load kernel spec: %w", err)
 	}


### PR DESCRIPTION
vmlinux BTF turns out to be a big headache, because it is quite large at roughly 150k types. The API we currently have in place forces a copy of the whole vmlinux btf.Spec on every call to LoadKernelSpec. We copy to prevent distinct callers of LoadKernelSpec from modifying types that may be referenced by someone else. As a result, some things that require access to kernel BTF are really slow: attaching fentry/fexit hooks, kfuncs, etc.

We've optimized the copying a little bit, but we can't get around the fact that there are a lot of objects to be copied so it's unlikely to get much faster. An attempt to copy btf.Spec lazily was abandoned due to it's complexity.

Which leaves us with this approach: the library shares a single kernel Spec and must take care to avoid mutating or exposing types contained therein. Users of the library always get a fresh copy and must themselves take care to cache the spec if necessary.

Due to import cycles this means we can't expose the kernel spec from package btf anymore and instead need a separate package. This will cause compilation errors, but they should be simple to fix since the semantics don't change otherwise.