### PR TITLE
Add Fentry and Fexit trace another ebpf

### DIFF
--- a/prog.go
+++ b/prog.go
@@ -977,6 +977,10 @@ func findTargetInProgram(prog *Program, name string, progType ProgramType, attac
 	switch (match{progType, attachType}) {
 	case match{Extension, AttachNone}:
 		typeName = name
+	case match{Tracing, AttachTraceFEntry}:
+		typeName = name
+	case match{Tracing, AttachTraceFExit}:
+		typeName = name
 	default:
 		return 0, errUnrecognizedAttachType
 	}


### PR DESCRIPTION
Linux Kernel support typeof Fentry & Fexit ebpf attach to another ebpf since 5.5