### PR TITLE
Add fentry & fexit for tracing loaded ebpf

### DIFF
--- a/prog.go
+++ b/prog.go
@@ -977,6 +977,10 @@ func findTargetInProgram(prog *Program, name string, progType ProgramType, attac
 	switch (match{progType, attachType}) {
 	case match{Extension, AttachNone}:
 		typeName = name
+	case match{Tracing, AttachTraceFEntry}:
+		typeName = name
+	case match{Tracing, AttachTraceFExit}:
+		typeName = name
 	default:
 		return 0, errUnrecognizedAttachType
 	}


### PR DESCRIPTION
[ref] https://github.com/libbpf/libbpf-bootstrap/blob/master/README.md

Linux Kernel support typeof Fentry & Fexit bpf attach to another bpf since 5.5