### PR TITLE
fix `container-all` make invocation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,12 +53,12 @@ TARGETS := \
 
 # Build all ELF binaries using a containerized LLVM toolchain.
 container-all:
-	${CONTAINER_ENGINE} run --rm ${CONTAINER_RUN_ARGS} \
+	+${CONTAINER_ENGINE} run --rm ${CONTAINER_RUN_ARGS} \
 		-v "${REPODIR}":/ebpf -w /ebpf --env MAKEFLAGS \
 		--env CFLAGS="-fdebug-prefix-map=/ebpf=." \
 		--env HOME="/tmp" \
 		"${IMAGE}:${VERSION}" \
-		$(MAKE) all
+		make all
 
 # (debug) Drop the user into a shell inside the container as root.
 container-shell:


### PR DESCRIPTION
It's probable I'm holding it wrong, but when running `make container-all` it uses the host path instead of the make binary in the container, failing with a "file not found" error because it cannot find it.

This PR fixes the issue by simply running `make` and trusting the `PATH` in the container to find the correct make binary.