### PR TITLE
program: improve error handling in haveSyscallWrapper

### DIFF
--- a/syscalls.go
+++ b/syscalls.go
@@ -287,7 +287,9 @@ var haveSyscallWrapper = internal.NewFeatureTest("syscall wrapper", "4.17", func
 	if errors.Is(err, os.ErrNotExist) {
 		return internal.ErrNotSupported
 	}
+	if err != nil {
+		return err
+	}
 
-	_ = tracefs.CloseTraceFSProbeEvent(tracefs.KprobeType, args.Group, testSyscallName)
-	return nil
+	return tracefs.CloseTraceFSProbeEvent(tracefs.KprobeType, args.Group, testSyscallName)
 })


### PR DESCRIPTION
Make sure we only attempt to remove the tracefs event if creating it really succeeded and return any errors encountered during cleanup.

cc @paulcacheux 