### PR TITLE
Print out the relocation name in the error message

### DIFF
--- a/elf_reader.go
+++ b/elf_reader.go
@@ -1054,7 +1054,7 @@ func resolveBTFValuesContents(es *elfSection, vs *btf.VarSecinfo, member btf.Mem
 		case elf.STT_OBJECT:
 			contents = append(contents, MapKV{uint32(k), r.Name})
 		default:
-			return nil, fmt.Errorf("unknown relocation type %v", t)
+			return nil, fmt.Errorf("unknown relocation %s type %v", r.Name, t)
 		}
 	}
 

--- a/elf_reader.go
+++ b/elf_reader.go
@@ -1054,7 +1054,7 @@ func resolveBTFValuesContents(es *elfSection, vs *btf.VarSecinfo, member btf.Mem
 		case elf.STT_OBJECT:
 			contents = append(contents, MapKV{uint32(k), r.Name})
 		default:
-			return nil, fmt.Errorf("unknown relocation %s type %v", r.Name, t)
+			return nil, fmt.Errorf("unknown relocation type %v for symbol %s", t, r.Name)
 		}
 	}
 


### PR DESCRIPTION
The original error message did not print the relocation name that is causing the problem. Adding it should help with debugging the problem.

Related [discussion](https://cilium.slack.com/archives/CKC55JL8L/p1682507708984999)

Credit to @lorenz for finding this problem and debugging with me :)

Before patch:
```
Error: can't write /root/.../tc/bpf_bpfel.go: can't load BPF from ELF: load BTF maps: map test_tc_calls_map: resolving values contents: unknown relocation type STT_NOTYPE
exit status 1
```

After patch:
```
Error: can't load BPF from ELF: file /root/.../bpf_bpfel.o: load BTF maps: map test_tc_calls_map: resolving values contents: unknown relocation handle_ipv6 type STT_NOTYPE
exit status 1
```