### PR TITLE
Add option to prevent omitting verifier logs

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -19,6 +19,9 @@ type CollectionOptions struct {
 	Maps     MapOptions
 	Programs ProgramOptions
 
+	// if VerboseLog is true, the verifier log lines won't be omitted
+	VerboseLog bool
+
 	// MapReplacements takes a set of Maps that will be used instead of
 	// creating new ones when loading the CollectionSpec.
 	//
@@ -509,6 +512,9 @@ func (cl *collectionLoader) loadProgram(progName string) (*Program, error) {
 
 		m, err := cl.loadMap(ins.Reference())
 		if err != nil {
+			if cl.opts.VerboseLog {
+				return nil, fmt.Errorf("program %s: %+w", progName, err)
+			}
 			return nil, fmt.Errorf("program %s: %w", progName, err)
 		}
 


### PR DESCRIPTION
I occasionally encounter verifier errors where the output only contains a brief message, and some crucial lines are omitted, as shown below:

```
2023/05/16 13:18:52 failed to initialize bpf module, field Alb: program alb: load program: permission denied: invalid access to map value, value_size=188 off=188 size=1: R1 max value is outside of the allowed memory range (86 line(s) omitted)
```

Upon examining the code, I couldn't find a way to obtain the complete error message in the output. This PR introduces an option to fully capture and display the verifier error.