### PR TITLE
sys: prevent clobbering existing entries in fd tracing registry

### DIFF
--- a/internal/sys/fd.go
+++ b/internal/sys/fd.go
@@ -86,17 +86,16 @@ func (fd *FD) Close() error {
 		return nil
 	}
 
-	value := int(fd.raw)
-	fd.raw = -1
-
-	fds.Delete(value)
-
-	fd.Forget()
-	return unix.Close(value)
+	return unix.Close(fd.disown())
 }
 
-func (fd *FD) Forget() {
+func (fd *FD) disown() int {
+	value := int(fd.raw)
+	fds.Delete(int(value))
+	fd.raw = -1
+
 	runtime.SetFinalizer(fd, nil)
+	return value
 }
 
 func (fd *FD) Dup() (*FD, error) {
@@ -114,7 +113,15 @@ func (fd *FD) Dup() (*FD, error) {
 	return newFD(dup), nil
 }
 
+// File takes ownership of FD and turns it into an [*os.File].
+//
+// You must not use the FD after the call returns.
+//
+// Returns nil if the FD is not valid.
 func (fd *FD) File(name string) *os.File {
-	fd.Forget()
-	return os.NewFile(uintptr(fd.raw), name)
+	if fd.raw < 0 {
+		return nil
+	}
+
+	return os.NewFile(uintptr(fd.disown()), name)
 }

--- a/internal/sys/fd.go
+++ b/internal/sys/fd.go
@@ -18,7 +18,13 @@ type FD struct {
 
 func newFD(value int) *FD {
 	if onLeakFD != nil {
-		fds.Store(value, callersFrames())
+		// Attempt to store the caller's stack for the given fd value.
+		// Panic if fds contains an existing stack for the fd.
+		old, exist := fds.LoadOrStore(value, callersFrames())
+		if exist {
+			f := old.(*runtime.Frames)
+			panic(fmt.Sprintf("found existing stack for fd %d:\n%s", value, FormatFrames(f)))
+		}
 	}
 
 	fd := &FD{value}

--- a/internal/sys/fd_test.go
+++ b/internal/sys/fd_test.go
@@ -47,3 +47,20 @@ func TestFD(t *testing.T) {
 
 	reserveFdZero()
 }
+
+func TestFDFile(t *testing.T) {
+	fd := newFD(openFd(t))
+	file := fd.File("test")
+	qt.Assert(t, file, qt.IsNotNil)
+	qt.Assert(t, file.Close(), qt.IsNil)
+	qt.Assert(t, fd.File("closed"), qt.IsNil)
+
+	_, err := fd.Dup()
+	qt.Assert(t, err, qt.ErrorIs, ErrClosedFd)
+}
+
+func openFd(tb testing.TB) int {
+	fd, err := unix.Open(os.DevNull, syscall.O_RDONLY, 0)
+	qt.Assert(tb, err, qt.IsNil)
+	return fd
+}

--- a/internal/sys/fd_trace.go
+++ b/internal/sys/fd_trace.go
@@ -1,6 +1,8 @@
 package sys
 
 import (
+	"bytes"
+	"fmt"
 	"runtime"
 	"sync"
 )
@@ -75,4 +77,17 @@ func callersFrames() *runtime.Frames {
 	}
 
 	return runtime.CallersFrames(c)
+}
+
+// FormatFrames formats a runtime.Frames as a human-readable string.
+func FormatFrames(fs *runtime.Frames) string {
+	var b bytes.Buffer
+	for {
+		f, more := fs.Next()
+		b.WriteString(fmt.Sprintf("\t%s+%#x\n\t\t%s:%d\n", f.Function, f.PC-f.Entry, f.File, f.Line))
+		if !more {
+			break
+		}
+	}
+	return b.String()
 }

--- a/internal/testutils/fdtrace/fd.go
+++ b/internal/testutils/fdtrace/fd.go
@@ -1,7 +1,6 @@
 package fdtrace
 
 import (
-	"bytes"
 	"fmt"
 	"os"
 	"runtime"
@@ -19,7 +18,7 @@ func TestMain(m *testing.M) {
 	var leak bool
 	sys.OnLeakFD(func(fs *runtime.Frames) {
 		fmt.Fprintln(os.Stderr, "leaked fd created at:")
-		fmt.Fprintln(os.Stderr, formatFrames(fs))
+		fmt.Fprintln(os.Stderr, sys.FormatFrames(fs))
 		leak = true
 	})
 
@@ -32,16 +31,4 @@ func TestMain(m *testing.M) {
 	}
 
 	os.Exit(ret)
-}
-
-func formatFrames(fs *runtime.Frames) string {
-	var b bytes.Buffer
-	for {
-		f, more := fs.Next()
-		b.WriteString(fmt.Sprintf("\t%s+%#x\n\t\t%s:%d\n", f.Function, f.PC-f.Entry, f.File, f.Line))
-		if !more {
-			break
-		}
-	}
-	return b.String()
 }


### PR DESCRIPTION
newFD() didn't check whether the stack it tried to insert for the given fd would overwrite an existing entry.

Use LoadOrStore to check if a stack is already present, and panic if there is.