### PR TITLE
btf: avoid triggering feature probe on import

### DIFF
--- a/btf/ext_info.go
+++ b/btf/ext_info.go
@@ -185,7 +185,7 @@ marshal:
 	buf := getBuffer()
 	defer putBuffer(buf)
 
-	if err := marshalTypes(buf, spec.types, stb, kernelMarshalOptions); err != nil {
+	if err := marshalTypes(buf, spec.types, stb, kernelMarshalOptions()); err != nil {
 		return nil, nil, nil, fmt.Errorf("marshal BTF: %w", err)
 	}
 

--- a/btf/handle.go
+++ b/btf/handle.go
@@ -45,7 +45,7 @@ func NewHandle(spec *Spec) (*Handle, error) {
 		stb = newStringTableBuilder(spec.strings.Num())
 	}
 
-	err := marshalTypes(buf, spec.types, stb, kernelMarshalOptions)
+	err := marshalTypes(buf, spec.types, stb, kernelMarshalOptions())
 	if err != nil {
 		return nil, fmt.Errorf("marshal BTF: %w", err)
 	}

--- a/btf/marshal.go
+++ b/btf/marshal.go
@@ -17,8 +17,10 @@ type marshalOptions struct {
 }
 
 // kernelMarshalOptions will generate BTF suitable for the current kernel.
-var kernelMarshalOptions = &marshalOptions{
-	StripFuncLinkage: haveFuncLinkage() != nil,
+func kernelMarshalOptions() *marshalOptions {
+	return &marshalOptions{
+		StripFuncLinkage: haveFuncLinkage() != nil,
+	}
 }
 
 // encoder turns Types into raw BTF.


### PR DESCRIPTION
Importing package btf currently executes a feature test since we use it to initialize a global variable. Move initialization to a function to avoid this.