### PR TITLE
CI: try to fix job timeouts

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -9,10 +9,6 @@ agent:
 execution_time_limit:
   minutes: 10
 
-global_job_config:
-  secrets:
-    - name: Coveralls
-
 auto_cancel:
   running:
     when: "branch != 'master'"

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -6,9 +6,6 @@ agent:
     type: e1-standard-2
     os_image: ubuntu2004
 
-execution_time_limit:
-  minutes: 10
-
 auto_cancel:
   running:
     when: "branch != 'master'"
@@ -45,6 +42,8 @@ blocks:
           value: "9"
       jobs:
       - name: Build and Lint
+        execution_time_limit:
+          minutes: 10
         commands:
           - ( export GOOS=darwin; go build ./... && for p in $(go list ./...) ; do go test -c $p || exit ; done )
           - ( export GOARCH=arm GOARM=6; go build ./... && for p in $(go list ./...) ; do go test -c $p || exit ; done )
@@ -58,11 +57,15 @@ blocks:
           - golangci-lint run
           - cache store
       - name: Run unit tests on previous stable Go
+        execution_time_limit:
+          minutes: 10
         commands:
           - sem-version go 1.19.6
           - go test -v ./cmd/bpf2go
           - gotestsum --raw-command --ignore-non-json-output-lines --junitfile junit.xml -- ./run-tests.sh $CI_MAX_KERNEL_VERSION -short -count 1 -json ./...
       - name: Run unit tests
+        execution_time_limit:
+          minutes: 10
         matrix:
           - env_var: KERNEL_VERSION
             values: ["5.19", "5.15", "5.10", "5.4", "4.19", "4.14", "4.9"]


### PR DESCRIPTION
CI: use per-job execution time limits

    The current Sempahore configuration kills jobs if their waiting
    + executing time exceeds 10 minutes. This is causing problems when multiple
    PRs are going through CI at the same time.

    Switch to per-job execution time limits instead which do not take waiting
    time into account if I understand correctly.

    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>

CI: remove Coveralls secret

    The Coveralls integration never really worked, get rid of it.

    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>
