### PR TITLE
.semaphore: another attempt at debugging the timeouts

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -62,7 +62,7 @@ blocks:
         commands:
           - sem-version go 1.19.9
           - go test -v ./cmd/bpf2go
-          - gotestsum --raw-command --ignore-non-json-output-lines --junitfile junit.xml -- ./run-tests.sh $CI_MAX_KERNEL_VERSION -short -count 1 -json ./...
+          - gotestsum --raw-command --ignore-non-json-output-lines --junitfile junit.xml -- ./run-tests.sh $CI_MAX_KERNEL_VERSION -short -count 1 -timeout 5m -json ./...
       - name: Run unit tests
         execution_time_limit:
           minutes: 10
@@ -70,4 +70,4 @@ blocks:
           - env_var: KERNEL_VERSION
             values: ["5.19", "5.15", "5.10", "5.4", "4.19", "4.14", "4.9"]
         commands:
-          - gotestsum --raw-command --ignore-non-json-output-lines --junitfile junit.xml -- ./run-tests.sh $KERNEL_VERSION -short -count 1 -json ./...
+          - gotestsum --raw-command --ignore-non-json-output-lines --junitfile junit.xml -- ./run-tests.sh $KERNEL_VERSION -short -count 1 -timeout 5m -json ./...

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -62,7 +62,7 @@ blocks:
         commands:
           - sem-version go 1.19.9
           - go test -v ./cmd/bpf2go
-          - gotestsum --raw-command --ignore-non-json-output-lines --junitfile junit.xml --hide-summary=skipped -- ./run-tests.sh $CI_MAX_KERNEL_VERSION -short -count 1 -timeout 5m -json ./...
+          - gotestsum --raw-command --ignore-non-json-output-lines --junitfile junit.xml --hide-summary=skipped --debug -- ./run-tests.sh $CI_MAX_KERNEL_VERSION -short -count 1 -timeout 5m -json ./...
       - name: Run unit tests
         execution_time_limit:
           minutes: 10
@@ -70,4 +70,4 @@ blocks:
           - env_var: KERNEL_VERSION
             values: ["5.19", "5.15", "5.10", "5.4", "4.19", "4.14", "4.9"]
         commands:
-          - gotestsum --raw-command --ignore-non-json-output-lines --junitfile junit.xml --hide-summary=skipped -- ./run-tests.sh $KERNEL_VERSION -short -count 1 -timeout 5m -json ./...
+          - gotestsum --raw-command --ignore-non-json-output-lines --junitfile junit.xml --hide-summary=skipped --debug -- ./run-tests.sh $KERNEL_VERSION -short -count 1 -timeout 5m -json ./...

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -62,7 +62,7 @@ blocks:
         commands:
           - sem-version go 1.19.9
           - go test -v ./cmd/bpf2go
-          - gotestsum --raw-command --ignore-non-json-output-lines --junitfile junit.xml -- ./run-tests.sh $CI_MAX_KERNEL_VERSION -short -count 1 -timeout 5m -json ./...
+          - gotestsum --raw-command --ignore-non-json-output-lines --junitfile junit.xml --hide-summary=skipped -- ./run-tests.sh $CI_MAX_KERNEL_VERSION -short -count 1 -timeout 5m -json ./...
       - name: Run unit tests
         execution_time_limit:
           minutes: 10
@@ -70,4 +70,4 @@ blocks:
           - env_var: KERNEL_VERSION
             values: ["5.19", "5.15", "5.10", "5.4", "4.19", "4.14", "4.9"]
         commands:
-          - gotestsum --raw-command --ignore-non-json-output-lines --junitfile junit.xml -- ./run-tests.sh $KERNEL_VERSION -short -count 1 -timeout 5m -json ./...
+          - gotestsum --raw-command --ignore-non-json-output-lines --junitfile junit.xml --hide-summary=skipped -- ./run-tests.sh $KERNEL_VERSION -short -count 1 -timeout 5m -json ./...

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -16,14 +16,14 @@ blocks:
       prologue:
         commands:
           - sudo sh -c 'swapoff -a && fallocate -l 2G /swapfile && chmod 0600 /swapfile && mkswap /swapfile && swapon /swapfile'
-          - sem-version go 1.20.1
+          - sem-version go 1.20.4
           - export PATH="$PATH:$(go env GOPATH)/bin"
           - checkout
           # Disabled, see https://github.com/cilium/ebpf/issues/898
           # - cache restore
           - go mod tidy
-          - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$(go env GOPATH)/bin" v1.51.2
-          - go install gotest.tools/gotestsum@v1.8.1
+          - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$(go env GOPATH)/bin" v1.53.3
+          - go install gotest.tools/gotestsum@v1.10.0
           - sudo pip3 install https://github.com/amluto/virtme/archive/beb85146cd91de37ae455eccb6ab67c393e6e290.zip
           - sudo apt-get update
           - sudo apt-get install -y --no-install-recommends qemu-system-x86 clang-9 llvm-9
@@ -32,7 +32,7 @@ blocks:
         always:
           commands:
             - sudo dmesg
-            - test-results publish junit.xml
+            - test -f junit.xml && test-results publish junit.xml
       env_vars:
         - name: TMPDIR
           value: /tmp
@@ -60,7 +60,7 @@ blocks:
         execution_time_limit:
           minutes: 10
         commands:
-          - sem-version go 1.19.6
+          - sem-version go 1.19.9
           - go test -v ./cmd/bpf2go
           - gotestsum --raw-command --ignore-non-json-output-lines --junitfile junit.xml -- ./run-tests.sh $CI_MAX_KERNEL_VERSION -short -count 1 -json ./...
       - name: Run unit tests


### PR DESCRIPTION
.semaphore: add Go test timeout

    We've got some test runs which are killed by CI since they take longer than
    10 minutes to complete. This is suspiciously close to the Go test timeout of
    10 minutes. Set a 5 minute per-package timeout to catch a stuck test in CI.

    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>

.semaphore: update test dependencies

    Pull in new versions of gotestsum and golanglint-ci. Only attempt to publish
    the JUnit XML if it exists.

    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>
