### PR TITLE
Keep code multi OS aware

### DIFF
--- a/internal/testutils/cgroup.go
+++ b/internal/testutils/cgroup.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/cilium/ebpf/internal"
-	"golang.org/x/sys/unix"
+	"github.com/cilium/ebpf/internal/unix"
 )
 
 var cgroup2Path = internal.Memoize(func() (string, error) {

--- a/internal/unix/types_linux.go
+++ b/internal/unix/types_linux.go
@@ -196,3 +196,7 @@ func Open(path string, mode int, perm uint32) (int, error) {
 func Fstat(fd int, stat *Stat_t) error {
 	return linux.Fstat(fd, stat)
 }
+
+func SetsockoptInt(fd, level, opt, value int) error {
+	return linux.SetsockoptInt(fd, level, opt, value)
+}

--- a/internal/unix/types_other.go
+++ b/internal/unix/types_other.go
@@ -106,7 +106,19 @@ type Statfs_t struct {
 	Spare   [4]int64
 }
 
-type Stat_t struct{}
+type Stat_t struct {
+	Dev     uint64
+	Ino     uint64
+	Nlink   uint64
+	Mode    uint32
+	Uid     uint32
+	Gid     uint32
+	_       int32
+	Rdev    uint64
+	Size    int64
+	Blksize int64
+	Blocks  int64
+}
 
 type Rlimit struct {
 	Cur uint64

--- a/internal/unix/types_other.go
+++ b/internal/unix/types_other.go
@@ -288,3 +288,7 @@ func Open(path string, mode int, perm uint32) (int, error) {
 func Fstat(fd int, stat *Stat_t) error {
 	return errNonLinux
 }
+
+func SetsockoptInt(fd, level, opt, value int) error {
+	return errNonLinux
+}

--- a/link/socket_filter.go
+++ b/link/socket_filter.go
@@ -15,7 +15,7 @@ func AttachSocketFilter(conn syscall.Conn, program *ebpf.Program) error {
 	}
 	var ssoErr error
 	err = rawConn.Control(func(fd uintptr) {
-		ssoErr = syscall.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_ATTACH_BPF, program.FD())
+		ssoErr = unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_ATTACH_BPF, program.FD())
 	})
 	if ssoErr != nil {
 		return ssoErr
@@ -31,7 +31,7 @@ func DetachSocketFilter(conn syscall.Conn) error {
 	}
 	var ssoErr error
 	err = rawConn.Control(func(fd uintptr) {
-		ssoErr = syscall.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_DETACH_BPF, 0)
+		ssoErr = unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_DETACH_BPF, 0)
 	})
 	if ssoErr != nil {
 		return ssoErr


### PR DESCRIPTION
Adapt code to be able to run on multiple OS.

As described in https://github.com/cilium/ebpf/issues/1073 currently there is an issue with non Linux support:

```bash
$ GOOS=windows go build ./...
# github.com/cilium/ebpf/internal/testutils
internal/testutils/cgroup.go:58:21: undefined: unix.Stat_t
internal/testutils/cgroup.go:59:14: undefined: unix.Fstat
# github.com/cilium/ebpf/link
link/socket_filter.go:18:34: cannot use int(fd) (value of type int) as syscall.Handle value in argument to syscall.SetsockoptInt
link/socket_filter.go:34:34: cannot use int(fd) (value of type int) as syscall.Handle value in argument to syscall.SetsockoptInt
```

This PR moves Linux specific code into `/internal/unix`.

Fixes https://github.com/cilium/ebpf/issues/1073