### PR TITLE
Include map details when returning ErrMapIncompatible

### DIFF
--- a/collection_test.go
+++ b/collection_test.go
@@ -296,6 +296,7 @@ func TestCollectionSpecMapReplacements_NonExistingMap(t *testing.T) {
 }
 
 func TestCollectionSpecMapReplacements_SpecMismatch(t *testing.T) {
+	c := qt.New(t)
 	cs := &CollectionSpec{
 		Maps: map[string]*MapSpec{
 			"test-map": {
@@ -332,6 +333,12 @@ func TestCollectionSpecMapReplacements_SpecMismatch(t *testing.T) {
 	if !errors.Is(err, ErrMapIncompatible) {
 		t.Fatalf("Overriding a map with a mismatching spec failed with the wrong error")
 	}
+	var mErr *IncompatibleMapErr
+	if !errors.As(err, &mErr) {
+		t.Fatal("Overriding a map with a mismatching spec failed to provide error details")
+	}
+	c.Assert(mErr.Existing.ValueSize, qt.Equals, uint32(8))
+	c.Assert(mErr.Incoming.ValueSize, qt.Equals, uint32(4))
 }
 
 func TestCollectionRewriteConstants(t *testing.T) {

--- a/collection_test.go
+++ b/collection_test.go
@@ -331,14 +331,14 @@ func TestCollectionSpecMapReplacements_SpecMismatch(t *testing.T) {
 		t.Fatal("Overriding a map with a mismatching spec did not fail")
 	}
 	if !errors.Is(err, ErrMapIncompatible) {
-		t.Fatalf("Overriding a map with a mismatching spec failed with the wrong error")
+		t.Fatalf("Error did not wrap ErrMapIncompatible: %s", err)
 	}
-	var mErr *IncompatibleMapErr
-	if !errors.As(err, &mErr) {
-		t.Fatal("Overriding a map with a mismatching spec failed to provide error details")
+	var merr *IncompatibleMapError
+	if !errors.As(err, &merr) {
+		t.Fatalf("Error didn't contain an IncompatibleMapError: %s", err)
 	}
-	c.Assert(mErr.Existing.ValueSize, qt.Equals, uint32(8))
-	c.Assert(mErr.Incoming.ValueSize, qt.Equals, uint32(4))
+	c.Assert(merr.Existing.ValueSize, qt.Equals, uint32(8))
+	c.Assert(merr.Incoming.ValueSize, qt.Equals, uint32(4))
 }
 
 func TestCollectionRewriteConstants(t *testing.T) {

--- a/map.go
+++ b/map.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"time"
 	"unsafe"
 
@@ -26,6 +27,42 @@ var (
 	ErrMapIncompatible  = errors.New("map spec is incompatible with existing map")
 	errMapNoBTFValue    = errors.New("map spec does not contain a BTF Value")
 )
+
+type IncompatibleMapErr struct {
+	Existing *MapInfo
+	Incoming *MapSpec
+}
+
+func NewErrIncompatibleMap(existing *MapInfo, incoming *MapSpec) *IncompatibleMapErr {
+	return &IncompatibleMapErr{
+		Existing: existing,
+		Incoming: incoming,
+	}
+}
+
+func (e *IncompatibleMapErr) Error() string {
+	return fmt.Sprintf("details(existing -> incoming) : %s", e.diff())
+}
+
+func (e *IncompatibleMapErr) diff() string {
+	diffs := []string{}
+	if e.Existing.Type != e.Incoming.Type {
+		diffs = append(diffs, fmt.Sprintf("type : %s -> %s", e.Existing.Type, e.Incoming.Type))
+	}
+	if e.Existing.Flags != e.Incoming.Flags {
+		diffs = append(diffs, fmt.Sprintf("flags : %d -> %d", e.Existing.Flags, e.Incoming.Flags))
+	}
+	if e.Existing.KeySize != e.Incoming.KeySize {
+		diffs = append(diffs, fmt.Sprintf("keySize : %d -> %d", e.Existing.KeySize, e.Incoming.KeySize))
+	}
+	if e.Existing.ValueSize != e.Incoming.ValueSize {
+		diffs = append(diffs, fmt.Sprintf("valueSize : %d -> %d", e.Existing.ValueSize, e.Incoming.ValueSize))
+	}
+	if e.Existing.MaxEntries != e.Incoming.MaxEntries {
+		diffs = append(diffs, fmt.Sprintf("maxEntries : %d -> %d", e.Existing.MaxEntries, e.Incoming.MaxEntries))
+	}
+	return strings.Join(diffs, ", ")
+}
 
 // MapOptions control loading a map into the kernel.
 type MapOptions struct {
@@ -189,24 +226,34 @@ func (ms *MapSpec) Compatible(m *Map) error {
 		return err
 	}
 
+	asInfo := func(m *Map) *MapInfo {
+		return &MapInfo{
+			Type:       m.typ,
+			KeySize:    m.keySize,
+			ValueSize:  m.valueSize,
+			MaxEntries: m.maxEntries,
+			Flags:      m.flags,
+			Name:       m.name,
+		}
+	}
 	switch {
 	case m.typ != ms.Type:
-		return fmt.Errorf("expected type %v, got %v: %w", ms.Type, m.typ, ErrMapIncompatible)
+		return fmt.Errorf("%w: %w", ErrMapIncompatible, NewErrIncompatibleMap(asInfo(m), ms))
 
 	case m.keySize != ms.KeySize:
-		return fmt.Errorf("expected key size %v, got %v: %w", ms.KeySize, m.keySize, ErrMapIncompatible)
+		return fmt.Errorf("%w : %w", ErrMapIncompatible, NewErrIncompatibleMap(asInfo(m), ms))
 
 	case m.valueSize != ms.ValueSize:
-		return fmt.Errorf("expected value size %v, got %v: %w", ms.ValueSize, m.valueSize, ErrMapIncompatible)
+		return fmt.Errorf("%w %w", ErrMapIncompatible, NewErrIncompatibleMap(asInfo(m), ms))
 
 	case m.maxEntries != ms.MaxEntries:
-		return fmt.Errorf("expected max entries %v, got %v: %w", ms.MaxEntries, m.maxEntries, ErrMapIncompatible)
+		return fmt.Errorf("%w : %w", ErrMapIncompatible, NewErrIncompatibleMap(asInfo(m), ms))
 
 	// BPF_F_RDONLY_PROG is set unconditionally for devmaps. Explicitly allow
 	// this mismatch.
 	case !((ms.Type == DevMap || ms.Type == DevMapHash) && m.flags^ms.Flags == unix.BPF_F_RDONLY_PROG) &&
 		m.flags != ms.Flags:
-		return fmt.Errorf("expected flags %v, got %v: %w", ms.Flags, m.flags, ErrMapIncompatible)
+		return fmt.Errorf("%w : %w", ErrMapIncompatible, NewErrIncompatibleMap(asInfo(m), ms))
 	}
 	return nil
 }

--- a/map.go
+++ b/map.go
@@ -28,42 +28,6 @@ var (
 	errMapNoBTFValue    = errors.New("map spec does not contain a BTF Value")
 )
 
-type IncompatibleMapErr struct {
-	Existing *MapInfo
-	Incoming *MapSpec
-}
-
-func NewErrIncompatibleMap(existing *MapInfo, incoming *MapSpec) *IncompatibleMapErr {
-	return &IncompatibleMapErr{
-		Existing: existing,
-		Incoming: incoming,
-	}
-}
-
-func (e *IncompatibleMapErr) Error() string {
-	return fmt.Sprintf("details(existing -> incoming) : %s", e.diff())
-}
-
-func (e *IncompatibleMapErr) diff() string {
-	diffs := []string{}
-	if e.Existing.Type != e.Incoming.Type {
-		diffs = append(diffs, fmt.Sprintf("type : %s -> %s", e.Existing.Type, e.Incoming.Type))
-	}
-	if e.Existing.Flags != e.Incoming.Flags {
-		diffs = append(diffs, fmt.Sprintf("flags : %d -> %d", e.Existing.Flags, e.Incoming.Flags))
-	}
-	if e.Existing.KeySize != e.Incoming.KeySize {
-		diffs = append(diffs, fmt.Sprintf("keySize : %d -> %d", e.Existing.KeySize, e.Incoming.KeySize))
-	}
-	if e.Existing.ValueSize != e.Incoming.ValueSize {
-		diffs = append(diffs, fmt.Sprintf("valueSize : %d -> %d", e.Existing.ValueSize, e.Incoming.ValueSize))
-	}
-	if e.Existing.MaxEntries != e.Incoming.MaxEntries {
-		diffs = append(diffs, fmt.Sprintf("maxEntries : %d -> %d", e.Existing.MaxEntries, e.Incoming.MaxEntries))
-	}
-	return strings.Join(diffs, ", ")
-}
-
 // MapOptions control loading a map into the kernel.
 type MapOptions struct {
 	// The base path to pin maps in if requested via PinByName.
@@ -216,47 +180,83 @@ type MapKV struct {
 	Value interface{}
 }
 
+type mapInfo struct {
+	Type       MapType
+	KeySize    uint32
+	ValueSize  uint32
+	MaxEntries uint32
+	Flags      uint32
+}
+
+type IncompatibleMapError struct {
+	Existing mapInfo
+	Incoming mapInfo
+	diff     string
+}
+
+func (err *IncompatibleMapError) Error() string {
+	return fmt.Sprintf("%s: %s", err.diff, ErrMapIncompatible)
+}
+
+func (*IncompatibleMapError) Is(target error) bool {
+	return target == ErrMapIncompatible
+}
+
 // Compatible returns nil if an existing map may be used instead of creating
 // one from the spec.
 //
-// Returns an error wrapping [ErrMapIncompatible] otherwise. The error also wraps [IncompatibleMapErr]
-// which contains useful information about the incompatibility.
+// If the Map is not compatible, returns an [IncompatibleMapError] wrapping
+// [ErrMapIncompatible]. The [IncompatibleMapError] contains the relevant fields
+// of the existing and incoming maps and can be inspected for error handling
+// using errors.As.
 func (ms *MapSpec) Compatible(m *Map) error {
 	ms, err := ms.fixupMagicFields()
 	if err != nil {
 		return err
 	}
 
-	asInfo := func(m *Map) *MapInfo {
-		return &MapInfo{
+	diffs := []string{}
+	if m.typ != ms.Type {
+		diffs = append(diffs, fmt.Sprintf("Type: %s changed to %s", m.typ, ms.Type))
+	}
+	if m.keySize != ms.KeySize {
+		diffs = append(diffs, fmt.Sprintf("KeySize: %d changed to %d", m.keySize, ms.KeySize))
+	}
+	if m.valueSize != ms.ValueSize {
+		diffs = append(diffs, fmt.Sprintf("ValueSize: %d changed to %d", m.valueSize, ms.ValueSize))
+	}
+	if m.maxEntries != ms.MaxEntries {
+		diffs = append(diffs, fmt.Sprintf("MaxEntries: %d changed to %d", m.maxEntries, ms.MaxEntries))
+	}
+
+	// BPF_F_RDONLY_PROG is set unconditionally for devmaps. Explicitly allow
+	// this mismatch.
+	if !((ms.Type == DevMap || ms.Type == DevMapHash) && m.flags^ms.Flags == unix.BPF_F_RDONLY_PROG) &&
+		m.flags != ms.Flags {
+		diffs = append(diffs, fmt.Sprintf("Flags: %d changed to %d", m.flags, ms.Flags))
+	}
+
+	if len(diffs) == 0 {
+		return nil
+	}
+
+	return &IncompatibleMapError{
+		Existing: mapInfo{
 			Type:       m.typ,
 			KeySize:    m.keySize,
 			ValueSize:  m.valueSize,
 			MaxEntries: m.maxEntries,
 			Flags:      m.flags,
-			Name:       m.name,
-		}
+		},
+		Incoming: mapInfo{
+			Type:       ms.Type,
+			KeySize:    ms.KeySize,
+			ValueSize:  ms.ValueSize,
+			MaxEntries: ms.MaxEntries,
+			Flags:      ms.Flags,
+		},
+		diff: strings.Join(diffs, ", "),
 	}
-	switch {
-	case m.typ != ms.Type:
-		return errors.Join(ErrMapIncompatible, NewErrIncompatibleMap(asInfo(m), ms))
-
-	case m.keySize != ms.KeySize:
-		return errors.Join(ErrMapIncompatible, NewErrIncompatibleMap(asInfo(m), ms))
-
-	case m.valueSize != ms.ValueSize:
-		return errors.Join(ErrMapIncompatible, NewErrIncompatibleMap(asInfo(m), ms))
-
-	case m.maxEntries != ms.MaxEntries:
-		return errors.Join(ErrMapIncompatible, NewErrIncompatibleMap(asInfo(m), ms))
-
-	// BPF_F_RDONLY_PROG is set unconditionally for devmaps. Explicitly allow
-	// this mismatch.
-	case !((ms.Type == DevMap || ms.Type == DevMapHash) && m.flags^ms.Flags == unix.BPF_F_RDONLY_PROG) &&
-		m.flags != ms.Flags:
-		return errors.Join(ErrMapIncompatible, NewErrIncompatibleMap(asInfo(m), ms))
-	}
-	return nil
 }
 
 // Map represents a Map file descriptor.

--- a/map_test.go
+++ b/map_test.go
@@ -1720,22 +1720,76 @@ func TestMapPinning(t *testing.T) {
 	if value != 42 {
 		t.Fatal("Pinning doesn't use pinned maps")
 	}
+}
 
+func TestMapPinningIncompatible(t *testing.T) {
+	tmp := testutils.TempBPFFS(t)
+	c := qt.New(t)
+
+	spec := &MapSpec{
+		Name:       "test",
+		Type:       Hash,
+		KeySize:    4,
+		ValueSize:  4,
+		MaxEntries: 1,
+		Pinning:    PinByName,
+	}
+
+	m1, err := NewMapWithOptions(spec, MapOptions{PinPath: tmp})
+	if err != nil {
+		t.Fatal("Can't create map:", err)
+	}
+	defer m1.Close()
+	pinned := m1.IsPinned()
+	c.Assert(pinned, qt.IsTrue)
+
+	_, err = m1.Info()
+	c.Assert(err, qt.IsNil)
+
+	if err := m1.Put(uint32(0), uint32(42)); err != nil {
+		t.Fatal("Can't write value:", err)
+	}
 	spec.KeySize = 8
-	m3, err := NewMapWithOptions(spec, MapOptions{PinPath: tmp})
-	if err == nil {
-		m3.Close()
-		t.Fatalf("Opening a pinned map with a mismatching spec did not fail")
+	tc := map[string]*MapSpec{
+		"KeySize":    {Name: spec.Name, Type: spec.Type, KeySize: 8, ValueSize: spec.ValueSize, MaxEntries: spec.MaxEntries, Pinning: spec.Pinning},
+		"ValueSize":  {Name: spec.Name, Type: spec.Type, KeySize: spec.ValueSize, ValueSize: 8, MaxEntries: spec.MaxEntries, Pinning: spec.Pinning},
+		"Type":       {Name: spec.Name, Type: Array, KeySize: spec.ValueSize, ValueSize: spec.ValueSize, MaxEntries: spec.MaxEntries, Pinning: spec.Pinning},
+		"MaxEntries": {Name: spec.Name, Type: spec.Type, KeySize: spec.ValueSize, ValueSize: spec.ValueSize, MaxEntries: 2, Pinning: spec.Pinning},
+		"Flags":      {Name: spec.Name, Type: spec.Type, KeySize: spec.ValueSize, ValueSize: spec.ValueSize, MaxEntries: spec.MaxEntries, Pinning: spec.Pinning, Flags: unix.BPF_F_RDONLY_PROG},
 	}
-	if !errors.Is(err, ErrMapIncompatible) {
-		t.Fatalf("Opening a pinned map with a mismatching spec failed with the wrong error")
+	for name, spec := range tc {
+		m3, err := NewMapWithOptions(spec, MapOptions{PinPath: tmp})
+		if err == nil {
+			m3.Close()
+			t.Fatalf("Opening a pinned map with a mismatching spec did not fail")
+		}
+		if !errors.Is(err, ErrMapIncompatible) {
+			t.Fatalf("Opening a pinned map with a mismatching spec failed with the wrong error")
+		}
+		var merr *IncompatibleMapErr
+		if !errors.As(err, &merr) {
+			t.Fatal("Opening a pinned map with a mismatch spec failed to provide additional details")
+		}
+		switch name {
+		case "KeySize":
+			c.Assert(merr.Existing.KeySize, qt.Equals, uint32(4))
+			c.Assert(merr.Incoming.KeySize, qt.Equals, uint32(8))
+		case "ValueSize":
+			c.Assert(merr.Existing.ValueSize, qt.Equals, uint32(4))
+			c.Assert(merr.Incoming.ValueSize, qt.Equals, uint32(8))
+		case "Type":
+			c.Assert(merr.Existing.Type, qt.Equals, Hash)
+			c.Assert(merr.Incoming.Type, qt.Equals, Array)
+		case "MaxEntries":
+			c.Assert(merr.Existing.MaxEntries, qt.Equals, uint32(1))
+			c.Assert(merr.Incoming.MaxEntries, qt.Equals, uint32(2))
+		case "Flags":
+			c.Assert(merr.Existing.Flags, qt.Equals, uint32(0))
+			c.Assert(merr.Incoming.Flags, qt.Equals, uint32(unix.BPF_F_RDONLY_PROG))
+		default:
+			t.Fatalf("unhandled incompatible map pinning testcase %s", name)
+		}
 	}
-	var merr *IncompatibleMapErr
-	if !errors.As(err, &merr) {
-		t.Fatal("Opening a pinned map with a mismatch spec failed to provide additional details")
-	}
-	c.Assert(merr.Existing.KeySize, qt.Equals, uint32(4))
-	c.Assert(merr.Incoming.KeySize, qt.Equals, uint32(8))
 }
 
 func TestPerfEventArrayCompatible(t *testing.T) {

--- a/map_test.go
+++ b/map_test.go
@@ -1724,9 +1724,8 @@ func TestMapPinning(t *testing.T) {
 
 func TestMapPinningIncompatible(t *testing.T) {
 	tmp := testutils.TempBPFFS(t)
-	c := qt.New(t)
 
-	spec := &MapSpec{
+	base := MapSpec{
 		Name:       "test",
 		Type:       Hash,
 		KeySize:    4,
@@ -1735,60 +1734,79 @@ func TestMapPinningIncompatible(t *testing.T) {
 		Pinning:    PinByName,
 	}
 
-	m1, err := NewMapWithOptions(spec, MapOptions{PinPath: tmp})
+	m1, err := NewMapWithOptions(&base, MapOptions{PinPath: tmp})
 	if err != nil {
 		t.Fatal("Can't create map:", err)
 	}
 	defer m1.Close()
-	pinned := m1.IsPinned()
-	c.Assert(pinned, qt.IsTrue)
 
-	_, err = m1.Info()
-	c.Assert(err, qt.IsNil)
+	tests := []struct {
+		name string
+		spec func(*MapSpec)
+		test func(*qt.C, *IncompatibleMapError)
+	}{
+		{
+			"Type",
+			func(spec *MapSpec) { spec.Type = Array },
+			func(c *qt.C, merr *IncompatibleMapError) {
+				c.Assert(merr.Existing.Type, qt.Equals, Hash)
+				c.Assert(merr.Incoming.Type, qt.Equals, Array)
+			},
+		},
+		{
+			"KeySize",
+			func(spec *MapSpec) { spec.KeySize = 8 },
+			func(c *qt.C, merr *IncompatibleMapError) {
+				c.Assert(merr.Existing.KeySize, qt.Equals, uint32(4))
+				c.Assert(merr.Incoming.KeySize, qt.Equals, uint32(8))
+			},
+		},
+		{
+			"ValueSize",
+			func(spec *MapSpec) { spec.ValueSize = 8 },
+			func(c *qt.C, merr *IncompatibleMapError) {
+				c.Assert(merr.Existing.ValueSize, qt.Equals, uint32(4))
+				c.Assert(merr.Incoming.ValueSize, qt.Equals, uint32(8))
+			},
+		},
+		{
+			"MaxEntries",
+			func(spec *MapSpec) { spec.MaxEntries = 2 },
+			func(c *qt.C, merr *IncompatibleMapError) {
+				c.Assert(merr.Existing.MaxEntries, qt.Equals, uint32(1))
+				c.Assert(merr.Incoming.MaxEntries, qt.Equals, uint32(2))
+			},
+		},
+		{
+			"Flags",
+			func(spec *MapSpec) { spec.Flags = unix.BPF_F_RDONLY_PROG },
+			func(c *qt.C, merr *IncompatibleMapError) {
+				c.Assert(merr.Existing.Flags, qt.Equals, uint32(0))
+				c.Assert(merr.Incoming.Flags, qt.Equals, uint32(unix.BPF_F_RDONLY_PROG))
+			},
+		},
+	}
 
-	if err := m1.Put(uint32(0), uint32(42)); err != nil {
-		t.Fatal("Can't write value:", err)
-	}
-	spec.KeySize = 8
-	tc := map[string]*MapSpec{
-		"KeySize":    {Name: spec.Name, Type: spec.Type, KeySize: 8, ValueSize: spec.ValueSize, MaxEntries: spec.MaxEntries, Pinning: spec.Pinning},
-		"ValueSize":  {Name: spec.Name, Type: spec.Type, KeySize: spec.ValueSize, ValueSize: 8, MaxEntries: spec.MaxEntries, Pinning: spec.Pinning},
-		"Type":       {Name: spec.Name, Type: Array, KeySize: spec.ValueSize, ValueSize: spec.ValueSize, MaxEntries: spec.MaxEntries, Pinning: spec.Pinning},
-		"MaxEntries": {Name: spec.Name, Type: spec.Type, KeySize: spec.ValueSize, ValueSize: spec.ValueSize, MaxEntries: 2, Pinning: spec.Pinning},
-		"Flags":      {Name: spec.Name, Type: spec.Type, KeySize: spec.ValueSize, ValueSize: spec.ValueSize, MaxEntries: spec.MaxEntries, Pinning: spec.Pinning, Flags: unix.BPF_F_RDONLY_PROG},
-	}
-	for name, spec := range tc {
-		m3, err := NewMapWithOptions(spec, MapOptions{PinPath: tmp})
-		if err == nil {
-			m3.Close()
-			t.Fatalf("Opening a pinned map with a mismatching spec did not fail")
-		}
-		if !errors.Is(err, ErrMapIncompatible) {
-			t.Fatalf("Opening a pinned map with a mismatching spec failed with the wrong error")
-		}
-		var merr *IncompatibleMapErr
-		if !errors.As(err, &merr) {
-			t.Fatal("Opening a pinned map with a mismatch spec failed to provide additional details")
-		}
-		switch name {
-		case "KeySize":
-			c.Assert(merr.Existing.KeySize, qt.Equals, uint32(4))
-			c.Assert(merr.Incoming.KeySize, qt.Equals, uint32(8))
-		case "ValueSize":
-			c.Assert(merr.Existing.ValueSize, qt.Equals, uint32(4))
-			c.Assert(merr.Incoming.ValueSize, qt.Equals, uint32(8))
-		case "Type":
-			c.Assert(merr.Existing.Type, qt.Equals, Hash)
-			c.Assert(merr.Incoming.Type, qt.Equals, Array)
-		case "MaxEntries":
-			c.Assert(merr.Existing.MaxEntries, qt.Equals, uint32(1))
-			c.Assert(merr.Incoming.MaxEntries, qt.Equals, uint32(2))
-		case "Flags":
-			c.Assert(merr.Existing.Flags, qt.Equals, uint32(0))
-			c.Assert(merr.Incoming.Flags, qt.Equals, uint32(unix.BPF_F_RDONLY_PROG))
-		default:
-			t.Fatalf("unhandled incompatible map pinning testcase %s", name)
-		}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := base.Copy()
+			tt.spec(spec)
+
+			m3, err := NewMapWithOptions(spec, MapOptions{PinPath: tmp})
+			if err == nil {
+				m3.Close()
+				t.Fatalf("Opening a pinned map with a mismatching spec did not fail")
+			}
+			if !errors.Is(err, ErrMapIncompatible) {
+				t.Fatalf("Error did not wrap ErrMapIncompatible: %s", err)
+			}
+			var merr *IncompatibleMapError
+			if !errors.As(err, &merr) {
+				t.Fatalf("Error didn't contain an IncompatibleMapError: %s", err)
+			}
+
+			tt.test(qt.New(t), merr)
+		})
 	}
 }
 

--- a/map_test.go
+++ b/map_test.go
@@ -1730,6 +1730,12 @@ func TestMapPinning(t *testing.T) {
 	if !errors.Is(err, ErrMapIncompatible) {
 		t.Fatalf("Opening a pinned map with a mismatching spec failed with the wrong error")
 	}
+	var merr *IncompatibleMapErr
+	if !errors.As(err, &merr) {
+		t.Fatal("Opening a pinned map with a mismatch spec failed to provide additional details")
+	}
+	c.Assert(merr.Existing.KeySize, qt.Equals, uint32(4))
+	c.Assert(merr.Incoming.KeySize, qt.Equals, uint32(8))
 }
 
 func TestPerfEventArrayCompatible(t *testing.T) {


### PR DESCRIPTION
Addresses #1034 

Opted for a solution that maintains compatibility with existing error checks of the form: 
```go
errors.Is(err, ErrMapIncompatible)
```