### PR TITLE
elf: don't clamp PerfEventArray.MaxEntries at parse time

### DIFF
--- a/elf_reader.go
+++ b/elf_reader.go
@@ -694,10 +694,6 @@ func (ec *elfCode) loadMaps() error {
 				spec.Extra = bytes.NewReader(extra)
 			}
 
-			if err := spec.clampPerfEventArraySize(); err != nil {
-				return fmt.Errorf("map %s: %w", mapName, err)
-			}
-
 			ec.maps[mapName] = &spec
 		}
 	}
@@ -759,10 +755,6 @@ func (ec *elfCode) loadBTFMaps() error {
 
 			mapSpec, err := mapSpecFromBTF(sec, &vs, mapStruct, ec.btf, name, false)
 			if err != nil {
-				return fmt.Errorf("map %v: %w", name, err)
-			}
-
-			if err := mapSpec.clampPerfEventArraySize(); err != nil {
 				return fmt.Errorf("map %v: %w", name, err)
 			}
 

--- a/elf_reader_test.go
+++ b/elf_reader_test.go
@@ -24,11 +24,6 @@ import (
 )
 
 func TestLoadCollectionSpec(t *testing.T) {
-	cpus, err := internal.PossibleCPUs()
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	coll := &CollectionSpec{
 		Maps: map[string]*MapSpec{
 			"hash_map": {
@@ -55,7 +50,7 @@ func TestLoadCollectionSpec(t *testing.T) {
 			"perf_event_array": {
 				Name:       "perf_event_array",
 				Type:       PerfEventArray,
-				MaxEntries: uint32(cpus),
+				MaxEntries: 4096,
 			},
 			// Maps prefixed by btf_ are ignored when testing ELFs
 			// that don't have BTF info embedded. (clang<9)

--- a/map_test.go
+++ b/map_test.go
@@ -1736,9 +1736,7 @@ func TestMapPinning(t *testing.T) {
 
 func TestPerfEventArrayCompatible(t *testing.T) {
 	ms := &MapSpec{
-		Type:      PerfEventArray,
-		KeySize:   4,
-		ValueSize: 4,
+		Type: PerfEventArray,
 	}
 
 	m, err := NewMap(ms)

--- a/map_test.go
+++ b/map_test.go
@@ -1734,6 +1734,23 @@ func TestMapPinning(t *testing.T) {
 	}
 }
 
+func TestPerfEventArrayCompatible(t *testing.T) {
+	ms := &MapSpec{
+		Type:      PerfEventArray,
+		KeySize:   4,
+		ValueSize: 4,
+	}
+
+	m, err := NewMap(ms)
+	qt.Assert(t, err, qt.IsNil)
+	defer m.Close()
+
+	qt.Assert(t, ms.Compatible(m), qt.IsNil)
+
+	ms.MaxEntries = m.MaxEntries() - 1
+	qt.Assert(t, ms.Compatible(m), qt.IsNotNil)
+}
+
 type benchValue struct {
 	ID      uint32
 	Val16   uint16

--- a/map_test.go
+++ b/map_test.go
@@ -637,8 +637,6 @@ func TestMapLoadPinned(t *testing.T) {
 }
 
 func TestMapLoadReusePinned(t *testing.T) {
-	c := qt.New(t)
-
 	for _, typ := range []MapType{Array, Hash, DevMap, DevMapHash} {
 		t.Run(typ.String(), func(t *testing.T) {
 			if typ == DevMap {
@@ -658,11 +656,11 @@ func TestMapLoadReusePinned(t *testing.T) {
 			}
 
 			m1, err := NewMapWithOptions(spec, MapOptions{PinPath: tmp})
-			c.Assert(err, qt.IsNil)
+			qt.Assert(t, err, qt.IsNil)
 			defer m1.Close()
 
 			m2, err := NewMapWithOptions(spec, MapOptions{PinPath: tmp})
-			c.Assert(err, qt.IsNil)
+			qt.Assert(t, err, qt.IsNil)
 			defer m2.Close()
 		})
 	}


### PR DESCRIPTION
elf: don't clamp PerfEventArray.MaxEntries at parse time

    One key idea of the ELF reader is that it is deterministic: it should always
    produce the same output regardless of which system it runs on. The
    PerfEventArray clamping logic violates this since it substitutes the number
    of possible CPUs.

    Move the logic into map creation and adjust MapSpec.Compatible to do the
    same fixup.

    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>

map: fix MapSpec.Compatible for PerfEventArray with zero key or value size

    MapSpec.Compatible currently returns an error when comparing a
    PerfEventArray created from a MapSpec without explicit key or value sizes.
    This is because we only do the fixup just before executing the
    BPF_MAP_CREATE syscall.

    Move the fixup logic into a separate function so that we can invoke it from 
    MapSpec.Compatible.

    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>

map: fix buggy TestMapLoadReusePinned

    The test calls t.Fatal on the wrong (parent) t since it reuses qt.New from
    the parent scope. Remove qt.New.

    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>
