### PR TITLE
[DRAFT] btf: handle BTF_KIND_FWD for struct/union in the type compat check

### DIFF
--- a/btf/core.go
+++ b/btf/core.go
@@ -902,6 +902,24 @@ func coreAreTypesCompatible(localType Type, targetType Type) error {
 		localType = UnderlyingType(*l)
 		targetType = UnderlyingType(*t)
 
+		/* For forward declarations, kflag dictates
+		 * whether the target is a struct or union.
+		 */
+		switch (localType).(type) {
+		case *Fwd:
+			localKind := localType.(*Fwd).Kind
+			switch (targetType).(type) {
+			case *Struct:
+				if localKind == FwdStruct {
+					return nil
+				}
+			case *Union:
+				if localKind == FwdUnion {
+					return nil
+				}
+			}
+		}
+
 		if reflect.TypeOf(localType) != reflect.TypeOf(targetType) {
 			return fmt.Errorf("type mismatch: %w", errIncompatibleTypes)
 		}


### PR DESCRIPTION
This patch adds support for forward declarations of struct/union to enable the usage of kernel functions with a pointer to a incomplete kfunc's struct.