### PR TITLE
collection: Add Pin/Unpin/Assign methods

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -4,6 +4,8 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"os"
+	"path"
 	"reflect"
 	"strings"
 
@@ -677,6 +679,102 @@ func LoadCollection(file string) (*Collection, error) {
 		return nil, err
 	}
 	return NewCollection(spec)
+}
+
+func (coll *Collection) pinMaps(objPath string) error {
+	var err error
+
+	for name, m := range coll.Maps {
+		// Skip .rodata, .data, .bss, etc.
+		if strings.HasPrefix(name, ".") {
+			continue
+		}
+
+		// bpffs does not allow "."s
+		name = strings.ReplaceAll(name, ".", "_")
+		mapPath := path.Join(objPath, name)
+		if err = m.Pin(mapPath); err != nil {
+			err = fmt.Errorf("failed to pin map %s: %w", name, err)
+			break
+		}
+	}
+
+	if err != nil {
+		for _, m := range coll.Maps {
+			m.Unpin() //nolint:errcheck
+		}
+		return err
+	}
+
+	return nil
+}
+
+func (coll *Collection) pinProgs(objPath string) error {
+	var err error
+
+	for name, prog := range coll.Programs {
+		progPath := path.Join(objPath, name)
+		if err = prog.Pin(progPath); err != nil {
+			err = fmt.Errorf("failed to pin program %s: %w", name, err)
+			break
+		}
+	}
+
+	if err != nil {
+		for _, prog := range coll.Programs {
+			prog.Unpin() //nolint:errcheck
+		}
+		return err
+	}
+
+	return nil
+}
+
+// Pin persists the Maps and Programs in the Collection on the BPF virtual file
+// system past the lifetime of the process that created it.
+//
+// Calling Pin on a previously pinned Collection will overwrite the paths, except when
+// the new path already exists. Re-pinning across filesystems is not supported.
+//
+// This requires bpffs to be mounted above path. See
+// https://docs.cilium.io/en/stable/network/kubernetes/configuration/#mounting-bpffs-with-systemd
+func (coll *Collection) Pin(path string) error {
+	if err := os.MkdirAll(path, 0700); err != nil {
+		return err
+	}
+
+	if err := coll.pinMaps(path); err != nil {
+		return err
+	}
+
+	if err := coll.pinProgs(path); err != nil {
+		for _, m := range coll.Maps {
+			m.Unpin() //nolint:errcheck
+		}
+		return err
+	}
+
+	return nil
+}
+
+// Unpin removes the persisted state for the Collection from the BPF virtual
+// filesystem.
+//
+// Unpinning an unpinned Collection returns nil.
+func (coll *Collection) Unpin() error {
+	for name, m := range coll.Maps {
+		if err := m.Unpin(); err != nil {
+			return fmt.Errorf("failed to unpin map %s: %w", name, err)
+		}
+	}
+
+	for name, prog := range coll.Programs {
+		if err := prog.Unpin(); err != nil {
+			return fmt.Errorf("failed to unpin program %s: %w", name, err)
+		}
+	}
+
+	return nil
 }
 
 // Close frees all maps and programs associated with the collection.

--- a/collection_test.go
+++ b/collection_test.go
@@ -435,7 +435,7 @@ func TestCollectionSpec_LoadAndAssign_LazyLoading(t *testing.T) {
 	}
 }
 
-func TestCollectionAssign(t *testing.T) {
+func TestCollectionSpecAssign(t *testing.T) {
 	var specs struct {
 		Program *ProgramSpec `ebpf:"prog1"`
 		Map     *MapSpec     `ebpf:"map1"`
@@ -558,6 +558,50 @@ func TestAssignValues(t *testing.T) {
 		})
 	}
 
+}
+
+func TestCollectionAssign(t *testing.T) {
+	var objs struct {
+		Program *Program `ebpf:"prog1"`
+		Map     *Map     `ebpf:"map1"`
+	}
+
+	cs := &CollectionSpec{
+		Maps: map[string]*MapSpec{
+			"map1": {
+				Type:       Array,
+				KeySize:    4,
+				ValueSize:  4,
+				MaxEntries: 1,
+			},
+		},
+		Programs: map[string]*ProgramSpec{
+			"prog1": {
+				Type: SocketFilter,
+				Instructions: asm.Instructions{
+					asm.LoadImm(asm.R0, 0, asm.DWord),
+					asm.Return(),
+				},
+				License: "MIT",
+			},
+		},
+	}
+
+	coll, err := NewCollection(cs)
+	qt.Assert(t, err, qt.IsNil)
+	defer coll.Close()
+
+	qt.Assert(t, coll.Assign(&objs), qt.IsNil)
+	defer objs.Program.Close()
+	defer objs.Map.Close()
+
+	// Check that objs has received ownership of map and prog
+	qt.Assert(t, objs.Program.FD() >= 0, qt.IsTrue)
+	qt.Assert(t, objs.Map.FD() >= 0, qt.IsTrue)
+
+	// Check that the collection has lost ownership
+	qt.Assert(t, coll.Programs, qt.Not(qt.Contains), "prog1")
+	qt.Assert(t, coll.Maps, qt.Not(qt.Contains), "map1")
 }
 
 func TestIncompleteLoadAndAssign(t *testing.T) {

--- a/collection_test.go
+++ b/collection_test.go
@@ -3,6 +3,7 @@ package ebpf
 import (
 	"errors"
 	"fmt"
+	"path"
 	"reflect"
 	"testing"
 
@@ -727,4 +728,69 @@ func ExampleCollectionSpec_LoadAndAssign() {
 
 	// Output: SocketFilter
 	// Array
+}
+
+func TestCollectionPinUnpin(t *testing.T) {
+	spec := &CollectionSpec{
+		Maps: map[string]*MapSpec{
+			"pinmap1": {
+				Type:       Array,
+				KeySize:    4,
+				ValueSize:  4,
+				MaxEntries: 1,
+			},
+			"pinmap2": {
+				Type:       Array,
+				KeySize:    4,
+				ValueSize:  4,
+				MaxEntries: 1,
+			},
+		},
+		Programs: map[string]*ProgramSpec{
+			"pinprog1": {
+				Type: SocketFilter,
+				Instructions: asm.Instructions{
+					asm.LoadImm(asm.R0, 0, asm.DWord),
+					asm.Return(),
+				},
+				License: "MIT",
+			},
+			"pinprog2": {
+				Type: SocketFilter,
+				Instructions: asm.Instructions{
+					asm.LoadImm(asm.R0, 0, asm.DWord),
+					asm.Return(),
+				},
+				License: "MIT",
+			},
+		},
+		Types: &btf.Spec{},
+	}
+
+	coll, err := NewCollection(spec)
+	qt.Assert(t, err, qt.IsNil)
+	defer coll.Close()
+
+	bpffs := testutils.TempBPFFS(t)
+	pinPath := path.Join(bpffs, "myobj")
+
+	// Nothing is pinned yet
+	before := testutils.Glob(t, path.Join(pinPath, "*"))
+	qt.Assert(t, before, qt.HasLen, 0)
+
+	// Pin all maps and objects
+	qt.Assert(t, coll.Pin(pinPath), qt.IsNil)
+	defer coll.Unpin() //nolint:errcheck
+
+	after := testutils.Glob(t, path.Join(pinPath, "*"))
+	qt.Assert(t, after, qt.HasLen, 4)
+	qt.Assert(t, after, qt.Contains, path.Join(pinPath, "pinmap1"))
+	qt.Assert(t, after, qt.Contains, path.Join(pinPath, "pinmap2"))
+	qt.Assert(t, after, qt.Contains, path.Join(pinPath, "pinprog1"))
+	qt.Assert(t, after, qt.Contains, path.Join(pinPath, "pinprog2"))
+
+	// Now check that Unpin() also works
+	qt.Assert(t, coll.Unpin(), qt.IsNil)
+	after2 := testutils.Glob(t, path.Join(pinPath, "*"))
+	qt.Assert(t, after2, qt.HasLen, 0)
 }


### PR DESCRIPTION
Allow pinning entire object files at once instead of on a per-map
or per-prog basis. Also make it work for bpf2go users.

See individual commits for motivation and details.