### PR TITLE
all: fix typos in comments and tests

### DIFF
--- a/asm/alu.go
+++ b/asm/alu.go
@@ -75,7 +75,7 @@ const (
 	Xor ALUOp = 0xa0
 	// Mov - move value from one place to another
 	Mov ALUOp = 0xb0
-	// ArSh - arithmatic shift
+	// ArSh - arithmetic shift
 	ArSh ALUOp = 0xc0
 	// Swap - endian conversions
 	Swap ALUOp = 0xd0

--- a/asm/instruction_test.go
+++ b/asm/instruction_test.go
@@ -146,7 +146,7 @@ func TestInstructionLoadMapValue(t *testing.T) {
 		t.Error("Expected map fd to be 1, got", fd)
 	}
 	if off := ins.mapOffset(); off != 123 {
-		t.Fatal("Expected map offset to be 123 after changin the pointer, got", off)
+		t.Fatal("Expected map offset to be 123 after changing the pointer, got", off)
 	}
 }
 

--- a/btf/btf_test.go
+++ b/btf/btf_test.go
@@ -294,7 +294,7 @@ func TestLoadSpecFromElf(t *testing.T) {
 
 		var v *Var
 		if err := spec.TypeByName("key3", &v); err != nil {
-			t.Error("Cant find key3:", err)
+			t.Error("Can't find key3:", err)
 		} else {
 			if v.Linkage != GlobalVar {
 				t.Error("Expected global linkage:", v)

--- a/elf_reader.go
+++ b/elf_reader.go
@@ -777,7 +777,7 @@ func (ec *elfCode) loadBTFMaps() error {
 
 // mapSpecFromBTF produces a MapSpec based on a btf.Struct def representing
 // a BTF map definition. The name and spec arguments will be copied to the
-// resulting MapSpec, and inner must be true on any resursive invocations.
+// resulting MapSpec, and inner must be true on any recursive invocations.
 func mapSpecFromBTF(es *elfSection, vs *btf.VarSecinfo, def *btf.Struct, spec *btf.Spec, name string, inner bool) (*MapSpec, error) {
 	var (
 		key, value         btf.Type

--- a/features/map.go
+++ b/features/map.go
@@ -248,7 +248,7 @@ func HaveMapFlag(flag MapFlags) (err error) {
 
 func probeMapFlag(attr *sys.MapCreateAttr) error {
 	// For now, we do not check if the map type is supported because we only support
-	// probing for flags defined on arrays and hashs that are always supported.
+	// probing for flags defined on arrays and hashes that are always supported.
 	// In the future, if we allow probing on flags defined on newer types, checking for map type
 	// support will be required.
 	if attr.MapType == sys.BPF_MAP_TYPE_UNSPEC {

--- a/internal/epoll/poller.go
+++ b/internal/epoll/poller.go
@@ -100,7 +100,7 @@ func (p *Poller) Add(fd int, id int) error {
 	}
 
 	// The representation of EpollEvent isn't entirely accurate.
-	// Pad is fully useable, not just padding. Hence we stuff the
+	// Pad is fully usable, not just padding. Hence we stuff the
 	// id in there, which allows us to identify the event later (e.g.,
 	// in case of perf events, which CPU sent it).
 	event := unix.EpollEvent{

--- a/map_test.go
+++ b/map_test.go
@@ -2159,7 +2159,7 @@ func ExampleMap_perCPU() {
 }
 
 // It is possible to use unsafe.Pointer to avoid marshalling
-// and copy overhead. It is the resposibility of the caller to ensure
+// and copy overhead. It is the responsibility of the caller to ensure
 // the correct size of unsafe.Pointers.
 //
 // Note that using unsafe.Pointer is only marginally faster than

--- a/types.go
+++ b/types.go
@@ -44,7 +44,7 @@ const (
 	// if an skb is from a socket belonging to a specific cgroup
 	CGroupArray
 	// LRUHash - This allows you to create a small hash structure that will purge the
-	// least recently used items rather than thow an error when you run out of memory
+	// least recently used items rather than throw an error when you run out of memory
 	LRUHash
 	// LRUCPUHash - This is NOT like PerCPUHash, this structure is shared among the CPUs,
 	// it has more to do with including the CPU id with the LRU calculation so that if a


### PR DESCRIPTION
This PR fixes spelling mistakes in Go comments and test messages.