### PR TITLE
go: require v1.20

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cilium/ebpf
 
-go 1.19
+go 1.20
 
 require (
 	github.com/frankban/quicktest v1.14.5


### PR DESCRIPTION
v1.21.0 has been released, so v1.19 is now EOL.