### PR TITLE
run-tests: support new selftest packaging

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -130,7 +130,7 @@ else
   if fetch "${selftests}"; then
     echo "Decompressing selftests"
     mkdir "${input}/bpf"
-    tar --strip-components=4 -xf "${tmp_dir}/${selftests}" -C "${input}/bpf"
+    tar --strip-components=5 -xf "${tmp_dir}/${selftests}" -C "${input}/bpf"
   else
     echo "No selftests found, disabling"
   fi


### PR DESCRIPTION
The new selftests packaging has an additional ./ directory at the start of the filenames. Strip another path component.