### PR TITLE
elf: don't set BPF_F_MMAPABLE on .kconfig

### DIFF
--- a/elf_reader.go
+++ b/elf_reader.go
@@ -1142,7 +1142,7 @@ func (ec *elfCode) loadKconfigSection() error {
 		KeySize:    uint32(4),
 		ValueSize:  ds.Size,
 		MaxEntries: 1,
-		Flags:      unix.BPF_F_RDONLY_PROG | unix.BPF_F_MMAPABLE,
+		Flags:      unix.BPF_F_RDONLY_PROG,
 		Freeze:     true,
 		Key:        &btf.Int{Size: 4},
 		Value:      ds,

--- a/elf_reader_test.go
+++ b/elf_reader_test.go
@@ -586,8 +586,9 @@ func TestKconfigKernelVersion(t *testing.T) {
 			Main *Program `ebpf:"kernel_version"`
 		}
 
+		testutils.SkipOnOldKernel(t, "5.2", "readonly maps")
+
 		err = spec.LoadAndAssign(&obj, nil)
-		testutils.SkipIfNotSupported(t, err)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
We don't need to set the MMAPABLE flag on .kconfig section since the library never mmaps it. This allows using .kconfig on kernel
>=5.2 instead of >=5.5.