### PR TITLE
CI: test against 6.1

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -16,8 +16,8 @@ blocks:
       prologue:
         commands:
           - sudo sh -c 'swapoff -a && fallocate -l 2G /swapfile && chmod 0600 /swapfile && mkswap /swapfile && swapon /swapfile'
-          - sudo mkdir -p /usr/local/golang/1.21.0 && curl -fL "https://go.dev/dl/go1.21.0.linux-amd64.tar.gz" | sudo tar -xz -C /usr/local/golang/1.21.0
-          - sem-version go 1.21.0
+          - sudo mkdir -p /usr/local/golang/1.21.1 && curl -fL "https://go.dev/dl/go1.21.1.linux-amd64.tar.gz" | sudo tar -xz -C /usr/local/golang/1.21.1
+          - sem-version go 1.21.1
           - export PATH="$PATH:$(go env GOPATH)/bin"
           - checkout
           # Disabled, see https://github.com/cilium/ebpf/issues/898
@@ -61,7 +61,7 @@ blocks:
         execution_time_limit:
           minutes: 10
         commands:
-          - sem-version go 1.20.6
+          - sem-version go 1.20.8
           - go test -v ./cmd/bpf2go
           - gotestsum --raw-command --ignore-non-json-output-lines --junitfile junit.xml -- ./run-tests.sh $CI_MAX_KERNEL_VERSION -short -count 1 -json ./...
       - name: Run unit tests

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -38,7 +38,7 @@ blocks:
         - name: TMPDIR
           value: /tmp
         - name: CI_MAX_KERNEL_VERSION
-          value: "5.19"
+          value: "6.1"
         - name: CI_MIN_CLANG_VERSION
           value: "9"
       jobs:
@@ -69,6 +69,6 @@ blocks:
           minutes: 10
         matrix:
           - env_var: KERNEL_VERSION
-            values: ["5.19", "5.15", "5.10", "5.4", "4.19", "4.14", "4.9"]
+            values: ["6.1", "5.15", "5.10", "5.4", "4.19", "4.14", "4.9"]
         commands:
           - gotestsum --raw-command --ignore-non-json-output-lines --junitfile junit.xml -- ./run-tests.sh $KERNEL_VERSION -short -count 1 -json ./...

--- a/elf_reader_test.go
+++ b/elf_reader_test.go
@@ -985,14 +985,11 @@ func TestLibBPFCompat(t *testing.T) {
 			t.Skip("Skipping due to possible bug in upstream CO-RE generation")
 		case "test_usdt", "test_urandom_usdt", "test_usdt_multispec":
 			t.Skip("Skipping due to missing support for usdt.bpf.h")
-		case "bpf_cubic", "bpf_iter_tcp6", "bpf_iter_tcp4",
-			"bpf_iter_ipv6_route", "test_subskeleton_lib", "test_skeleton",
-			"test_subskeleton", "test_core_extern",
+		case "lsm_cgroup", "bpf_iter_ipv6_route", "test_core_extern",
 			"profiler1", "profiler2", "profiler3":
-			t.Skip("Skipping due to using CONFIG_* variable which are not supported at the moment")
-		case "lsm_cgroup":
 			t.Skip("Skipping due to using weak CONFIG_* variables")
-		case "linked_maps1", "linked_maps2", "linked_funcs1", "linked_funcs2":
+		case "linked_maps1", "linked_maps2", "linked_funcs1", "linked_funcs2",
+			"test_subskeleton", "test_subskeleton_lib":
 			t.Skip("Skipping due to relying on cross ELF linking")
 		}
 


### PR DESCRIPTION
CI: update to latest Go point releases

    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>

CI: test against 6.1

    Replace 5.19 with 6.1 as the latest kernel we test against. This requires
    updating the libbpf integration tests. In v6.1 the selftest build system
    started adding a .bpf suffix to all object files containing BPF programs.
    Introduce a helper selftestName so that we only have to deal with this in a
    single place. This also allows taking care of the .linked[123] suffixes
    which have made some of the test skipping code overly verbose.

    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>

elf: update libbpf integration tests

    We now support CONFIG_* variables, so update the integration tests 
    accordingly.

    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>
