### PR TITLE
btf: work around missing ENUM64 support

### DIFF
--- a/btf/btf.go
+++ b/btf/btf.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/cilium/ebpf/internal"
 	"github.com/cilium/ebpf/internal/sys"
-	"github.com/cilium/ebpf/internal/unix"
 )
 
 const btfMagic = 0xeB9F
@@ -772,98 +771,4 @@ func (iter *TypesIterator) Next() bool {
 	iter.Type = iter.types[iter.index]
 	iter.index++
 	return true
-}
-
-// haveBTF attempts to load a BTF blob containing an Int. It should pass on any
-// kernel that supports BPF_BTF_LOAD.
-var haveBTF = internal.NewFeatureTest("BTF", "4.18", func() error {
-	// 0-length anonymous integer
-	err := probeBTF(&Int{})
-	if errors.Is(err, unix.EINVAL) || errors.Is(err, unix.EPERM) {
-		return internal.ErrNotSupported
-	}
-	return err
-})
-
-// haveMapBTF attempts to load a minimal BTF blob containing a Var. It is
-// used as a proxy for .bss, .data and .rodata map support, which generally
-// come with a Var and Datasec. These were introduced in Linux 5.2.
-var haveMapBTF = internal.NewFeatureTest("Map BTF (Var/Datasec)", "5.2", func() error {
-	if err := haveBTF(); err != nil {
-		return err
-	}
-
-	v := &Var{
-		Name: "a",
-		Type: &Pointer{(*Void)(nil)},
-	}
-
-	err := probeBTF(v)
-	if errors.Is(err, unix.EINVAL) || errors.Is(err, unix.EPERM) {
-		// Treat both EINVAL and EPERM as not supported: creating the map may still
-		// succeed without Btf* attrs.
-		return internal.ErrNotSupported
-	}
-	return err
-})
-
-// haveProgBTF attempts to load a BTF blob containing a Func and FuncProto. It
-// is used as a proxy for ext_info (func_info) support, which depends on
-// Func(Proto) by definition.
-var haveProgBTF = internal.NewFeatureTest("Program BTF (func/line_info)", "5.0", func() error {
-	if err := haveBTF(); err != nil {
-		return err
-	}
-
-	fn := &Func{
-		Name: "a",
-		Type: &FuncProto{Return: (*Void)(nil)},
-	}
-
-	err := probeBTF(fn)
-	if errors.Is(err, unix.EINVAL) || errors.Is(err, unix.EPERM) {
-		return internal.ErrNotSupported
-	}
-	return err
-})
-
-var haveFuncLinkage = internal.NewFeatureTest("BTF func linkage", "5.6", func() error {
-	if err := haveProgBTF(); err != nil {
-		return err
-	}
-
-	fn := &Func{
-		Name:    "a",
-		Type:    &FuncProto{Return: (*Void)(nil)},
-		Linkage: GlobalFunc,
-	}
-
-	err := probeBTF(fn)
-	if errors.Is(err, unix.EINVAL) {
-		return internal.ErrNotSupported
-	}
-	return err
-})
-
-func probeBTF(typ Type) error {
-	b, err := NewBuilder([]Type{typ})
-	if err != nil {
-		return err
-	}
-
-	buf, err := b.Marshal(nil, nil)
-	if err != nil {
-		return err
-	}
-
-	fd, err := sys.BtfLoad(&sys.BtfLoadAttr{
-		Btf:     sys.NewSlicePointer(buf),
-		BtfSize: uint32(len(buf)),
-	})
-
-	if err == nil {
-		fd.Close()
-	}
-
-	return err
 }

--- a/btf/btf_test.go
+++ b/btf/btf_test.go
@@ -364,22 +364,6 @@ func TestSpecTypeByID(t *testing.T) {
 	qt.Assert(t, err, qt.ErrorIs, ErrNotFound)
 }
 
-func TestHaveBTF(t *testing.T) {
-	testutils.CheckFeatureTest(t, haveBTF)
-}
-
-func TestHaveMapBTF(t *testing.T) {
-	testutils.CheckFeatureTest(t, haveMapBTF)
-}
-
-func TestHaveProgBTF(t *testing.T) {
-	testutils.CheckFeatureTest(t, haveProgBTF)
-}
-
-func TestHaveFuncLinkage(t *testing.T) {
-	testutils.CheckFeatureTest(t, haveFuncLinkage)
-}
-
 func ExampleSpec_TypeByName() {
 	// Acquire a Spec via one of its constructors.
 	spec := new(Spec)

--- a/btf/feature.go
+++ b/btf/feature.go
@@ -2,6 +2,7 @@ package btf
 
 import (
 	"errors"
+	"math"
 
 	"github.com/cilium/ebpf/internal"
 	"github.com/cilium/ebpf/internal/sys"
@@ -73,6 +74,25 @@ var haveFuncLinkage = internal.NewFeatureTest("BTF func linkage", "5.6", func() 
 	}
 
 	err := probeBTF(fn)
+	if errors.Is(err, unix.EINVAL) {
+		return internal.ErrNotSupported
+	}
+	return err
+})
+
+var haveEnum64 = internal.NewFeatureTest("ENUM64", "6.0", func() error {
+	if err := haveBTF(); err != nil {
+		return err
+	}
+
+	enum := &Enum{
+		Size: 8,
+		Values: []EnumValue{
+			{"TEST", math.MaxUint32 + 1},
+		},
+	}
+
+	err := probeBTF(enum)
 	if errors.Is(err, unix.EINVAL) {
 		return internal.ErrNotSupported
 	}

--- a/btf/feature.go
+++ b/btf/feature.go
@@ -1,0 +1,103 @@
+package btf
+
+import (
+	"errors"
+
+	"github.com/cilium/ebpf/internal"
+	"github.com/cilium/ebpf/internal/sys"
+	"github.com/cilium/ebpf/internal/unix"
+)
+
+// haveBTF attempts to load a BTF blob containing an Int. It should pass on any
+// kernel that supports BPF_BTF_LOAD.
+var haveBTF = internal.NewFeatureTest("BTF", "4.18", func() error {
+	// 0-length anonymous integer
+	err := probeBTF(&Int{})
+	if errors.Is(err, unix.EINVAL) || errors.Is(err, unix.EPERM) {
+		return internal.ErrNotSupported
+	}
+	return err
+})
+
+// haveMapBTF attempts to load a minimal BTF blob containing a Var. It is
+// used as a proxy for .bss, .data and .rodata map support, which generally
+// come with a Var and Datasec. These were introduced in Linux 5.2.
+var haveMapBTF = internal.NewFeatureTest("Map BTF (Var/Datasec)", "5.2", func() error {
+	if err := haveBTF(); err != nil {
+		return err
+	}
+
+	v := &Var{
+		Name: "a",
+		Type: &Pointer{(*Void)(nil)},
+	}
+
+	err := probeBTF(v)
+	if errors.Is(err, unix.EINVAL) || errors.Is(err, unix.EPERM) {
+		// Treat both EINVAL and EPERM as not supported: creating the map may still
+		// succeed without Btf* attrs.
+		return internal.ErrNotSupported
+	}
+	return err
+})
+
+// haveProgBTF attempts to load a BTF blob containing a Func and FuncProto. It
+// is used as a proxy for ext_info (func_info) support, which depends on
+// Func(Proto) by definition.
+var haveProgBTF = internal.NewFeatureTest("Program BTF (func/line_info)", "5.0", func() error {
+	if err := haveBTF(); err != nil {
+		return err
+	}
+
+	fn := &Func{
+		Name: "a",
+		Type: &FuncProto{Return: (*Void)(nil)},
+	}
+
+	err := probeBTF(fn)
+	if errors.Is(err, unix.EINVAL) || errors.Is(err, unix.EPERM) {
+		return internal.ErrNotSupported
+	}
+	return err
+})
+
+var haveFuncLinkage = internal.NewFeatureTest("BTF func linkage", "5.6", func() error {
+	if err := haveProgBTF(); err != nil {
+		return err
+	}
+
+	fn := &Func{
+		Name:    "a",
+		Type:    &FuncProto{Return: (*Void)(nil)},
+		Linkage: GlobalFunc,
+	}
+
+	err := probeBTF(fn)
+	if errors.Is(err, unix.EINVAL) {
+		return internal.ErrNotSupported
+	}
+	return err
+})
+
+func probeBTF(typ Type) error {
+	b, err := NewBuilder([]Type{typ})
+	if err != nil {
+		return err
+	}
+
+	buf, err := b.Marshal(nil, nil)
+	if err != nil {
+		return err
+	}
+
+	fd, err := sys.BtfLoad(&sys.BtfLoadAttr{
+		Btf:     sys.NewSlicePointer(buf),
+		BtfSize: uint32(len(buf)),
+	})
+
+	if err == nil {
+		fd.Close()
+	}
+
+	return err
+}

--- a/btf/feature_test.go
+++ b/btf/feature_test.go
@@ -1,0 +1,23 @@
+package btf
+
+import (
+	"testing"
+
+	"github.com/cilium/ebpf/internal/testutils"
+)
+
+func TestHaveBTF(t *testing.T) {
+	testutils.CheckFeatureTest(t, haveBTF)
+}
+
+func TestHaveMapBTF(t *testing.T) {
+	testutils.CheckFeatureTest(t, haveMapBTF)
+}
+
+func TestHaveProgBTF(t *testing.T) {
+	testutils.CheckFeatureTest(t, haveProgBTF)
+}
+
+func TestHaveFuncLinkage(t *testing.T) {
+	testutils.CheckFeatureTest(t, haveFuncLinkage)
+}

--- a/btf/feature_test.go
+++ b/btf/feature_test.go
@@ -21,3 +21,7 @@ func TestHaveProgBTF(t *testing.T) {
 func TestHaveFuncLinkage(t *testing.T) {
 	testutils.CheckFeatureTest(t, haveFuncLinkage)
 }
+
+func TestHaveEnum64(t *testing.T) {
+	testutils.CheckFeatureTest(t, haveEnum64)
+}

--- a/btf/types.go
+++ b/btf/types.go
@@ -278,21 +278,6 @@ func (e *Enum) copy() Type {
 	return &cpy
 }
 
-// has64BitValues returns true if the Enum contains a value larger than 32 bits.
-// Kernels before 6.0 have enum values that overrun u32 replaced with zeroes.
-//
-// 64-bit enums have their Enum.Size attributes correctly set to 8, but if we
-// use the size attribute as a heuristic during BTF marshaling, we'll emit
-// ENUM64s to kernels that don't support them.
-func (e *Enum) has64BitValues() bool {
-	for _, v := range e.Values {
-		if v.Value > math.MaxUint32 {
-			return true
-		}
-	}
-	return false
-}
-
 // FwdKind is the type of forward declaration.
 type FwdKind int
 


### PR DESCRIPTION
btf: move feature tests to separate file

    No other changes intended.

    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>

btf: add feature test for BTF_KIND_ENUM64

    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>

btf: work around missing ENUM64 support on older kernels

    Replace an ENUM64 with a 64-bit integer on kernels which don't support the
    former. This behaviour is similar to libbpf, which replaces the ENUM64 with
    a union instead.

    Remove the old heuristic which encoded a 64-bit enum as a 32-bit enum if
    none of the values exceeded math.MaxUint32. The heuristic has no tests and
    doesn't take the signedness of the enum into account.

    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>

Fixes #1116