### PR TITLE
Fix typo in the internal struct name

### DIFF
--- a/btf/core.go
+++ b/btf/core.go
@@ -889,7 +889,7 @@ func CheckTypeCompatibility(localType Type, targetType Type) error {
 func coreAreTypesCompatible(localType Type, targetType Type) error {
 
 	var (
-		localTs, targetTs typeDeque
+		localTs, targetTs typeDequeue
 		l, t              = &localType, &targetType
 		depth             = 0
 	)

--- a/btf/marshal.go
+++ b/btf/marshal.go
@@ -32,7 +32,7 @@ func KernelMarshalOptions() *MarshalOptions {
 type encoder struct {
 	MarshalOptions
 
-	pending internal.Deque[Type]
+	pending internal.Dequeue[Type]
 	buf     *bytes.Buffer
 	strings *stringTableBuilder
 	ids     map[Type]TypeID

--- a/btf/traversal.go
+++ b/btf/traversal.go
@@ -16,9 +16,9 @@ type postorderIterator struct {
 	root Type
 
 	// Contains types which need to be either walked or yielded.
-	types typeDeque
+	types typeDequeue
 	// Contains a boolean whether the type has been walked or not.
-	walked internal.Deque[bool]
+	walked internal.Dequeue[bool]
 	// The set of types which has been pushed onto types.
 	pushed map[Type]struct{}
 

--- a/btf/types.go
+++ b/btf/types.go
@@ -712,7 +712,7 @@ func copyTypes(types []Type, transform Transformer) []Type {
 
 type copier struct {
 	copies map[Type]Type
-	work   typeDeque
+	work   typeDequeue
 }
 
 func (c *copier) copy(typ *Type, transform Transformer) {
@@ -738,7 +738,7 @@ func (c *copier) copy(typ *Type, transform Transformer) {
 	}
 }
 
-type typeDeque = internal.Deque[*Type]
+type typeDequeue = internal.Dequeue[*Type]
 
 // inflateRawTypes takes a list of raw btf types linked via type IDs, and turns
 // it into a graph of Types connected via pointers.

--- a/btf/types_test.go
+++ b/btf/types_test.go
@@ -473,7 +473,7 @@ func BenchmarkWalk(b *testing.B) {
 			b.ReportAllocs()
 
 			for i := 0; i < b.N; i++ {
-				var dq typeDeque
+				var dq typeDequeue
 				walkType(typ, dq.Push)
 			}
 		})

--- a/cmd/bpf2go/main.go
+++ b/cmd/bpf2go/main.go
@@ -105,7 +105,7 @@ type bpf2go struct {
 	// C flags passed to the compiler.
 	cFlags          []string
 	skipGlobalTypes bool
-	// C types to include in the generatd output.
+	// C types to include in the generated output.
 	cTypes cTypes
 	// Build tags to be included in the output.
 	tags buildTags

--- a/internal/dequeue.go
+++ b/internal/dequeue.go
@@ -2,15 +2,15 @@ package internal
 
 import "math/bits"
 
-// Deque implements a double ended queue.
-type Deque[T any] struct {
+// Dequeue implements a double ended queue.
+type Dequeue[T any] struct {
 	elems       []T
 	read, write uint64
 	mask        uint64
 }
 
-// Reset clears the contents of the deque while retaining the backing buffer.
-func (dq *Deque[T]) Reset() {
+// Reset clears the contents of the dequeue while retaining the backing buffer.
+func (dq *Dequeue[T]) Reset() {
 	var zero T
 
 	for i := dq.read; i < dq.write; i++ {
@@ -20,19 +20,19 @@ func (dq *Deque[T]) Reset() {
 	dq.read, dq.write = 0, 0
 }
 
-func (dq *Deque[T]) Empty() bool {
+func (dq *Dequeue[T]) Empty() bool {
 	return dq.read == dq.write
 }
 
 // Push adds an element to the end.
-func (dq *Deque[T]) Push(e T) {
+func (dq *Dequeue[T]) Push(e T) {
 	dq.Grow(1)
 	dq.elems[dq.write&dq.mask] = e
 	dq.write++
 }
 
 // Shift returns the first element or the zero value.
-func (dq *Deque[T]) Shift() T {
+func (dq *Dequeue[T]) Shift() T {
 	var zero T
 
 	if dq.Empty() {
@@ -47,7 +47,7 @@ func (dq *Deque[T]) Shift() T {
 }
 
 // Pop returns the last element or the zero value.
-func (dq *Deque[T]) Pop() T {
+func (dq *Dequeue[T]) Pop() T {
 	var zero T
 
 	if dq.Empty() {
@@ -61,9 +61,9 @@ func (dq *Deque[T]) Pop() T {
 	return t
 }
 
-// Grow the deque's capacity, if necessary, to guarantee space for another n
+// Grow the dequeue's capacity, if necessary, to guarantee space for another n
 // elements.
-func (dq *Deque[T]) Grow(n int) {
+func (dq *Dequeue[T]) Grow(n int) {
 	have := dq.write - dq.read
 	need := have + uint64(n)
 	if need < have {

--- a/internal/dequeue_test.go
+++ b/internal/dequeue_test.go
@@ -2,9 +2,9 @@ package internal
 
 import "testing"
 
-func TestDeque(t *testing.T) {
+func TestDequeue(t *testing.T) {
 	t.Run("pop", func(t *testing.T) {
-		var dq Deque[int]
+		var dq Dequeue[int]
 		dq.Push(1)
 		dq.Push(2)
 
@@ -22,7 +22,7 @@ func TestDeque(t *testing.T) {
 	})
 
 	t.Run("shift", func(t *testing.T) {
-		var td Deque[int]
+		var td Dequeue[int]
 		td.Push(1)
 		td.Push(2)
 
@@ -40,7 +40,7 @@ func TestDeque(t *testing.T) {
 	})
 
 	t.Run("push", func(t *testing.T) {
-		var td Deque[int]
+		var td Dequeue[int]
 		td.Push(1)
 		td.Push(2)
 		td.Shift()
@@ -60,7 +60,7 @@ func TestDeque(t *testing.T) {
 	})
 
 	t.Run("grow", func(t *testing.T) {
-		var td Deque[int]
+		var td Dequeue[int]
 		td.Push(1)
 		td.Push(2)
 		td.Push(3)


### PR DESCRIPTION
This PR corrected the typo in the `dequeue`.