### PR TITLE
btf: clean up some small things

### DIFF
--- a/btf/btf.go
+++ b/btf/btf.go
@@ -46,7 +46,7 @@ type Spec struct {
 	// Includes all struct flavors and types with the same name.
 	namedTypes map[essentialName][]Type
 
-	// String table from ELF, may be nil.
+	// String table from ELF.
 	strings *stringTable
 
 	// Byte order of the ELF we decoded the spec from, may be nil.
@@ -225,10 +225,6 @@ func loadRawSpec(btf io.ReaderAt, bo binary.ByteOrder, base *Spec) (*Spec, error
 	if base != nil {
 		if base.firstTypeID != 0 {
 			return nil, fmt.Errorf("can't use split BTF as base")
-		}
-
-		if base.strings == nil {
-			return nil, fmt.Errorf("parse split BTF: base must be loaded from an ELF")
 		}
 
 		baseStrings = base.strings

--- a/btf/btf.go
+++ b/btf/btf.go
@@ -79,18 +79,6 @@ func (h *btfHeader) stringStart() int64 {
 	return int64(h.HdrLen + h.StringOff)
 }
 
-// newSpec creates a Spec containing only Void.
-func newSpec() *Spec {
-	return &Spec{
-		[]Type{(*Void)(nil)},
-		map[Type]TypeID{(*Void)(nil): 0},
-		0,
-		make(map[essentialName][]Type),
-		nil,
-		nil,
-	}
-}
-
 // LoadSpec opens file and calls LoadSpecFromReader on it.
 func LoadSpec(file string) (*Spec, error) {
 	fh, err := os.Open(file)

--- a/btf/btf_test.go
+++ b/btf/btf_test.go
@@ -357,10 +357,12 @@ func TestSpecCopy(t *testing.T) {
 }
 
 func TestSpecTypeByID(t *testing.T) {
-	_, err := newSpec().TypeByID(0)
+	spec := specFromTypes(t, nil)
+
+	_, err := spec.TypeByID(0)
 	qt.Assert(t, err, qt.IsNil)
 
-	_, err = newSpec().TypeByID(1)
+	_, err = spec.TypeByID(1)
 	qt.Assert(t, err, qt.ErrorIs, ErrNotFound)
 }
 

--- a/btf/btf_types.go
+++ b/btf/btf_types.go
@@ -2,9 +2,12 @@ package btf
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"unsafe"
+
+	"github.com/cilium/ebpf/internal"
 )
 
 //go:generate stringer -linecomment -output=btf_types_string.go -type=FuncLinkage,VarLinkage,btfKind
@@ -68,6 +71,63 @@ const (
 	btfTypeKindFlagShift = 31
 	btfTypeKindFlagMask  = 1
 )
+
+var btfHeaderLen = binary.Size(&btfHeader{})
+
+type btfHeader struct {
+	Magic   uint16
+	Version uint8
+	Flags   uint8
+	HdrLen  uint32
+
+	TypeOff   uint32
+	TypeLen   uint32
+	StringOff uint32
+	StringLen uint32
+}
+
+// typeStart returns the offset from the beginning of the .BTF section
+// to the start of its type entries.
+func (h *btfHeader) typeStart() int64 {
+	return int64(h.HdrLen + h.TypeOff)
+}
+
+// stringStart returns the offset from the beginning of the .BTF section
+// to the start of its string table.
+func (h *btfHeader) stringStart() int64 {
+	return int64(h.HdrLen + h.StringOff)
+}
+
+// parseBTFHeader parses the header of the .BTF section.
+func parseBTFHeader(r io.Reader, bo binary.ByteOrder) (*btfHeader, error) {
+	var header btfHeader
+	if err := binary.Read(r, bo, &header); err != nil {
+		return nil, fmt.Errorf("can't read header: %v", err)
+	}
+
+	if header.Magic != btfMagic {
+		return nil, fmt.Errorf("incorrect magic value %v", header.Magic)
+	}
+
+	if header.Version != 1 {
+		return nil, fmt.Errorf("unexpected version %v", header.Version)
+	}
+
+	if header.Flags != 0 {
+		return nil, fmt.Errorf("unsupported flags %v", header.Flags)
+	}
+
+	remainder := int64(header.HdrLen) - int64(binary.Size(&header))
+	if remainder < 0 {
+		return nil, errors.New("header length shorter than btfHeader size")
+	}
+
+	if _, err := io.CopyN(internal.DiscardZeroes{}, r, remainder); err != nil {
+		return nil, fmt.Errorf("header padding: %v", err)
+	}
+
+	return &header, nil
+}
 
 var btfTypeLen = binary.Size(btfType{})
 

--- a/btf/fuzz_test.go
+++ b/btf/fuzz_test.go
@@ -56,8 +56,6 @@ func FuzzExtInfo(f *testing.F) {
 	}
 	f.Add(buf.Bytes(), []byte("\x00foo\x00barfoo\x00"))
 
-	emptySpec := specFromTypes(f, nil)
-
 	f.Fuzz(func(t *testing.T, data, strings []byte) {
 		if len(data) < binary.Size(btfExtHeader{}) {
 			t.Skip("data is too short")
@@ -68,7 +66,10 @@ func FuzzExtInfo(f *testing.F) {
 			t.Skip("invalid string table")
 		}
 
-		info, err := loadExtInfos(bytes.NewReader(data), internal.NativeEndian, emptySpec, table)
+		emptySpec := specFromTypes(t, nil)
+		emptySpec.strings = table
+
+		info, err := loadExtInfos(bytes.NewReader(data), internal.NativeEndian, emptySpec)
 		if err != nil {
 			if info != nil {
 				t.Fatal("info is not nil")

--- a/btf/fuzz_test.go
+++ b/btf/fuzz_test.go
@@ -56,7 +56,7 @@ func FuzzExtInfo(f *testing.F) {
 	}
 	f.Add(buf.Bytes(), []byte("\x00foo\x00barfoo\x00"))
 
-	emptySpec := newSpec()
+	emptySpec := specFromTypes(f, nil)
 
 	f.Fuzz(func(t *testing.T, data, strings []byte) {
 		if len(data) < binary.Size(btfExtHeader{}) {

--- a/btf/marshal_test.go
+++ b/btf/marshal_test.go
@@ -201,3 +201,13 @@ func marshalNativeEndian(tb testing.TB, types []Type) []byte {
 	qt.Assert(tb, err, qt.IsNil)
 	return buf
 }
+
+func specFromTypes(tb testing.TB, types []Type) *Spec {
+	tb.Helper()
+
+	btf := marshalNativeEndian(tb, types)
+	spec, err := loadRawSpec(bytes.NewReader(btf), internal.NativeEndian, nil)
+	qt.Assert(tb, err, qt.IsNil)
+
+	return spec
+}

--- a/btf/marshal_test.go
+++ b/btf/marshal_test.go
@@ -79,15 +79,6 @@ func TestRoundtripVMlinux(t *testing.T) {
 		types[i+1], types[j+1] = types[j+1], types[i+1]
 	})
 
-	// Skip per CPU datasec, see https://github.com/cilium/ebpf/issues/921
-	for i, typ := range types {
-		if ds, ok := typ.(*Datasec); ok && ds.Name == ".data..percpu" {
-			types[i] = types[len(types)-1]
-			types = types[:len(types)-1]
-			break
-		}
-	}
-
 	seen := make(map[Type]bool)
 limitTypes:
 	for i, typ := range types {

--- a/btf/types_test.go
+++ b/btf/types_test.go
@@ -1,12 +1,9 @@
 package btf
 
 import (
-	"bytes"
 	"fmt"
 	"reflect"
 	"testing"
-
-	"github.com/cilium/ebpf/internal"
 
 	qt "github.com/frankban/quicktest"
 	"github.com/google/go-cmp/cmp"
@@ -240,10 +237,7 @@ func TestTagMarshaling(t *testing.T) {
 		&typeTag{&Int{}, "foo"},
 	} {
 		t.Run(fmt.Sprint(typ), func(t *testing.T) {
-			buf := marshalNativeEndian(t, []Type{typ})
-
-			s, err := loadRawSpec(bytes.NewReader(buf), internal.NativeEndian, nil)
-			qt.Assert(t, err, qt.IsNil)
+			s := specFromTypes(t, []Type{typ})
 
 			have, err := s.TypeByID(1)
 			qt.Assert(t, err, qt.IsNil)


### PR DESCRIPTION
These commits have languished in a branch of mine for a while. I think they're good to go in on their own.

btf: remove newSpec

    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>

btf: Spec.strings can't be nil anymore

    Spec always has a string table now that NewSpec is not a thing anymore.

    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>

btf: move btfHeader to btf_types.go

    Move btfHeader so that all btf* types live in the same file. This reduces
    the size of btf.go as well.

    No other changes intended.

    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>

btf: don't skip per-CPU datasec in tests anymore

    There is an upstream fix and we have a workaround for the Datasec issue. 
    Don't skip it in tests anymore.

    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>

btf: use slices.BinarySearch when reading a string table

    Reading a string table uses a custom function to search a []uint32 since
    that made a measurable difference back in time. Instead of copying the
    implementation we can now use the generic slices.BinarySearch.

    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>
