### PR TITLE
Update bpf2go and stringer go:generate statements across the codebase

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ container-all:
 		--env CFLAGS="-fdebug-prefix-map=/ebpf=." \
 		--env HOME="/tmp" \
 		"${IMAGE}:${VERSION}" \
-		make all
+		make BPF2GO_CC="$(CLANG)" BPF2GO_FLAGS="$(CFLAGS)" all
 
 # (debug) Drop the user into a shell inside the container as root.
 container-shell:
@@ -81,9 +81,6 @@ all: format $(addsuffix -el.elf,$(TARGETS)) $(addsuffix -eb.elf,$(TARGETS)) gene
 	ln -srf testdata/loader-$(CLANG)-el.elf testdata/loader-el.elf
 	ln -srf testdata/loader-$(CLANG)-eb.elf testdata/loader-eb.elf
 
-# $BPF_CLANG is used in go:generate invocations.
-generate: export BPF_CLANG := $(CLANG)
-generate: export BPF_CFLAGS := $(CFLAGS)
 generate:
 	go generate ./...
 

--- a/asm/alu.go
+++ b/asm/alu.go
@@ -1,6 +1,6 @@
 package asm
 
-//go:generate stringer -output alu_string.go -type=Source,Endianness,ALUOp
+//go:generate go run golang.org/x/tools/cmd/stringer@latest -output alu_string.go -type=Source,Endianness,ALUOp
 
 // Source of ALU / ALU64 / Branch operations
 //

--- a/asm/func.go
+++ b/asm/func.go
@@ -1,6 +1,6 @@
 package asm
 
-//go:generate stringer -output func_string.go -type=BuiltinFunc
+//go:generate go run golang.org/x/tools/cmd/stringer@latest -output func_string.go -type=BuiltinFunc
 
 // BuiltinFunc is a built-in eBPF function.
 type BuiltinFunc int32

--- a/asm/jump.go
+++ b/asm/jump.go
@@ -1,6 +1,6 @@
 package asm
 
-//go:generate stringer -output jump_string.go -type=JumpOp
+//go:generate go run golang.org/x/tools/cmd/stringer@latest -output jump_string.go -type=JumpOp
 
 // JumpOp affect control flow.
 //

--- a/asm/load_store.go
+++ b/asm/load_store.go
@@ -1,6 +1,6 @@
 package asm
 
-//go:generate stringer -output load_store_string.go -type=Mode,Size
+//go:generate go run golang.org/x/tools/cmd/stringer@latest -output load_store_string.go -type=Mode,Size
 
 // Mode for load and store operations
 //

--- a/asm/opcode.go
+++ b/asm/opcode.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 )
 
-//go:generate stringer -output opcode_string.go -type=Class
+//go:generate go run golang.org/x/tools/cmd/stringer@latest -output opcode_string.go -type=Class
 
 // Class of operations
 //

--- a/btf/btf_types.go
+++ b/btf/btf_types.go
@@ -7,7 +7,7 @@ import (
 	"unsafe"
 )
 
-//go:generate stringer -linecomment -output=btf_types_string.go -type=FuncLinkage,VarLinkage,btfKind
+//go:generate go run golang.org/x/tools/cmd/stringer@latest -linecomment -output=btf_types_string.go -type=FuncLinkage,VarLinkage,btfKind
 
 // btfKind describes a Type.
 type btfKind uint8

--- a/cmd/bpf2go/README.md
+++ b/cmd/bpf2go/README.md
@@ -15,13 +15,18 @@ This will emit `foo_bpfel.go` and `foo_bpfeb.go`, with types using `foo`
 as a stem. The two files contain compiled BPF for little and big
 endian systems, respectively.
 
+## Environment Variables
+
 You can use environment variables to affect all bpf2go invocations
 across a project, e.g. to set specific C flags:
 
-    //go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cflags "$BPF_CFLAGS" foo path/to/src.c
+    BPF2GO_FLAGS="-O2 -g -Wall -Werror $(CFLAGS)" go generate ./...
 
-By exporting `$BPF_CFLAGS` from your build system you can then control
-all builds from a single location.
+Alternatively, by exporting `$BPF2GO_FLAGS` from your build system, you can
+control all builds from a single location.
+
+Most bpf2go arguments can be controlled this way. See `bpf2go -h` for an
+up-to-date list.
 
 ## Generated types
 

--- a/cmd/bpf2go/test/doc.go
+++ b/cmd/bpf2go/test/doc.go
@@ -2,5 +2,4 @@
 // specific API.
 package test
 
-// $BPF_CLANG and $BPF_CFLAGS are set by the Makefile.
-//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc $BPF_CLANG test ../testdata/minimal.c
+//go:generate go run github.com/cilium/ebpf/cmd/bpf2go test ../testdata/minimal.c

--- a/examples/cgroup_skb/main.go
+++ b/examples/cgroup_skb/main.go
@@ -17,8 +17,7 @@ import (
 	"github.com/cilium/ebpf/rlimit"
 )
 
-// $BPF_CLANG and $BPF_CFLAGS are set by the Makefile.
-//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc $BPF_CLANG -cflags $BPF_CFLAGS bpf cgroup_skb.c -- -I../headers
+//go:generate go run github.com/cilium/ebpf/cmd/bpf2go bpf cgroup_skb.c -- -I../headers
 
 func main() {
 	// Allow the current process to lock memory for eBPF resources.

--- a/examples/fentry/main.go
+++ b/examples/fentry/main.go
@@ -28,8 +28,7 @@ import (
 	"github.com/cilium/ebpf/rlimit"
 )
 
-// $BPF_CLANG and $BPF_CFLAGS are set by the Makefile.
-//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc $BPF_CLANG -cflags $BPF_CFLAGS -type event bpf fentry.c -- -I../headers
+//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -type event bpf fentry.c -- -I../headers
 
 func main() {
 	stopper := make(chan os.Signal, 1)

--- a/examples/kprobe/main.go
+++ b/examples/kprobe/main.go
@@ -12,8 +12,7 @@ import (
 	"github.com/cilium/ebpf/rlimit"
 )
 
-// $BPF_CLANG and $BPF_CFLAGS are set by the Makefile.
-//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc $BPF_CLANG -cflags $BPF_CFLAGS bpf kprobe.c -- -I../headers
+//go:generate go run github.com/cilium/ebpf/cmd/bpf2go bpf kprobe.c -- -I../headers
 
 const mapKey uint32 = 0
 

--- a/examples/kprobe_percpu/main.go
+++ b/examples/kprobe_percpu/main.go
@@ -12,8 +12,7 @@ import (
 	"github.com/cilium/ebpf/rlimit"
 )
 
-// $BPF_CLANG and $BPF_CFLAGS are set by the Makefile.
-//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc $BPF_CLANG -cflags $BPF_CFLAGS bpf kprobe_percpu.c -- -I../headers
+//go:generate go run github.com/cilium/ebpf/cmd/bpf2go bpf kprobe_percpu.c -- -I../headers
 
 const mapKey uint32 = 0
 

--- a/examples/kprobepin/main.go
+++ b/examples/kprobepin/main.go
@@ -15,8 +15,7 @@ import (
 	"github.com/cilium/ebpf/rlimit"
 )
 
-// $BPF_CLANG and $BPF_CFLAGS are set by the Makefile.
-//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc $BPF_CLANG -cflags $BPF_CFLAGS bpf kprobe_pin.c -- -I../headers
+//go:generate go run github.com/cilium/ebpf/cmd/bpf2go bpf kprobe_pin.c -- -I../headers
 
 const (
 	mapKey    uint32 = 0

--- a/examples/ringbuffer/main.go
+++ b/examples/ringbuffer/main.go
@@ -15,8 +15,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// $BPF_CLANG and $BPF_CFLAGS are set by the Makefile.
-//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc $BPF_CLANG -cflags $BPF_CFLAGS -type event bpf ringbuffer.c -- -I../headers
+//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -type event bpf ringbuffer.c -- -I../headers
 
 func main() {
 	// Name of the kernel function to trace.

--- a/examples/tcprtt/main.go
+++ b/examples/tcprtt/main.go
@@ -30,8 +30,7 @@ import (
 	"github.com/cilium/ebpf/rlimit"
 )
 
-// $BPF_CLANG and $BPF_CFLAGS are set by the Makefile.
-//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc $BPF_CLANG -cflags $BPF_CFLAGS -type event bpf tcprtt.c -- -I../headers
+//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -type event bpf tcprtt.c -- -I../headers
 
 func main() {
 	stopper := make(chan os.Signal, 1)

--- a/examples/tcprtt_sockops/main.go
+++ b/examples/tcprtt_sockops/main.go
@@ -40,8 +40,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// $BPF_CLANG and $BPF_CFLAGS are set by the Makefile.
-//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -tags "linux" -cc $BPF_CLANG -cflags $BPF_CFLAGS -type rtt_event bpf tcprtt_sockops.c -- -I../headers
+//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -tags "linux" -type rtt_event bpf tcprtt_sockops.c -- -I../headers
 
 func main() {
 	stopper := make(chan os.Signal, 1)

--- a/examples/tracepoint_in_c/main.go
+++ b/examples/tracepoint_in_c/main.go
@@ -12,8 +12,7 @@ import (
 	"github.com/cilium/ebpf/rlimit"
 )
 
-// $BPF_CLANG and $BPF_CFLAGS are set by the Makefile.
-//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc $BPF_CLANG -cflags $BPF_CFLAGS bpf tracepoint.c -- -I../headers
+//go:generate go run github.com/cilium/ebpf/cmd/bpf2go bpf tracepoint.c -- -I../headers
 
 const mapKey uint32 = 0
 

--- a/examples/uretprobe/main.go
+++ b/examples/uretprobe/main.go
@@ -21,8 +21,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// $BPF_CLANG and $BPF_CFLAGS are set by the Makefile.
-//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc $BPF_CLANG -cflags $BPF_CFLAGS -target amd64 -type event bpf uretprobe.c -- -I../headers
+//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -target amd64 -type event bpf uretprobe.c -- -I../headers
 
 const (
 	// The path to the ELF binary containing the function to trace.

--- a/examples/xdp/main.go
+++ b/examples/xdp/main.go
@@ -20,8 +20,7 @@ import (
 	"github.com/cilium/ebpf/link"
 )
 
-// $BPF_CLANG and $BPF_CFLAGS are set by the Makefile.
-//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc $BPF_CLANG -cflags $BPF_CFLAGS bpf xdp.c -- -I../headers
+//go:generate go run github.com/cilium/ebpf/cmd/bpf2go bpf xdp.c -- -I../headers
 
 func main() {
 	if len(os.Args) < 2 {

--- a/internal/sys/syscall.go
+++ b/internal/sys/syscall.go
@@ -123,7 +123,7 @@ type TypeID uint32
 // MapFlags control map behaviour.
 type MapFlags uint32
 
-//go:generate stringer -type MapFlags
+//go:generate go run golang.org/x/tools/cmd/stringer@latest -type MapFlags
 
 const (
 	BPF_F_NO_PREALLOC MapFlags = 1 << iota

--- a/internal/tracefs/kprobe.go
+++ b/internal/tracefs/kprobe.go
@@ -20,7 +20,7 @@ var (
 	ErrInvalidMaxActive = errors.New("can only set maxactive on kretprobes")
 )
 
-//go:generate stringer -type=ProbeType -linecomment
+//go:generate go run golang.org/x/tools/cmd/stringer@latest -type=ProbeType -linecomment
 
 type ProbeType uint8
 

--- a/types.go
+++ b/types.go
@@ -5,7 +5,7 @@ import (
 	"github.com/cilium/ebpf/internal/unix"
 )
 
-//go:generate stringer -output types_string.go -type=MapType,ProgramType,PinType
+//go:generate go run golang.org/x/tools/cmd/stringer@latest -output types_string.go -type=MapType,ProgramType,PinType
 
 // MapType indicates the type map structure
 // that will be initialized in the kernel.
@@ -158,7 +158,7 @@ const (
 // Will cause invalid argument (EINVAL) at program load time if set incorrectly.
 type AttachType uint32
 
-//go:generate stringer -type AttachType -trimprefix Attach
+//go:generate go run golang.org/x/tools/cmd/stringer@latest -type AttachType -trimprefix Attach
 
 // AttachNone is an alias for AttachCGroupInetIngress for readability reasons.
 const AttachNone AttachType = 0


### PR DESCRIPTION
https://github.com/cilium/ebpf/pull/1047 added env support to bpf2go, so use it.

Also cleaned up the stringer statements that would otherwise pick an old version from my GOBIN.