### PR TITLE
dependabot: add configuration, ignore indirect Python dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/docs"
+    schedule:
+      interval: "weekly"
+    allow:
+      # Only manage direct dependencies in Pipfile, ignore transient
+      # dependencies only appearing in Pipfile.lock.
+      - dependency-name: "*"
+        dependency-type: "direct"


### PR DESCRIPTION
What it says on the tin. We immediately got slapped with a dependabot PR after merging the documentation. Ignore security vulnerabilities in transient dependencies, we're only interested in keeping up with direct dependencies since Python code is only run during documentation build.