### PR TITLE
sys: small cleanups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,10 +105,9 @@ testdata/loader-%-eb.elf: testdata/loader.c
 generate-btf: KERNEL_VERSION?=6.1.29
 generate-btf:
 	$(eval TMP := $(shell mktemp -d))
-	curl -fL "$(CI_KERNEL_URL)/linux-$(KERNEL_VERSION).bz" -o "$(TMP)/bzImage"
-	/lib/modules/$(uname -r)/build/scripts/extract-vmlinux "$(TMP)/bzImage" > "$(TMP)/vmlinux"
+	curl -fL "$(CI_KERNEL_URL)/linux-$(KERNEL_VERSION)-amd64.tgz" -o "$(TMP)/linux.tgz"
+	tar xvf "$(TMP)/linux.tgz" -C "$(TMP)" --strip-components=2 ./boot/vmlinuz ./lib/modules
+	/lib/modules/$(shell uname -r)/build/scripts/extract-vmlinux "$(TMP)/vmlinuz" > "$(TMP)/vmlinux"
 	$(OBJCOPY) --dump-section .BTF=/dev/stdout "$(TMP)/vmlinux" /dev/null | gzip > "btf/testdata/vmlinux.btf.gz"
-	curl -fL "$(CI_KERNEL_URL)/linux-$(KERNEL_VERSION)-selftests-bpf.tgz" -o "$(TMP)/selftests.tgz"
-	tar -xf "$(TMP)/selftests.tgz" --to-stdout tools/testing/selftests/bpf/bpf_testmod/bpf_testmod.ko | \
-		$(OBJCOPY) --dump-section .BTF="btf/testdata/btf_testmod.btf" - /dev/null
+	find "$(TMP)/modules" -type f -name bpf_testmod.ko -exec $(OBJCOPY) --dump-section .BTF="btf/testdata/btf_testmod.btf" {} /dev/null \;
 	$(RM) -r "$(TMP)"

--- a/internal/sys/syscall.go
+++ b/internal/sys/syscall.go
@@ -11,7 +11,7 @@ import (
 // ENOTSUPP is a Linux internal error code that has leaked into UAPI.
 //
 // It is not the same as ENOTSUP or EOPNOTSUPP.
-var ENOTSUPP = syscall.Errno(524)
+const ENOTSUPP = syscall.Errno(524)
 
 // BPF wraps SYS_BPF.
 //


### PR DESCRIPTION
Makefile: fix generate-btf

    My recent changes to the kernel packaging format broke the generate-btf 
    target. Fix the invocation to work against current builds.

    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>

internal/cmd/gentypes: print more helpful error when patch fails

    Output the struct being patched just before showing the patch error. This
    makes it easier to figure out how the patch went wrong. Example output:

      struct BtfInfo
       Struct:"bpf_btf_info"[fields=6]
         "btf" Int[unsigned size=64]
         "btf_size" Typedef:"__u32"[Int:"unsigned int"]
         "id" Typedef:"__u32"[Int:"unsigned int"]
         "name" Int[unsigned size=64]
         "name_len" Typedef:"__u32"[Int:"unsigned int"]
         "kernel_btf" Typedef:"__u32"[Int:"unsigned int"]
     Error: output "BtfInfo": patch 1: missing members: frood

    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>

sys: make ENOTSUPP a constant

    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>
