### PR TITLE
collection: Freeze map right before prog load

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -517,6 +517,13 @@ func (cl *collectionLoader) loadProgram(progName string) (*Program, error) {
 		if err := ins.AssociateMap(m); err != nil {
 			return nil, fmt.Errorf("program %s: map %s: %w", progName, ins.Reference(), err)
 		}
+
+		mapSpec := cl.coll.Maps[m.name]
+		if mapSpec.Freeze {
+			if err := m.finalize(mapSpec); err != nil {
+				return nil, fmt.Errorf("populating map %s: %w", m.name, err)
+			}
+		}
 	}
 
 	prog, err := newProgramWithOptions(progSpec, cl.opts.Programs)

--- a/map.go
+++ b/map.go
@@ -79,6 +79,8 @@ type MapSpec struct {
 
 	// The key and value type of this map. May be nil.
 	Key, Value btf.Type
+
+	freezed bool
 }
 
 func (ms *MapSpec) String() string {
@@ -1209,6 +1211,10 @@ func (m *Map) Freeze() error {
 // finalize populates the Map according to the Contents specified
 // in spec and freezes the Map if requested by spec.
 func (m *Map) finalize(spec *MapSpec) error {
+	if spec.freezed {
+		return nil
+	}
+
 	for _, kv := range spec.Contents {
 		if err := m.Put(kv.Key, kv.Value); err != nil {
 			return fmt.Errorf("putting value: key %v: %w", kv.Key, err)
@@ -1219,6 +1225,7 @@ func (m *Map) finalize(spec *MapSpec) error {
 		if err := m.Freeze(); err != nil {
 			return fmt.Errorf("freezing map: %w", err)
 		}
+		spec.freezed = true
 	}
 
 	return nil


### PR DESCRIPTION
If freeze is requested, let's do that right before prog load. The freeze property would aid the verifier process at prog load ([0]).

  [0]: https://github.com/cilium/ebpf/discussions/1143