### PR TITLE
docs: copy shorthands to clipboard in getting-started

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   - package-ecosystem: "pip"
     directory: "/docs"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     allow:
       # Only manage direct dependencies in Pipfile, ignore transient
       # dependencies only appearing in Pipfile.lock.

--- a/docs/Pipfile
+++ b/docs/Pipfile
@@ -6,13 +6,13 @@ name = "pypi"
 [packages]
 mkdocs = "*"
 pymdown-extensions = "*"
-mkdocs-material = "9.4.3"
+mkdocs-material = "*"
 mkdocs-macros-plugin = "*"
 mkdocs-git-revision-date-localized-plugin = "*"
 mkdocs-git-authors-plugin = "*"
 
 [dev-packages]
 
-# Whatever Netlify's Ubuntu version uses.
 [requires]
+# Whatever Netlify's Ubuntu version uses.
 python_version = "3.8"

--- a/docs/Pipfile.lock
+++ b/docs/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "3996cc6b420d076240e6ff80f516cd05feaf4d5cd51af99f0b73c1d9ad1ee5a6"
+            "sha256": "7fdc85c0382ce4d85cc6b25bb2aec19714c29f6c688841be8bf66245550e5749"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -311,12 +311,12 @@
         },
         "mkdocs-material": {
             "hashes": [
-                "sha256:3274a47a4e55a541b25bd8fa4937cf3f3c82a51763453511661e0052062758b9",
-                "sha256:5c9abc3f6ba8f88be1f9f13df23d695ca4dddbdd8a3538e4e6279c055c3936bc"
+                "sha256:86fe79253afccc7f085f89a2d8e9e3300f82c4813d9b910d9081ce57a7e68380",
+                "sha256:ab84a7cfaf009c47cd2926cdd7e6040b8cc12c3806cc533e8b16d57bd16d9c47"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.8'",
-            "version": "==9.4.3"
+            "version": "==9.4.4"
         },
         "mkdocs-material-extensions": {
             "hashes": [

--- a/docs/ebpf/guides/getting-started.md
+++ b/docs/ebpf/guides/getting-started.md
@@ -137,7 +137,7 @@ write to get up and running.
 Before using the Go toolchain, Go wants us to declare a Go module. This command
 should take care of that:
 
-```shell-session
+```{ .shell-session data-copy="go mod init ebpf-test && go mod tidy" }
 % go mod init ebpf-test
 go: creating new go.mod: module ebpf-test
 go: to add module requirements and sums:
@@ -148,7 +148,7 @@ go: to add module requirements and sums:
 We also need to manually add a dependency on `bpf2go` since it's not explicitly
 imported by a `.go` source file:
 
-```shell-session
+```{ .shell-session data-copy="go get github.com/cilium/ebpf/cmd/bpf2go" }
 % go get github.com/cilium/ebpf/cmd/bpf2go
 go: added github.com/cilium/ebpf v0.11.0
 go: added golang.org/x/exp v0.0.0-20230224173230-c95f2b4c22f2
@@ -157,7 +157,7 @@ go: added golang.org/x/sys v0.6.0
 
 Now we're ready to run `go generate`: 
 
-```shell-session
+```{ .shell-session data-copy="go generate" }
 % go generate
 Compiled /home/timo/getting_started/counter_bpfel.o
 Stripped /home/timo/getting_started/counter_bpfel.o
@@ -231,7 +231,7 @@ Save this file as `main.go` in the same directory alongside `counter.c` and
 
 Now `main.go` is in place, we can finally compile and run our Go application!
 
-```shell-session
+```{ .shell-session data-copy="go build && sudo ./ebpf-test" }
 % go build && sudo ./ebpf-test
 2023/09/20 17:18:43 Counting incoming packets on eth0..
 2023/09/20 17:18:47 Received 0 packets
@@ -248,7 +248,7 @@ When iterating on the C code, make sure to keep generated files up-to-date.
 Without re-running bpf2go, the eBPF C won't be recompiled, and any changes made
 to the C program structure won't be reflected in the Go scaffolding.
 
-```shell-session
+```{ .shell-session data-copy="go generate && go build && sudo ./ebpf-test" }
 % go generate && go build && sudo ./ebpf-test
 ```
 


### PR DESCRIPTION
No longer copy the whole snippet including output.