### PR TITLE
CI: tidy up golangci-lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,9 @@ jobs:
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v3.7.0
+        with:
+          args: "--out-format colored-line-number"
+          skip-pkg-cache: true
 
       - name: Generate and format code
         run: |

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,11 +1,4 @@
 ---
-issues:
-  exclude-rules:
-    # syscall param structs will have unused fields in Go code.
-    - path: syscall.*.go
-      linters:
-        - structcheck
-
 linters:
   disable-all: true
   enable:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -9,7 +9,6 @@ issues:
 linters:
   disable-all: true
   enable:
-    - errcheck
     - goimports
     - gosimple
     - govet
@@ -19,8 +18,3 @@ linters:
     - typecheck
     - unused
     - gofmt
-
-    # Could be enabled later:
-    # - gocyclo
-    # - maligned
-    # - gosec


### PR DESCRIPTION
CI: output line numbers from golangci-lint

    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>

CI: remove errcheck linter

    The errcheck linter causes too many false positives to be useful. For
    example, running the upstream errcheck binary flags a ton of
    "unchecked" defer Close() calls which are probably filtered out by
    golangci-lint.

    As an appeal to authority, Cilium proper doesn't have errcheck enabled
    either. And the author of the high quality staticcheck has said that
    implementing errcheck without a high false positive rate is not possible.

    Just disable the linter.

    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>

CI: remove obsolete structcheck rules

    structcheck was obsoleted a while ago. Remove the obsolete exclude rules.

    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>
