### PR TITLE
Add Remaining and Size to perf/ring Record

### DIFF
--- a/perf/ring.go
+++ b/perf/ring.go
@@ -127,6 +127,7 @@ func createPerfEvent(cpu, watermark int, overwritable bool) (int, error) {
 type ringReader interface {
 	loadHead()
 	size() int
+	remaining() int
 	writeTail()
 	Read(p []byte) (int, error)
 }
@@ -155,6 +156,10 @@ func (rr *forwardReader) loadHead() {
 
 func (rr *forwardReader) size() int {
 	return len(rr.ring)
+}
+
+func (rr *forwardReader) remaining() int {
+	return int((rr.head - rr.tail) & rr.mask)
 }
 
 func (rr *forwardReader) writeTail() {
@@ -242,6 +247,12 @@ func (rr *reverseReader) loadHead() {
 
 func (rr *reverseReader) size() int {
 	return len(rr.ring)
+}
+
+func (rr *reverseReader) remaining() int {
+	// remaining data is inaccurate for overwritable buffers
+	// once an overwrite happens, so return -1 here.
+	return -1
 }
 
 func (rr *reverseReader) writeTail() {

--- a/ringbuf/reader.go
+++ b/ringbuf/reader.go
@@ -44,6 +44,9 @@ func (rh *ringbufHeader) dataLen() int {
 
 type Record struct {
 	RawSample []byte
+
+	// The minimum number of bytes remaining in the ring buffer after this Record has been read.
+	Remaining int
 }
 
 // Read a record from an event ring.
@@ -98,6 +101,7 @@ func readRecord(rd *ringbufEventRing, rec *Record, buf []byte) error {
 
 	rd.storeConsumer()
 	rec.RawSample = rec.RawSample[:header.dataLen()]
+	rec.Remaining = rd.remaining()
 	return nil
 }
 
@@ -230,4 +234,9 @@ func (r *Reader) ReadInto(rec *Record) error {
 			return err
 		}
 	}
+}
+
+// BufferSize returns the size in bytes of the ring buffer
+func (r *Reader) BufferSize() int {
+	return r.ring.size()
 }

--- a/ringbuf/ring.go
+++ b/ringbuf/ring.go
@@ -98,6 +98,17 @@ func (rr *ringReader) isEmpty() bool {
 	return prod == cons
 }
 
+func (rr *ringReader) size() int {
+	return cap(rr.ring)
+}
+
+func (rr *ringReader) remaining() int {
+	cons := atomic.LoadUint64(rr.cons_pos)
+	prod := atomic.LoadUint64(rr.prod_pos)
+
+	return int((prod - cons) & rr.mask)
+}
+
 func (rr *ringReader) Read(p []byte) (int, error) {
 	prod := atomic.LoadUint64(rr.prod_pos)
 


### PR DESCRIPTION
This allows tracking utilization of the underlying buffers. Processing the values to make sense in a user's monitoring system is left to the user. 

Using the post-read remaining bytes allows the value to reach zero, whereas a pre-read value would never reach zero.