### PR TITLE
perf: clarify purpose of the package

### DIFF
--- a/perf/doc.go
+++ b/perf/doc.go
@@ -1,6 +1,5 @@
-// Package perf allows interacting with Linux perf_events.
+// Package perf allows reading from BPF perf event arrays.
 //
-// BPF allows submitting custom perf_events to a ring-buffer set up
-// by userspace. This is very useful to push things like packet samples
-// from BPF to a daemon running in user space.
+// A perf event array contains multiple perf event ringbuffers which can be used
+// to exchange sample like data with user space.
 package perf


### PR DESCRIPTION
Update the doc comment to make it clear that the package is only really about reading from PerfEventArray.