### PR TITLE
btf: some inflateRawTypes simplifications

### DIFF
--- a/btf/core.go
+++ b/btf/core.go
@@ -799,7 +799,7 @@ func coreFindMember(typ composite, name string) (Member, bool, error) {
 		if visited[target] {
 			continue
 		}
-		if len(visited) >= maxTypeDepth {
+		if len(visited) >= maxResolveDepth {
 			// This check is different than libbpf, which restricts the entire
 			// path to BPF_CORE_SPEC_MAX_LEN items.
 			return Member{}, false, fmt.Errorf("type is nested too deep")
@@ -895,7 +895,7 @@ func coreAreTypesCompatible(localType Type, targetType Type) error {
 	)
 
 	for ; l != nil && t != nil; l, t = localTs.Shift(), targetTs.Shift() {
-		if depth >= maxTypeDepth {
+		if depth >= maxResolveDepth {
 			return errors.New("types are nested too deep")
 		}
 

--- a/btf/core_test.go
+++ b/btf/core_test.go
@@ -652,7 +652,7 @@ func TestCORECopyWithoutQualifiers(t *testing.T) {
 		rng := testutils.Rand(t)
 		root := &Int{Name: "abc"}
 		v := Type(root)
-		for i := 0; i < maxTypeDepth; i++ {
+		for i := 0; i < maxResolveDepth; i++ {
 			q := qualifiers[rng.Intn(len(qualifiers))]
 			v = q.fn(v)
 			t.Log(q.name)

--- a/btf/format.go
+++ b/btf/format.go
@@ -118,7 +118,7 @@ func (gf *GoFormatter) writeType(typ Type, depth int) error {
 //	uint32
 func (gf *GoFormatter) writeTypeLit(typ Type, depth int) error {
 	depth++
-	if depth > maxTypeDepth {
+	if depth > maxResolveDepth {
 		return errNestedTooDeep
 	}
 
@@ -265,7 +265,7 @@ func (gf *GoFormatter) writeStructField(m Member, depth int) error {
 		}
 
 		depth++
-		if depth > maxTypeDepth {
+		if depth > maxResolveDepth {
 			return errNestedTooDeep
 		}
 
@@ -338,7 +338,7 @@ func (gf *GoFormatter) writePadding(bytes uint32) {
 
 func skipQualifiers(typ Type) Type {
 	result := typ
-	for depth := 0; depth <= maxTypeDepth; depth++ {
+	for depth := 0; depth <= maxResolveDepth; depth++ {
 		switch v := (result).(type) {
 		case qualifier:
 			result = v.qualify()

--- a/btf/types.go
+++ b/btf/types.go
@@ -12,7 +12,9 @@ import (
 	"github.com/cilium/ebpf/internal/sys"
 )
 
-const maxTypeDepth = 32
+// Mirrors MAX_RESOLVE_DEPTH in libbpf.
+// https://github.com/libbpf/libbpf/blob/e26b84dc330c9644c07428c271ab491b0f01f4e1/src/btf.c#L761
+const maxResolveDepth = 32
 
 // TypeID identifies a type in a BTF section.
 type TypeID = sys.TypeID
@@ -589,7 +591,7 @@ func Sizeof(typ Type) (int, error) {
 		elem int64
 	)
 
-	for i := 0; i < maxTypeDepth; i++ {
+	for i := 0; i < maxResolveDepth; i++ {
 		switch v := typ.(type) {
 		case *Array:
 			if n > 0 && int64(v.Nelems) > math.MaxInt64/n {
@@ -1096,7 +1098,7 @@ func newEssentialName(name string) essentialName {
 // UnderlyingType skips qualifiers and Typedefs.
 func UnderlyingType(typ Type) Type {
 	result := typ
-	for depth := 0; depth <= maxTypeDepth; depth++ {
+	for depth := 0; depth <= maxResolveDepth; depth++ {
 		switch v := (result).(type) {
 		case qualifier:
 			result = v.qualify()
@@ -1115,7 +1117,7 @@ func UnderlyingType(typ Type) Type {
 // Returns the zero value and false if there is no T or if the type is nested
 // too deeply.
 func as[T Type](typ Type) (T, bool) {
-	for depth := 0; depth <= maxTypeDepth; depth++ {
+	for depth := 0; depth <= maxResolveDepth; depth++ {
 		switch v := (typ).(type) {
 		case T:
 			return v, true


### PR DESCRIPTION
btf: remove fixupAndAssert

    fixupAndAssert in inflateRawTypes is used to assert that a Type value has a
    certain concrete type. The only use is validating that Func.Type is a
    FuncProto so that a later check of Func.Type can type assert without error
    checking. This is a bad idea since understanding why the assertion is safe 
    now requires understanding how types are inflated.

    Remove fixupAndAssert and instead check for errors during the type
    assertion.

    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>

btf: rename maxTypeDepth to maxResolveDepth

    Rename the constant and document where it originates. The previous name is
    misleading since vmlinux BTF does contain types which are nested more deeply
    than 32 items at the moment.

    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>
