### PR TITLE
docs: improve Makefile UX with pipenv sync

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -12,11 +12,17 @@ preview: pipenv
 	pipenv run mkdocs serve
 
 shell: pipenv
-	pipenv shell
+	@echo "pipenv shell"
+	@exec pipenv shell
 
 pipenv:
 ifeq (, $(shell command -v pipenv 2> /dev/null))
 $(error "pipenv is not installed, exiting..")
 endif
+
+	@# Ensure a venv and install dependencies from Pipfile.lock. Buffer stdio
+	@# and display it on error as pipenv uses stdin and stderr arbitrarily.
+	@echo "pipenv sync"
+	@out=`pipenv sync 2>&1` || echo "$${out}"
 
 .PHONY: pipenv


### PR DESCRIPTION
Include 'pipenv sync' in the 'pipenv' make target to get the behaviour documented in the README.

Also adds an `exec` to the 'shell' target to avoid an error from make when the shell exits. Also, no need to keep make running during a shell session.