### PR TITLE
btf: stop accessing Spec.types from tests

### DIFF
--- a/btf/btf_test.go
+++ b/btf/btf_test.go
@@ -336,22 +336,24 @@ func TestGuessBTFByteOrder(t *testing.T) {
 
 func TestSpecCopy(t *testing.T) {
 	spec := parseELFBTF(t, "../testdata/loader-el.elf")
-
-	if len(spec.types) < 1 {
-		t.Fatal("Not enough types")
-	}
-
 	cpy := spec.Copy()
-	for i := range cpy.types {
-		if _, ok := cpy.types[i].(*Void); ok {
+
+	have := typesFromSpec(t, spec)
+	qt.Assert(t, len(spec.types) > 0, qt.IsTrue)
+
+	want := typesFromSpec(t, cpy)
+	qt.Assert(t, want, qt.HasLen, len(have))
+
+	for i := range want {
+		if _, ok := have[i].(*Void); ok {
 			// Since Void is an empty struct, a Type interface value containing
 			// &Void{} stores (*Void, nil). Since interface equality first compares
 			// the type and then the concrete value, Void is always equal.
 			continue
 		}
 
-		if cpy.types[i] == spec.types[i] {
-			t.Fatalf("Type at index %d is not a copy: %T == %T", i, cpy.types[i], spec.types[i])
+		if have[i] == want[i] {
+			t.Fatalf("Type at index %d is not a copy: %T == %T", i, have[i], want[i])
 		}
 	}
 }

--- a/btf/marshal_test.go
+++ b/btf/marshal_test.go
@@ -71,7 +71,7 @@ func TestBuilderAdd(t *testing.T) {
 }
 
 func TestRoundtripVMlinux(t *testing.T) {
-	types := vmlinuxSpec(t).types
+	types := typesFromSpec(t, vmlinuxSpec(t))
 
 	// Randomize the order to force different permutations of walking the type
 	// graph. Keep Void at index 0.
@@ -153,8 +153,7 @@ func TestMarshalEnum64(t *testing.T) {
 }
 
 func BenchmarkMarshaler(b *testing.B) {
-	spec := vmlinuxTestdataSpec(b)
-	types := spec.types[:100]
+	types := typesFromSpec(b, vmlinuxTestdataSpec(b))[:100]
 
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -169,7 +168,7 @@ func BenchmarkMarshaler(b *testing.B) {
 }
 
 func BenchmarkBuildVmlinux(b *testing.B) {
-	types := vmlinuxTestdataSpec(b).types
+	types := typesFromSpec(b, vmlinuxTestdataSpec(b))
 
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -201,4 +200,16 @@ func specFromTypes(tb testing.TB, types []Type) *Spec {
 	qt.Assert(tb, err, qt.IsNil)
 
 	return spec
+}
+
+func typesFromSpec(tb testing.TB, spec *Spec) []Type {
+	tb.Helper()
+
+	var types []Type
+	iter := spec.Iterate()
+	for iter.Next() {
+		types = append(types, iter.Type)
+	}
+
+	return types
 }


### PR DESCRIPTION
Spec.types is going away, so refactor tests to use an iterator to read all
types instead.

Updates #1068