### PR TITLE
btf: support both elf and raw BTF in loadKernelSpec

### DIFF
--- a/btf/btf.go
+++ b/btf/btf.go
@@ -322,12 +322,12 @@ func loadKernelSpec() (_ *Spec, fallback bool, _ error) {
 	}
 	defer file.Close()
 
-	spec, err := loadSpecFromELF(file)
+	spec, err := LoadSpecFromReader(file)
 	return spec, true, err
 }
 
 // findVMLinux scans multiple well-known paths for vmlinux kernel images.
-func findVMLinux() (*internal.SafeELFFile, error) {
+func findVMLinux() (*os.File, error) {
 	release, err := internal.KernelRelease()
 	if err != nil {
 		return nil, err
@@ -346,7 +346,7 @@ func findVMLinux() (*internal.SafeELFFile, error) {
 	}
 
 	for _, loc := range locations {
-		file, err := internal.OpenSafeELFFile(fmt.Sprintf(loc, release))
+		file, err := os.Open(fmt.Sprintf(loc, release))
 		if errors.Is(err, os.ErrNotExist) {
 			continue
 		}

--- a/btf/btf_test.go
+++ b/btf/btf_test.go
@@ -251,7 +251,7 @@ func TestFindVMLinux(t *testing.T) {
 	}
 	defer file.Close()
 
-	spec, err := loadSpecFromELF(file)
+	spec, err := LoadSpecFromReader(file)
 	if err != nil {
 		t.Fatal("Can't load BTF:", err)
 	}


### PR DESCRIPTION
We use the cilium ebpf library in some old centos 4.18 kernel and the btf file generated by phaloe tools for CO-RE，the error occurs as like "apply CO-RE relocations: bad magic number '[159 235 1 0]' in record at byte 0x0", since the btf file we used is raw format when the cilium ebpf library only support parse elf format btf file。

Support both elf and raw BTF parse will make the cilium library be available in old centos 4.18 kernel(centos 8.0 or centos 8.1 kernel).

What's more, I see the libbpf added the same feature: https://github.com/libbpf/libbpf/commit/0420f75dbcf732e3230ae212970b33a80026e225

The similar commit in cilium library: https://github.com/cilium/ebpf/commit/48bf2ba10aee9422c9e7f43836afec0788052658