### PR TITLE
example: fix key type of xdp example

### DIFF
--- a/examples/xdp/main.go
+++ b/examples/xdp/main.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/internal"
 	"github.com/cilium/ebpf/link"
 )
 
@@ -70,12 +71,14 @@ func main() {
 func formatMapContents(m *ebpf.Map) (string, error) {
 	var (
 		sb  strings.Builder
-		key []byte
+		key uint32
 		val uint32
 	)
 	iter := m.Iterate()
 	for iter.Next(&key, &val) {
-		sourceIP := net.IP(key) // IPv4 source address in network byte order.
+		b := make([]byte, 4)
+		internal.NativeEndian.PutUint32(b, key)
+		sourceIP := net.IP(b) // IPv4 source address in network byte order.
 		packetCount := val
 		sb.WriteString(fmt.Sprintf("\t%s => %d\n", sourceIP, packetCount))
 	}

--- a/examples/xdp/main.go
+++ b/examples/xdp/main.go
@@ -12,12 +12,12 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"net/netip"
 	"os"
 	"strings"
 	"time"
 
 	"github.com/cilium/ebpf"
-	"github.com/cilium/ebpf/internal"
 	"github.com/cilium/ebpf/link"
 )
 
@@ -71,14 +71,12 @@ func main() {
 func formatMapContents(m *ebpf.Map) (string, error) {
 	var (
 		sb  strings.Builder
-		key uint32
+		key netip.Addr
 		val uint32
 	)
 	iter := m.Iterate()
 	for iter.Next(&key, &val) {
-		b := make([]byte, 4)
-		internal.NativeEndian.PutUint32(b, key)
-		sourceIP := net.IP(b) // IPv4 source address in network byte order.
+		sourceIP := key // IPv4 source address in network byte order.
 		packetCount := val
 		sb.WriteString(fmt.Sprintf("\t%s => %d\n", sourceIP, packetCount))
 	}


### PR DESCRIPTION
The IP address output by [xdp demo](https://github.com/cilium/ebpf/tree/main/examples/xdp) is empty. Although it can be solved by directly changing the `key` type to `netip.Addr` after go1.18 version, I still use a more general way to fix it.
Issue: #1175