### PR TITLE
PinType: change from int to uint32

### DIFF
--- a/types.go
+++ b/types.go
@@ -219,7 +219,7 @@ const (
 type AttachFlags uint32
 
 // PinType determines whether a map is pinned into a BPFFS.
-type PinType int
+type PinType uint32
 
 // Valid pin types.
 //

--- a/types_string.go
+++ b/types_string.go
@@ -111,7 +111,7 @@ const _PinType_name = "PinNonePinByName"
 var _PinType_index = [...]uint8{0, 7, 16}
 
 func (i PinType) String() string {
-	if i < 0 || i >= PinType(len(_PinType_index)-1) {
+	if i >= PinType(len(_PinType_index)-1) {
 		return "PinType(" + strconv.FormatInt(int64(i), 10) + ")"
 	}
 	return _PinType_name[_PinType_index[i]:_PinType_index[i+1]]


### PR DESCRIPTION
For supporting custom pinning behaviours in Cilium, we're looking to extend the MapSpec.Pinning flag and treat it as a bitfield internally. libbpf and ebpf-go currently only support LIBBPF_PIN_BY_NAME and ebpf.PinByName respectively, which has a value of 1, so it's still up in the air whether or not this could officially evolve into a bitfield in the future, since doing so can be done while maintaining backwards compatibility.

In Cilium's case, we reserve the lower 4 bits for the upstream enum values and mask out the remaining bits before calling NewCollection. The upper bits are used for specifying flags to request specific behaviours, e.g. to ignore a pinned map during loading, and explicitly overwriting its pin at a later stage, when the entrypoint program(s) were successfully attached. Useful for working with prog arrays that need to remain pinned.

We want to keep using the existing ebpf.PinType type for this, but defining masks using a signed type needs to be done with care, so ideally PinType would be unsigned.

A few more data points on why this change is warranted:

- bpf_elf_map always had 'unsigned int' fields only, including 'pinning'
- libbpf reads the BTF map def 'pinning' field into a __u32
- Realistically, `enum libbpf_pin_type` will not acquire any negative values