### PR TITLE
sysenc: special case unmarshaling into []byte

### DIFF
--- a/internal/sysenc/marshal.go
+++ b/internal/sysenc/marshal.go
@@ -11,6 +11,8 @@ import (
 	"unsafe"
 
 	"github.com/cilium/ebpf/internal"
+
+	"golang.org/x/exp/slices"
 )
 
 // Marshal turns data into a byte slice using the system's native endianness.
@@ -86,6 +88,11 @@ func Unmarshal(data interface{}, buf []byte) error {
 
 	case *string:
 		*value = string(buf)
+		return nil
+
+	case *[]byte:
+		// Backwards compat: unmarshaling into a slice replaces the whole slice.
+		*value = slices.Clone(buf)
 		return nil
 
 	default:

--- a/map.go
+++ b/map.go
@@ -1411,11 +1411,7 @@ func (mi *MapIterator) Next(keyOut, valueOut interface{}) bool {
 			return false
 		}
 
-		// The user can get access to nextKey since unmarshalBytes
-		// does not copy when unmarshaling into a []byte.
-		// Make a copy to prevent accidental corruption of
-		// iterator state.
-		copy(mi.curKey, nextKey)
+		mi.curKey = nextKey
 
 		mi.count++
 		mi.err = mi.target.Lookup(nextKey, valueOut)

--- a/map_test.go
+++ b/map_test.go
@@ -75,6 +75,10 @@ func TestMap(t *testing.T) {
 		t.Error("Want value 42, got", v)
 	}
 
+	var slice []byte
+	qt.Assert(t, m.Lookup(uint32(0), &slice), qt.IsNil)
+	qt.Assert(t, slice, qt.DeepEquals, internal.NativeEndian.AppendUint32(nil, 42))
+
 	var k uint32
 	if err := m.NextKey(uint32(0), &k); err != nil {
 		t.Fatal("Can't get:", err)

--- a/map_test.go
+++ b/map_test.go
@@ -48,7 +48,6 @@ func newHash(t *testing.T) *Map {
 
 func TestMap(t *testing.T) {
 	m := createArray(t)
-	defer m.Close()
 
 	t.Log(m)
 
@@ -430,7 +429,6 @@ func TestMapCloneNil(t *testing.T) {
 func TestMapPin(t *testing.T) {
 	m := createArray(t)
 	c := qt.New(t)
-	defer m.Close()
 
 	if err := m.Put(uint32(0), uint32(42)); err != nil {
 		t.Fatal("Can't put:", err)
@@ -557,7 +555,6 @@ func TestMapPinMultiple(t *testing.T) {
 func TestMapPinWithEmptyPath(t *testing.T) {
 	m := createArray(t)
 	c := qt.New(t)
-	defer m.Close()
 
 	err := m.Pin("")
 
@@ -694,7 +691,6 @@ func TestMapLoadPinnedWithOptions(t *testing.T) {
 	testutils.SkipOnOldKernel(t, "4.15", "file_flags in BPF_OBJ_GET")
 
 	array := createArray(t)
-	defer array.Close()
 
 	tmp := testutils.TempBPFFS(t)
 
@@ -780,6 +776,7 @@ func createArray(t *testing.T) *Map {
 	if err != nil {
 		t.Fatal(err)
 	}
+	t.Cleanup(func() { m.Close() })
 	return m
 }
 
@@ -1276,7 +1273,6 @@ func TestIterateMapInMap(t *testing.T) {
 	defer parent.Close()
 
 	a := createArray(t)
-	defer a.Close()
 
 	if err := parent.Put(idx, a); err != nil {
 		t.Fatal(err)
@@ -1529,7 +1525,6 @@ func TestMapName(t *testing.T) {
 
 func TestMapFromFD(t *testing.T) {
 	m := createArray(t)
-	defer m.Close()
 
 	if err := m.Put(uint32(0), uint32(123)); err != nil {
 		t.Fatal(err)
@@ -1597,7 +1592,6 @@ func TestMapContents(t *testing.T) {
 
 func TestMapFreeze(t *testing.T) {
 	arr := createArray(t)
-	defer arr.Close()
 
 	err := arr.Freeze()
 	testutils.SkipIfNotSupported(t, err)

--- a/prog_test.go
+++ b/prog_test.go
@@ -713,7 +713,6 @@ func TestProgramRejectIncorrectByteOrder(t *testing.T) {
 
 func TestProgramSpecTag(t *testing.T) {
 	arr := createArray(t)
-	defer arr.Close()
 
 	spec := &ProgramSpec{
 		Type: SocketFilter,


### PR DESCRIPTION
map: use t.Cleanup in createArray

    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>

sysenc: special case unmarshaling into []byte

    The library has somewhat complicated semantics when unmarshaling map keys
    and values. It turns out that the following was supported
    (but not documented) until the zero-allocation marshaling work broke it:

        var s []byte
       m.Lookup(key, &s)

    The important thing is that the slice here is empty. The current code treats
    this as "the key should be zero length" while originally we'd assign the
    temporary buffer used by the syscall to s as a way to reduce allocations. In
    hindsight this wasn't a great idea, but it is what it is.

    Reintroduce the byte slice special case.

    Fixes https://github.com/cilium/ebpf/issues/1175

    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>
