### PR TITLE
sysenc: refuse to unmarshal into undersized dst

### DIFF
--- a/internal/sysenc/marshal.go
+++ b/internal/sysenc/marshal.go
@@ -99,7 +99,15 @@ func Unmarshal(data interface{}, buf []byte) error {
 
 		rd.Reset(buf)
 
-		return binary.Read(rd, internal.NativeEndian, value)
+		if err := binary.Read(rd, internal.NativeEndian, value); err != nil {
+			return err
+		}
+
+		if rd.Len() != 0 {
+			return fmt.Errorf("unmarshaling %T doesn't consume all data", data)
+		}
+
+		return nil
 	}
 }
 

--- a/map_test.go
+++ b/map_test.go
@@ -227,6 +227,15 @@ func TestBatchAPIHash(t *testing.T) {
 	}
 }
 
+func TestMapLookupKeyTooSmall(t *testing.T) {
+	m := createArray(t)
+	defer m.Close()
+
+	var small uint16
+	qt.Assert(t, m.Put(uint32(0), uint32(1234)), qt.IsNil)
+	qt.Assert(t, m.Lookup(uint32(0), &small), qt.IsNotNil)
+}
+
 func TestBatchAPIMapDelete(t *testing.T) {
 	if err := haveBatchAPI(); err != nil {
 		t.Skipf("batch api not available: %v", err)
@@ -1014,7 +1023,7 @@ func TestIterateEmptyMap(t *testing.T) {
 			entries := m.Iterate()
 
 			var key string
-			var value uint32
+			var value uint64
 			if entries.Next(&key, &value) != false {
 				t.Error("Empty hash should not be iterable")
 			}
@@ -1032,7 +1041,7 @@ func TestIterateEmptyMap(t *testing.T) {
 			m := makeMap(t, mapType)
 			entries := m.Iterate()
 			var key string
-			var value uint32
+			var value uint64
 			for entries.Next(&key, &value) {
 				// Some empty arrays like sockmap don't return any keys.
 			}


### PR DESCRIPTION
Unmarshal currently doesn't check that unmarshaling actually consumes to full buffer. This means that looking uint16 from an uint32 value doesn't return an error.

Fixes https://github.com/cilium/ebpf/issues/1157