### PR TITLE
btf: correct printing size of Int type in bytes

### DIFF
--- a/btf/types.go
+++ b/btf/types.go
@@ -117,7 +117,7 @@ type Int struct {
 }
 
 func (i *Int) Format(fs fmt.State, verb rune) {
-	formatType(fs, verb, i, i.Encoding, "size=", i.Size*8)
+	formatType(fs, verb, i, i.Encoding, "size=", i.Size)
 }
 
 func (i *Int) TypeName() string { return i.Name }

--- a/btf/types_test.go
+++ b/btf/types_test.go
@@ -502,5 +502,5 @@ func ExampleCopy_stripQualifiers() {
 	b := Copy(a, UnderlyingType)
 	// b has Volatile and Typedef removed.
 	fmt.Printf("%3v\n", b)
-	// Output: Pointer[target=Int[unsigned size=16]]
+	// Output: Pointer[target=Int[unsigned size=2]]
 }


### PR DESCRIPTION
It seems OK that the printing size of Int type in bits.

But while printing a struct, like 'struct sk_buff', it seems strange that the printing size units of Int type and Struct/Union type are different:

```
  : offset=1088
  : Union[fields=2]
    size: 4
    csum: offset=0
    csum: Typedef:"__wsum"[Typedef:"__u32"]
      __wsum: Typedef:"__u32"[Int:"unsigned int"]
        __u32: Int:"unsigned int"[unsigned size=32]
    : offset=0
    : Struct[fields=2]
  priority: offset=1120
  priority: Typedef:"__u32"[Int:"unsigned int"]
    __u32: Int:"unsigned int"[unsigned size=32]
```

So, it's better to make the printing size of Int type in bytes same as Struct/Union type.