### PR TITLE
Fix nil input to starting key of batch lookup

### DIFF
--- a/map.go
+++ b/map.go
@@ -974,7 +974,8 @@ func (m *Map) batchLookup(cmd sys.Cmd, startKey, nextKeyOut, keysOut, valuesOut 
 	}
 
 	var err error
-	if startKey != nil {
+	startKeyValue := reflect.ValueOf(startKey)
+	if startKey != nil && (startKeyValue != reflect.Value{} && !startKeyValue.IsNil()) {
 		attr.InBatch, err = marshalMapSyscallInput(startKey, int(m.keySize))
 		if err != nil {
 			return 0, err


### PR DESCRIPTION
Batch lookup requires the caller to provide the starting key
(`startKey`) from which the lookup begins. In order to perform a batch
lookup from the very beginning of the map, it is expected to pass a nil
`startKey`. Due to the type of `startKey` being `interface{}`, this
means that it's possible for the value of `startKey` to have a concrete
type T, but contain a nil value.

For example, let's say the concrete type T is an *int.

```
func dumpAll[T comparable](m *Map, startKey, key *T) (count int, err error) {
    ...
    m.batchLookup(..., startKey, ...)
    ...
}

dumpAll(m, nil, new(int))
```

The first call to `dumpAll()` must pass nil to `startKey`. When it
reaches `(*Map).batchLookup()`, `startKey` becomes a _non-nil_
`interface{}` with an underlying concrete type of `*int`, whose value
_is_ nil.

This is problematic because `startKey != nil` evaluates to true and the
call to `marshalMapSyscallInput()` expects `startKey` to contain a
non-nil value.

This commit fixes this by checking whether the underlying value of the
interface contains a non-nil value.

Signed-off-by: Chris Tarazi <chris@isovalent.com>
