### PR TITLE
elf: skip local_kptr_stash libbpf test

### DIFF
--- a/elf_reader_test.go
+++ b/elf_reader_test.go
@@ -1025,7 +1025,7 @@ func TestLibBPFCompat(t *testing.T) {
 			t.Skip("Skipping since weak relocations are not supported")
 		case "bloom_filter_map", "bloom_filter_bench":
 			t.Skip("Skipping due to missing MapExtra field in MapSpec")
-		case "netif_receive_skb":
+		case "netif_receive_skb", "local_kptr_stash":
 			t.Skip("Skipping due to possible bug in upstream CO-RE generation")
 		case "test_usdt", "test_urandom_usdt", "test_usdt_multispec":
 			t.Skip("Skipping due to missing support for usdt.bpf.h")


### PR DESCRIPTION
Seems like there is something funny going on with clang emitting the wrong immediate into the instruction stream.

See https://lore.kernel.org/bpf/CAN+4W8i=7Wv2VwvWZGhX_mc8E7EST10X_Z5XGBmq=WckusG_fw@mail.gmail.com/