### PR TITLE
small speedups during elf loading

### DIFF
--- a/btf/ext_info.go
+++ b/btf/ext_info.go
@@ -556,21 +556,21 @@ func LoadLineInfos(reader io.Reader, bo binary.ByteOrder, recordNum uint32, spec
 	return newLineInfos(lis, spec.strings)
 }
 
-func newLineInfo(li bpfLineInfo, strings *stringTable) (*lineInfo, error) {
+func newLineInfo(li bpfLineInfo, strings *stringTable) (lineInfo, error) {
 	line, err := strings.Lookup(li.LineOff)
 	if err != nil {
-		return nil, fmt.Errorf("lookup of line: %w", err)
+		return lineInfo{}, fmt.Errorf("lookup of line: %w", err)
 	}
 
 	fileName, err := strings.Lookup(li.FileNameOff)
 	if err != nil {
-		return nil, fmt.Errorf("lookup of filename: %w", err)
+		return lineInfo{}, fmt.Errorf("lookup of filename: %w", err)
 	}
 
 	lineNumber := li.LineCol >> bpfLineShift
 	lineColumn := li.LineCol & bpfColumnMax
 
-	return &lineInfo{
+	return lineInfo{
 		&Line{
 			fileName,
 			line,
@@ -590,7 +590,7 @@ func newLineInfos(blis []bpfLineInfo, strings *stringTable) (LineInfos, error) {
 		if err != nil {
 			return LineInfos{}, fmt.Errorf("offset %d: %w", bli.InsnOff, err)
 		}
-		lis.infos = append(lis.infos, *li)
+		lis.infos = append(lis.infos, li)
 	}
 	sort.Slice(lis.infos, func(i, j int) bool {
 		return lis.infos[i].offset <= lis.infos[j].offset

--- a/btf/ext_info.go
+++ b/btf/ext_info.go
@@ -666,7 +666,6 @@ func parseLineInfos(r io.Reader, bo binary.ByteOrder, strings *stringTable) (map
 // These records appear after a btf_ext_info_sec header in the line_info
 // sub-section of .BTF.ext.
 func parseLineInfoRecords(r io.Reader, bo binary.ByteOrder, recordSize uint32, recordNum uint32, offsetInBytes bool) ([]bpfLineInfo, error) {
-	var out []bpfLineInfo
 	var li bpfLineInfo
 
 	if exp, got := uint32(binary.Size(li)), recordSize; exp != got {
@@ -674,6 +673,7 @@ func parseLineInfoRecords(r io.Reader, bo binary.ByteOrder, recordSize uint32, r
 		return nil, fmt.Errorf("expected LineInfo record size %d, but BTF blob contains %d", exp, got)
 	}
 
+	out := make([]bpfLineInfo, 0, recordNum)
 	for i := uint32(0); i < recordNum; i++ {
 		if err := binary.Read(r, bo, &li); err != nil {
 			return nil, fmt.Errorf("can't read line info: %v", err)

--- a/collection_test.go
+++ b/collection_test.go
@@ -3,6 +3,8 @@ package ebpf
 import (
 	"errors"
 	"fmt"
+	"io"
+	"os"
 	"reflect"
 	"testing"
 
@@ -727,6 +729,27 @@ func BenchmarkNewCollectionManyProgs(b *testing.B) {
 			b.Fatal(err)
 		}
 		coll.Close()
+	}
+}
+
+func BenchmarkLoadCollectionManyProgs(b *testing.B) {
+	file, err := os.Open(fmt.Sprintf("testdata/manyprogs-%s.elf", internal.ClangEndian))
+	qt.Assert(b, err, qt.IsNil)
+	defer file.Close()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, err := file.Seek(0, io.SeekStart)
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		_, err = LoadCollectionSpecFromReader(file)
+		if err != nil {
+			b.Fatal(err)
+		}
 	}
 }
 

--- a/elf_reader.go
+++ b/elf_reader.go
@@ -373,7 +373,7 @@ func (ec *elfCode) loadFunctions(section *elfSection) (map[string]asm.Instructio
 	r := bufio.NewReader(section.Open())
 
 	// Decode the section's instruction stream.
-	var insns asm.Instructions
+	insns := make(asm.Instructions, 0, section.Size/asm.InstructionSize)
 	if err := insns.Unmarshal(r, ec.ByteOrder); err != nil {
 		return nil, fmt.Errorf("decoding instructions for section %s: %w", section.Name, err)
 	}


### PR DESCRIPTION
This PR implements two speedups/memory usage improvements in the elf loading path.

The first one is about preallocating the instructions buffer, based on the size provided by the elf section header. Due to double width load instruction we might over allocate by a bit, but from testing on our ebpf code this over allocation is negligible compared to the pre-allocation done by `slice.append` anyway, and the win is significant in case of large instructions buffer.

The second one implements a fast path for `splitSymbols` in the case where the instructions are composed of only one symbol, which is the dominant use case from my understanding (happy to be challenged on that).

I implemented a small benchmark depicting some instructions on both ends of the spectrum (one symbol, and 2 symbols at both ends of the instructions stream).

Please let me know if you would like separate PRs for each of those.

Thanks