### PR TITLE
fix data race by caching ring buffer size

### DIFF
--- a/ringbuf/reader.go
+++ b/ringbuf/reader.go
@@ -117,6 +117,7 @@ type Reader struct {
 	header      []byte
 	haveData    bool
 	deadline    time.Time
+	bufferSize  int
 }
 
 // NewReader creates a new BPF ringbuf reader.
@@ -151,6 +152,7 @@ func NewReader(ringbufMap *ebpf.Map) (*Reader, error) {
 		ring:        ring,
 		epollEvents: make([]unix.EpollEvent, 1),
 		header:      make([]byte, ringbufHeaderSize),
+		bufferSize:  ring.size(),
 	}, nil
 }
 
@@ -238,5 +240,5 @@ func (r *Reader) ReadInto(rec *Record) error {
 
 // BufferSize returns the size in bytes of the ring buffer
 func (r *Reader) BufferSize() int {
-	return r.ring.size()
+	return r.bufferSize
 }


### PR DESCRIPTION
We fixed this for perf buffers, but not ring buffers. Oops.