### PR TITLE
Move PossibleCPUs to a public API

### DIFF
--- a/cpu.go
+++ b/cpu.go
@@ -1,16 +1,28 @@
-package internal
+package ebpf
 
 import (
 	"fmt"
 	"os"
 	"strings"
+
+	"github.com/cilium/ebpf/internal"
 )
 
 // PossibleCPUs returns the max number of CPUs a system may possibly have
 // Logical CPU numbers must be of the form 0-n
-var PossibleCPUs = Memoize(func() (int, error) {
+var PossibleCPUs = internal.Memoize(func() (int, error) {
 	return parseCPUsFromFile("/sys/devices/system/cpu/possible")
 })
+
+// MustPossibleCPUs is a helper that wraps a call to PossibleCPUs and panics if
+// the error is non-nil.
+func MustPossibleCPUs() int {
+	cpus, err := PossibleCPUs()
+	if err != nil {
+		panic(err)
+	}
+	return cpus
+}
 
 func parseCPUsFromFile(path string) (int, error) {
 	spec, err := os.ReadFile(path)

--- a/cpu.go
+++ b/cpu.go
@@ -8,16 +8,20 @@ import (
 	"github.com/cilium/ebpf/internal"
 )
 
-// PossibleCPUs returns the max number of CPUs a system may possibly have
-// Logical CPU numbers must be of the form 0-n
-var PossibleCPUs = internal.Memoize(func() (int, error) {
+var possibleCPU = internal.Memoize(func() (int, error) {
 	return parseCPUsFromFile("/sys/devices/system/cpu/possible")
 })
 
-// MustPossibleCPUs is a helper that wraps a call to PossibleCPUs and panics if
+// PossibleCPU returns the max number of CPUs a system may possibly have
+// Logical CPU numbers must be of the form 0-n
+func PossibleCPU() (int, error) {
+	return possibleCPU()
+}
+
+// MustPossibleCPU is a helper that wraps a call to PossibleCPU and panics if
 // the error is non-nil.
-func MustPossibleCPUs() int {
-	cpus, err := PossibleCPUs()
+func MustPossibleCPU() int {
+	cpus, err := PossibleCPU()
 	if err != nil {
 		panic(err)
 	}

--- a/cpu_test.go
+++ b/cpu_test.go
@@ -1,4 +1,4 @@
-package internal
+package ebpf
 
 import (
 	"testing"

--- a/map.go
+++ b/map.go
@@ -133,7 +133,7 @@ func (spec *MapSpec) fixupMagicFields() (*MapSpec, error) {
 		spec.KeySize = 4
 		spec.ValueSize = 4
 
-		n, err := PossibleCPUs()
+		n, err := PossibleCPU()
 		if err != nil {
 			return nil, fmt.Errorf("fixup perf event array: %w", err)
 		}
@@ -515,7 +515,7 @@ func newMap(fd *sys.FD, name string, typ MapType, keySize, valueSize, maxEntries
 		return m, nil
 	}
 
-	possibleCPUs, err := PossibleCPUs()
+	possibleCPUs, err := PossibleCPU()
 	if err != nil {
 		return nil, err
 	}

--- a/map.go
+++ b/map.go
@@ -133,7 +133,7 @@ func (spec *MapSpec) fixupMagicFields() (*MapSpec, error) {
 		spec.KeySize = 4
 		spec.ValueSize = 4
 
-		n, err := internal.PossibleCPUs()
+		n, err := PossibleCPUs()
 		if err != nil {
 			return nil, fmt.Errorf("fixup perf event array: %w", err)
 		}
@@ -515,7 +515,7 @@ func newMap(fd *sys.FD, name string, typ MapType, keySize, valueSize, maxEntries
 		return m, nil
 	}
 
-	possibleCPUs, err := internal.PossibleCPUs()
+	possibleCPUs, err := PossibleCPUs()
 	if err != nil {
 		return nil, err
 	}

--- a/map_test.go
+++ b/map_test.go
@@ -1314,7 +1314,7 @@ func TestIterateMapInMap(t *testing.T) {
 func TestPerCPUMarshaling(t *testing.T) {
 	for _, typ := range []MapType{PerCPUHash, PerCPUArray, LRUCPUHash} {
 		t.Run(typ.String(), func(t *testing.T) {
-			numCPU, err := internal.PossibleCPUs()
+			numCPU, err := PossibleCPUs()
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1372,7 +1372,7 @@ type bpfCgroupStorageKey struct {
 }
 
 func TestCgroupPerCPUStorageMarshaling(t *testing.T) {
-	numCPU, err := internal.PossibleCPUs()
+	numCPU, err := PossibleCPUs()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/map_test.go
+++ b/map_test.go
@@ -1314,10 +1314,7 @@ func TestIterateMapInMap(t *testing.T) {
 func TestPerCPUMarshaling(t *testing.T) {
 	for _, typ := range []MapType{PerCPUHash, PerCPUArray, LRUCPUHash} {
 		t.Run(typ.String(), func(t *testing.T) {
-			numCPU, err := PossibleCPUs()
-			if err != nil {
-				t.Fatal(err)
-			}
+			numCPU := MustPossibleCPU()
 			if numCPU < 2 {
 				t.Skip("Test requires at least two CPUs")
 			}
@@ -1372,10 +1369,7 @@ type bpfCgroupStorageKey struct {
 }
 
 func TestCgroupPerCPUStorageMarshaling(t *testing.T) {
-	numCPU, err := PossibleCPUs()
-	if err != nil {
-		t.Fatal(err)
-	}
+	numCPU := MustPossibleCPU()
 	if numCPU < 2 {
 		t.Skip("Test requires at least two CPUs")
 	}

--- a/marshalers.go
+++ b/marshalers.go
@@ -53,7 +53,7 @@ func marshalPerCPUValue(slice any, elemLength int) (sys.Pointer, error) {
 		return sys.Pointer{}, errors.New("per-CPU value requires slice")
 	}
 
-	possibleCPUs, err := internal.PossibleCPUs()
+	possibleCPUs, err := PossibleCPUs()
 	if err != nil {
 		return sys.Pointer{}, err
 	}
@@ -91,7 +91,7 @@ func unmarshalPerCPUValue(slicePtr any, elemLength int, buf []byte) error {
 		return fmt.Errorf("per-cpu value requires pointer to slice")
 	}
 
-	possibleCPUs, err := internal.PossibleCPUs()
+	possibleCPUs, err := PossibleCPUs()
 	if err != nil {
 		return err
 	}

--- a/marshalers.go
+++ b/marshalers.go
@@ -53,7 +53,7 @@ func marshalPerCPUValue(slice any, elemLength int) (sys.Pointer, error) {
 		return sys.Pointer{}, errors.New("per-CPU value requires slice")
 	}
 
-	possibleCPUs, err := PossibleCPUs()
+	possibleCPUs, err := PossibleCPU()
 	if err != nil {
 		return sys.Pointer{}, err
 	}
@@ -91,7 +91,7 @@ func unmarshalPerCPUValue(slicePtr any, elemLength int, buf []byte) error {
 		return fmt.Errorf("per-cpu value requires pointer to slice")
 	}
 
-	possibleCPUs, err := PossibleCPUs()
+	possibleCPUs, err := PossibleCPU()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Prequel to #1192 

Note: Also added `MustPossibleCPUs()` as a wrapper.

Considered switching to `sync.OnceValues()`, but instead referenced `internal.Memoize()`