### PR TITLE
map: allow pre-allocating per-CPU values on lookup

### DIFF
--- a/map_test.go
+++ b/map_test.go
@@ -75,6 +75,10 @@ func TestMap(t *testing.T) {
 		t.Error("Want value 42, got", v)
 	}
 
+	sliceVal := make([]uint32, 1)
+	qt.Assert(t, m.Lookup(uint32(0), sliceVal), qt.IsNil)
+	qt.Assert(t, sliceVal, qt.DeepEquals, []uint32{42})
+
 	var slice []byte
 	qt.Assert(t, m.Lookup(uint32(0), &slice), qt.IsNil)
 	qt.Assert(t, slice, qt.DeepEquals, internal.NativeEndian.AppendUint32(nil, 42))
@@ -1345,6 +1349,16 @@ func TestPerCPUMarshaling(t *testing.T) {
 			}
 
 			// Make sure unmarshaling works on slices containing pointers
+			retrievedVal := make([]*customEncoding, numCPU)
+			if err := arr.Lookup(uint32(0), retrievedVal); err == nil {
+				t.Fatal("Slices with nil values should generate error")
+			}
+			for i := range retrievedVal {
+				retrievedVal[i] = &customEncoding{}
+			}
+			if err := arr.Lookup(uint32(0), retrievedVal); err != nil {
+				t.Fatal("Can't retrieve key 0:", err)
+			}
 			var retrieved []*customEncoding
 			if err := arr.Lookup(uint32(0), &retrieved); err != nil {
 				t.Fatal("Can't retrieve key 0:", err)

--- a/marshalers_test.go
+++ b/marshalers_test.go
@@ -1,0 +1,37 @@
+package ebpf
+
+import (
+	"testing"
+
+	"github.com/cilium/ebpf/internal"
+	qt "github.com/frankban/quicktest"
+)
+
+func TestUnmarshalPerCPUValue(t *testing.T) {
+	possibleCPUs := MustPossibleCPU()
+	expected := make([]uint32, possibleCPUs)
+	for i := 0; i < possibleCPUs; i++ {
+		expected[i] = uint32(1021 * (i + 1))
+	}
+	elemLength := 4
+
+	buf := make([]byte, possibleCPUs*internal.Align(elemLength, 8))
+	b := buf
+	for _, elem := range expected {
+		internal.NativeEndian.PutUint32(b, elem)
+		b = b[8:]
+	}
+	slice := make([]uint32, possibleCPUs)
+	err := unmarshalPerCPUValue(slice, elemLength, buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	qt.Assert(t, slice, qt.DeepEquals, expected)
+
+	smallSlice := make([]uint32, possibleCPUs-1)
+
+	err = unmarshalPerCPUValue(smallSlice, elemLength, buf)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}

--- a/marshalers_test.go
+++ b/marshalers_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/cilium/ebpf/internal"
+
 	qt "github.com/frankban/quicktest"
 )
 
@@ -29,9 +30,8 @@ func TestUnmarshalPerCPUValue(t *testing.T) {
 	qt.Assert(t, slice, qt.DeepEquals, expected)
 
 	smallSlice := make([]uint32, possibleCPUs-1)
+	qt.Assert(t, unmarshalPerCPUValue(smallSlice, elemLength, buf), qt.IsNotNil)
 
-	err = unmarshalPerCPUValue(smallSlice, elemLength, buf)
-	if err == nil {
-		t.Fatal("expected error")
-	}
+	nilElemSlice := make([]*uint32, possibleCPUs)
+	qt.Assert(t, unmarshalPerCPUValue(nilElemSlice, elemLength, buf), qt.IsNotNil)
 }


### PR DESCRIPTION
Prequel to #1192 note that this *will* conflict with #1219 and need a rebase.. oh for a stacked diff workflow on GH.