### PR TITLE
map: Introduce BatchCursor abstraction

### DIFF
--- a/map.go
+++ b/map.go
@@ -968,6 +968,10 @@ func (m *Map) guessNonExistentKey() ([]byte, error) {
 // "cursor" to subsequent calls of this function to continue the batching
 // operation in the case of chunking.
 //
+// Warning: This API is not very safe to use as the kernel implementation for
+// batching relies on the user to be aware of subtle details with regarding to
+// different map type implementations.
+//
 // ErrKeyNotExist is returned when the batch lookup has reached
 // the end of all possible results, even when partial results
 // are returned. It should be used to evaluate when lookup is "done".
@@ -983,6 +987,10 @@ func (m *Map) BatchLookup(cursor *BatchCursor, keysOut, valuesOut interface{}, o
 // "cursor" is an pointer to an opaque handle. It must be non-nil. Pass
 // "cursor" to subsequent calls of this function to continue the batching
 // operation in the case of chunking.
+//
+// Warning: This API is not very safe to use as the kernel implementation for
+// batching relies on the user to be aware of subtle details with regarding to
+// different map type implementations.
 //
 // ErrKeyNotExist is returned when the batch lookup has reached
 // the end of all possible results, even when partial results

--- a/map_test.go
+++ b/map_test.go
@@ -186,6 +186,37 @@ func TestMapBatch(t *testing.T) {
 	}
 }
 
+func TestMapBatchCursorReuse(t *testing.T) {
+	spec := &MapSpec{
+		Type:       Array,
+		KeySize:    4,
+		ValueSize:  4,
+		MaxEntries: 4,
+	}
+
+	arr1, err := NewMap(spec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer arr1.Close()
+
+	arr2, err := NewMap(spec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer arr2.Close()
+
+	tmp := make([]uint32, 2)
+
+	var cursor BatchCursor
+	_, err = arr1.BatchLookup(&cursor, tmp, tmp, nil)
+	testutils.SkipIfNotSupported(t, err)
+	qt.Assert(t, err, qt.IsNil)
+
+	_, err = arr2.BatchLookup(&cursor, tmp, tmp, nil)
+	qt.Assert(t, err, qt.IsNotNil)
+}
+
 func TestMapLookupKeyTooSmall(t *testing.T) {
 	m := createArray(t)
 	defer m.Close()


### PR DESCRIPTION
See commit msgs.

* Introduce BatchCursor abstraction
* Add unit test for batch lookup with chunking
* Add warning to Batch* API operations

---

Main commit for convenience: 

> Introduce BatchCursor abstraction
> 
> The batch API in the kernel is quite tricky to get right. In order to
> pass the arguments in correctly, especially regarding the "in_batch" and
> "out_batch" arguments, it requires knowledge of how the batch map
> iteration is implemented in the kernel.
> 
> In order to avoid pushing the cognitive overhead onto users of the
> library, abstract away the details of batch map iteration into an opaque
> type, BatchCursor.
> 
> Users are expected to pass in a reference to a BatchCursor and the
> library will handle allocating the underlying buffer when needed.
> Specifically, the first time that a batch API is called using the
> cursor, the underlying buffer will be nil, which signfifies that the
> "in_batch" (aka "prevKey") should be nil to indicate the starting of a
> batching operation, and "out_batch" (aka "nextKey") is set to an
> newly-allocated buffer. Previously, users were expected to carry the
> "out_batch" reference in order to pass it in as "in_batch" upon the next
> call to the batching operation. Instead, with this abstraction, the
> cursor handles it for the user, by using the underlying buffer for both
> "in_batch" and "out_batch" in subsequent calls.
> 
> Signed-off-by: Chris Tarazi <chris@isovalent.com>
> Suggested-by: Lorenz Bauer <lmb@isovalent.com>
