### PR TITLE
CI: allow writing PRs from trusted workflow

### DIFF
--- a/.github/workflows/trusted.yml
+++ b/.github/workflows/trusted.yml
@@ -5,8 +5,7 @@ on:
       - completed
 
 permissions:
-  issues: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   tag-breaking-change:


### PR DESCRIPTION
Another error from the workflow:

    Unhandled error: HttpError: Resource not accessible by integration
      at /home/runner/work/_actions/actions/github-script/v3/dist/index.js:2591:23
      at processTicksAndRejections (node:internal/process/task_queues:96:5)
      at async eval (eval at callAsyncFunction (/home/runner/work/_actions/actions/github-script/v3/dist/index.js:7514:16), <anonymous>:4:1)
      at async main (/home/runner/work/_actions/actions/github-script/v3/dist/index.js:7541:20) {
    status: 403,
    ...

Allow the workflow to set labels on pull requests, which according to the documentation needs write permission.