### PR TITLE
link: rename First, Last to Head, Tail

### DIFF
--- a/.github/workflows/apidiff.yml
+++ b/.github/workflows/apidiff.yml
@@ -21,15 +21,14 @@ jobs:
 
       - name: Run go-apidiff
         id: apidiff
+        continue-on-error: true
         uses: joelanford/go-apidiff@main
 
       - name: Create apidiff.json
-        if: always()
         run: |
           echo '{"id": ${{ github.event.pull_request.number }}, "semver-type": "${{ steps.apidiff.outputs.semver-type }}"}' > apidiff.json
 
       - name: Upload apidiff.json
-        if: always()
         uses: actions/upload-artifact@v3
         with:
           name: apidiff

--- a/link/anchor.go
+++ b/link/anchor.go
@@ -35,7 +35,8 @@ func (firstAnchor) anchor() (fdOrID, flags uint32, _ error) {
 	return 0, sys.BPF_F_BEFORE, nil
 }
 
-func First() Anchor {
+// Head is the position before all other programs or links.
+func Head() Anchor {
 	return firstAnchor{}
 }
 
@@ -45,7 +46,8 @@ func (lastAnchor) anchor() (fdOrID, flags uint32, _ error) {
 	return 0, sys.BPF_F_AFTER, nil
 }
 
-func Last() Anchor {
+// Tail is the position after all other programs or links.
+func Tail() Anchor {
 	return lastAnchor{}
 }
 

--- a/link/program_test.go
+++ b/link/program_test.go
@@ -84,8 +84,8 @@ func TestRawAttachProgramAnchor(t *testing.T) {
 	b := mustLoadProgram(t, ebpf.SchedCLS, 0, "")
 
 	for _, anchor := range []Anchor{
-		First(),
-		Last(),
+		Head(),
+		Tail(),
 		AfterProgram(a),
 		AfterProgramByID(aID),
 		AfterLink(link),

--- a/link/tcx_test.go
+++ b/link/tcx_test.go
@@ -39,8 +39,8 @@ func TestTCXAnchor(t *testing.T) {
 	linkID := linkInfo.ID
 
 	for _, anchor := range []Anchor{
-		First(),
-		Last(),
+		Head(),
+		Tail(),
 		BeforeProgram(a),
 		BeforeProgramByID(programID),
 		AfterLink(linkA),


### PR DESCRIPTION
Timo suggested renaming First and Last to make it less likely that users assume that the position is guaranteed for the lifetime of the link.