### PR TITLE
map: avoid allocations in MapIterator.Next

### DIFF
--- a/map_test.go
+++ b/map_test.go
@@ -1103,6 +1103,32 @@ func TestMapIterate(t *testing.T) {
 	}
 }
 
+func TestMapIteratorAllocations(t *testing.T) {
+	arr, err := NewMap(&MapSpec{
+		Type:       Array,
+		KeySize:    4,
+		ValueSize:  4,
+		MaxEntries: 10,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer arr.Close()
+
+	var k, v uint32
+	iter := arr.Iterate()
+	// Allocate any necessary temporary buffers.
+	qt.Assert(t, iter.Next(&k, &v), qt.IsTrue)
+
+	allocs := testing.AllocsPerRun(1, func() {
+		if !iter.Next(&k, &v) {
+			t.Fatal("Next failed")
+		}
+	})
+
+	qt.Assert(t, allocs, qt.Equals, float64(0))
+}
+
 func TestMapIterateHashKeyOneByteFull(t *testing.T) {
 	hash, err := NewMap(&MapSpec{
 		Type:       Hash,


### PR DESCRIPTION
Rejig MapIterator.Next to stop allocating nextKey over and over. This makes Next() not allocate in a steady state:

    core: 1
    goos: linux
    goarch: amd64
    pkg: github.com/cilium/ebpf
    cpu: 12th Gen Intel(R) Core(TM) i7-1260P
                            │  base.txt   │              opt.txt              │
                            │   sec/op    │   sec/op     vs base              │
    Iterate/MapIterator         1.596m ± 0%   1.500m ± 1%  -6.05% (p=0.002 n=6)
    Iterate/MapIteratorDelete   2.862m ± 0%   2.754m ± 0%  -3.75% (p=0.002 n=6)
    geomean                     2.137m        2.032m       -4.91%

                            │   base.txt    │              opt.txt              │
                            │     B/op      │    B/op     vs base               │
    Iterate/MapIterator         56082.00 ± 0%   96.00 ± 0%  -99.83% (p=0.002 n=6)
    Iterate/MapIteratorDelete    56082.0 ± 0%   104.0 ± 0%  -99.81% (p=0.002 n=6)
    geomean                      54.77Ki        99.92       -99.82%

                            │   base.txt    │              opt.txt              │
                            │   allocs/op   │ allocs/op   vs base               │
    Iterate/MapIterator         3004.000 ± 0%   4.000 ± 0%  -99.87% (p=0.002 n=6)
    Iterate/MapIteratorDelete   3004.000 ± 0%   4.000 ± 0%  -99.87% (p=0.002 n=6)
    geomean                       3.004k        4.000       -99.87%