### PR TITLE
CI: run tests on arm64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,4 @@
+name: ci
 on:
   push:
     branches: [ "main" ]
@@ -69,13 +70,6 @@ jobs:
           go build -v ./...
           go test -c -o /dev/null ./... >/dev/null
 
-      - name: Cross build arm64
-        env:
-          GOARCH: arm64
-        run: |
-          go build -v ./...
-          go test -c -o /dev/null ./... >/dev/null
-
   build-docs:
     name: Build Documentation
     runs-on: ubuntu-22.04
@@ -138,6 +132,39 @@ jobs:
         with:
           name: Test Results (previous stable Go)
           path: junit.xml
+
+  test-on-arm64:
+    name: Run tests on arm64
+    runs-on: actuated-arm64-2cpu-8gb
+    needs: build-and-lint
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '${{ env.prev_go_version }}'
+
+      - run: go install gotest.tools/gotestsum@v1.8.1
+
+      - name: Test
+        run: gotestsum --ignore-non-json-output-lines --junitfile junit.xml -- -exec sudo -short -count 1 -json ./...
+
+      - name: Benchmark
+        run: go test -exec sudo -short -run '^$' -bench . -benchtime=1x ./...
+
+      - name: Upload Test Results
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: Test Results (arm64)
+          path: junit.xml
+
+      - name: Show dmesg
+        if: failure()
+        run: |
+          sudo dmesg
 
   vm-test:
     name: Run tests on pre-built kernel

--- a/link/uprobe_test.go
+++ b/link/uprobe_test.go
@@ -71,15 +71,17 @@ func TestExecutableLazyLoadSymbols(t *testing.T) {
 	ex, err := OpenExecutable("/bin/bash")
 	qt.Assert(t, qt.IsNil(err))
 	// Addresses must be empty, will be lazy loaded.
-	qt.Assert(t, qt.DeepEquals(ex.addresses, map[string]uint64{}))
+	qt.Assert(t, qt.HasLen(ex.addresses, 0))
 
 	prog := mustLoadProgram(t, ebpf.Kprobe, 0, "")
-	up, err := ex.Uprobe(bashSym, prog, &UprobeOptions{Address: 123})
+	// Address must be a multiple of 4 on arm64, see
+	// https://elixir.bootlin.com/linux/v6.6.4/source/arch/arm64/kernel/probes/uprobes.c#L42
+	up, err := ex.Uprobe(bashSym, prog, &UprobeOptions{Address: 124})
 	qt.Assert(t, qt.IsNil(err))
 	up.Close()
 
 	// Addresses must still be empty as Address has been provided via options.
-	qt.Assert(t, qt.DeepEquals(ex.addresses, map[string]uint64{}))
+	qt.Assert(t, qt.HasLen(ex.addresses, 0))
 
 	up, err = ex.Uprobe(bashSym, prog, nil)
 	qt.Assert(t, qt.IsNil(err))


### PR DESCRIPTION
Use the actuated runners provided by the CNCF to run the testsuite on arm64. These runners do not support nested KVM and therefore we can run the VM tests there.

Fixes #266 