### PR TITLE
map: fix flaky TestMapBatch/Hash

### DIFF
--- a/map_test.go
+++ b/map_test.go
@@ -149,8 +149,8 @@ func TestMapBatch(t *testing.T) {
 				}
 				qt.Assert(t, err, qt.IsNil)
 
-				qt.Assert(t, count, qt.Equals, len(lookupKeys))
-				for i, key := range lookupKeys {
+				qt.Assert(t, count <= len(lookupKeys), qt.IsTrue)
+				for i, key := range lookupKeys[:count] {
 					value := lookupValues[i]
 					qt.Assert(t, value, qt.Equals, contents[key], qt.Commentf("value for key %d should match", key))
 				}


### PR DESCRIPTION
Hash table batch lookup proceeds by bucket, filling the user space output buffer only if the entire bucket can fit. Depending on the initial hash value chosen we may end up with a key to bucket distribution leads to a lookup returning a count less than the full size. For example:

    bucket keys
    0:     k1
    1:     k2, k3

In this case the first batch lookup with batch size 2 will return count == 1, since only the 0th bucket fits entirely.

Account for this in the test case.