### PR TITLE
map: avoid allocations during batch lookup of common types

### DIFF
--- a/internal/sysenc/buffer.go
+++ b/internal/sysenc/buffer.go
@@ -32,6 +32,7 @@ func UnsafeBuffer(ptr unsafe.Pointer) Buffer {
 
 // SyscallOutput prepares a Buffer for a syscall to write into.
 //
+// size is the length of the desired buffer in bytes.
 // The buffer may point at the underlying memory of dst, in which case [Unmarshal]
 // becomes a no-op.
 //

--- a/map_test.go
+++ b/map_test.go
@@ -2085,11 +2085,16 @@ func BenchmarkIterate(b *testing.B) {
 		b.ReportAllocs()
 		b.ResetTimer()
 
-		var cursor BatchCursor
 		for i := 0; i < b.N; i++ {
-			_, err := m.BatchLookup(&cursor, k, v, nil)
-			if err != nil && !errors.Is(err, ErrKeyNotExist) {
-				b.Fatal(err)
+			var cursor BatchCursor
+			for {
+				_, err := m.BatchLookup(&cursor, k, v, nil)
+				if errors.Is(err, ErrKeyNotExist) {
+					break
+				}
+				if err != nil {
+					b.Fatal(err)
+				}
 			}
 		}
 	})
@@ -2109,9 +2114,14 @@ func BenchmarkIterate(b *testing.B) {
 			b.StartTimer()
 
 			var cursor BatchCursor
-			_, err := m.BatchLookupAndDelete(&cursor, k, v, nil)
-			if err != nil && !errors.Is(err, ErrKeyNotExist) {
-				b.Fatal(err)
+			for {
+				_, err := m.BatchLookupAndDelete(&cursor, k, v, nil)
+				if errors.Is(err, ErrKeyNotExist) {
+					break
+				}
+				if err != nil {
+					b.Fatal(err)
+				}
 			}
 		}
 	})

--- a/map_test.go
+++ b/map_test.go
@@ -2040,6 +2040,7 @@ func BenchmarkIterate(b *testing.B) {
 		var k, v uint64
 
 		b.ReportAllocs()
+		b.ResetTimer()
 
 		for i := 0; i < b.N; i++ {
 			iter := m.Iterate()
@@ -2056,6 +2057,7 @@ func BenchmarkIterate(b *testing.B) {
 		var k, v uint64
 
 		b.ReportAllocs()
+		b.ResetTimer()
 
 		for i := 0; i < b.N; i++ {
 			b.StopTimer()
@@ -2081,6 +2083,7 @@ func BenchmarkIterate(b *testing.B) {
 		v := make([]uint64, m.MaxEntries())
 
 		b.ReportAllocs()
+		b.ResetTimer()
 
 		var cursor BatchCursor
 		for i := 0; i < b.N; i++ {
@@ -2096,6 +2099,7 @@ func BenchmarkIterate(b *testing.B) {
 		v := make([]uint64, m.MaxEntries())
 
 		b.ReportAllocs()
+		b.ResetTimer()
 
 		for i := 0; i < b.N; i++ {
 			b.StopTimer()
@@ -2114,6 +2118,7 @@ func BenchmarkIterate(b *testing.B) {
 
 	b.Run("BatchDelete", func(b *testing.B) {
 		b.ReportAllocs()
+		b.ResetTimer()
 
 		for i := 0; i < b.N; i++ {
 			b.StopTimer()


### PR DESCRIPTION
Extend the optimization from 4609dc73 ("map: zero-allocation operations for common types") to BatchLookup. This means that types without implicit padding will not incur allocations.

    core: 1
    goos: linux
    goarch: amd64
    pkg: github.com/cilium/ebpf
    cpu: 12th Gen Intel(R) Core(TM) i7-1260P
                        │   base.txt   │              opt.txt               │
                        │    sec/op    │   sec/op     vs base               │
    Iterate/BatchLookup   4317.0n ± 2%   771.6n ± 1%  -82.13% (p=0.002 n=6)

                        │   base.txt    │              opt.txt              │
                        │     B/op      │    B/op     vs base               │
    Iterate/BatchLookup   16432.00 ± 0%   48.00 ± 0%  -99.71% (p=0.002 n=6)

                        │  base.txt  │              opt.txt              │
                        │ allocs/op  │ allocs/op   vs base               │
    Iterate/BatchLookup   4.000 ± 0%   2.000 ± 0%  -50.00% (p=0.002 n=6)