### PR TITLE
Add support for netkit device

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   TMPDIR: /tmp
-  CI_MAX_KERNEL_VERSION: '6.6'
+  CI_MAX_KERNEL_VERSION: '6.7'
   CI_MIN_CLANG_VERSION: '11'
   go_version: '~1.22'
   prev_go_version: '~1.21'

--- a/attachtype_string.go
+++ b/attachtype_string.go
@@ -58,11 +58,18 @@ func _() {
 	_ = x[AttachTCXIngress-46]
 	_ = x[AttachTCXEgress-47]
 	_ = x[AttachTraceUprobeMulti-48]
+	_ = x[AttachCgroupUnixConnect-49]
+	_ = x[AttachCgroupUnixSendmsg-50]
+	_ = x[AttachCgroupUnixRecvmsg-51]
+	_ = x[AttachCgroupUnixGetpeername-52]
+	_ = x[AttachCgroupUnixGetsockname-53]
+	_ = x[AttachNetkitPrimary-54]
+	_ = x[AttachNetkitPeer-55]
 }
 
-const _AttachType_name = "NoneCGroupInetEgressCGroupInetSockCreateCGroupSockOpsSkSKBStreamParserSkSKBStreamVerdictCGroupDeviceSkMsgVerdictCGroupInet4BindCGroupInet6BindCGroupInet4ConnectCGroupInet6ConnectCGroupInet4PostBindCGroupInet6PostBindCGroupUDP4SendmsgCGroupUDP6SendmsgLircMode2FlowDissectorCGroupSysctlCGroupUDP4RecvmsgCGroupUDP6RecvmsgCGroupGetsockoptCGroupSetsockoptTraceRawTpTraceFEntryTraceFExitModifyReturnLSMMacTraceIterCgroupInet4GetPeernameCgroupInet6GetPeernameCgroupInet4GetSocknameCgroupInet6GetSocknameXDPDevMapCgroupInetSockReleaseXDPCPUMapSkLookupXDPSkSKBVerdictSkReuseportSelectSkReuseportSelectOrMigratePerfEventTraceKprobeMultiLSMCgroupStructOpsNetfilterTCXIngressTCXEgressTraceUprobeMulti"
+const _AttachType_name = "NoneCGroupInetEgressCGroupInetSockCreateCGroupSockOpsSkSKBStreamParserSkSKBStreamVerdictCGroupDeviceSkMsgVerdictCGroupInet4BindCGroupInet6BindCGroupInet4ConnectCGroupInet6ConnectCGroupInet4PostBindCGroupInet6PostBindCGroupUDP4SendmsgCGroupUDP6SendmsgLircMode2FlowDissectorCGroupSysctlCGroupUDP4RecvmsgCGroupUDP6RecvmsgCGroupGetsockoptCGroupSetsockoptTraceRawTpTraceFEntryTraceFExitModifyReturnLSMMacTraceIterCgroupInet4GetPeernameCgroupInet6GetPeernameCgroupInet4GetSocknameCgroupInet6GetSocknameXDPDevMapCgroupInetSockReleaseXDPCPUMapSkLookupXDPSkSKBVerdictSkReuseportSelectSkReuseportSelectOrMigratePerfEventTraceKprobeMultiLSMCgroupStructOpsNetfilterTCXIngressTCXEgressTraceUprobeMultiCgroupUnixConnectCgroupUnixSendmsgCgroupUnixRecvmsgCgroupUnixGetpeernameCgroupUnixGetsocknameNetkitPrimaryNetkitPeer"
 
-var _AttachType_index = [...]uint16{0, 4, 20, 40, 53, 70, 88, 100, 112, 127, 142, 160, 178, 197, 216, 233, 250, 259, 272, 284, 301, 318, 334, 350, 360, 371, 381, 393, 399, 408, 430, 452, 474, 496, 505, 526, 535, 543, 546, 558, 575, 601, 610, 626, 635, 644, 653, 663, 672, 688}
+var _AttachType_index = [...]uint16{0, 4, 20, 40, 53, 70, 88, 100, 112, 127, 142, 160, 178, 197, 216, 233, 250, 259, 272, 284, 301, 318, 334, 350, 360, 371, 381, 393, 399, 408, 430, 452, 474, 496, 505, 526, 535, 543, 546, 558, 575, 601, 610, 626, 635, 644, 653, 663, 672, 688, 705, 722, 739, 760, 781, 794, 804}
 
 func (i AttachType) String() string {
 	if i >= AttachType(len(_AttachType_index)-1) {

--- a/internal/cmd/gentypes/main.go
+++ b/internal/cmd/gentypes/main.go
@@ -477,6 +477,17 @@ import (
 			},
 		},
 		{
+			"LinkCreateNetkit", retFd, "link_create", "BPF_LINK_CREATE",
+			[]patch{
+				choose(1, "target_ifindex"),
+				choose(4, "netkit"),
+				replace(enumTypes["AttachType"], "attach_type"),
+				flattenAnon,
+				flattenAnon,
+				rename("relative_fd", "relative_fd_or_id"),
+			},
+		},
+		{
 			"LinkUpdate", retError, "link_update", "BPF_LINK_UPDATE",
 			nil,
 		},
@@ -575,6 +586,9 @@ import (
 			replace(enumTypes["AttachType"], "attach_type"),
 		}},
 		{"NetfilterLinkInfo", "netfilter", nil},
+		{"NetkitLinkInfo", "netkit", []patch{
+			replace(enumTypes["AttachType"], "attach_type"),
+		}},
 	}
 
 	sort.Slice(linkInfoExtraTypes, func(i, j int) bool {
@@ -604,6 +618,7 @@ import (
 		{"kprobe_multi", "kprobe_multi"},
 		{"perf_event", "perf_event"},
 		{"tcx", "tcx"},
+		{"netkit", "netkit"},
 	})
 	if err != nil {
 		return nil, fmt.Errorf("splitting linkInfo: %w", err)

--- a/internal/sys/types.go
+++ b/internal/sys/types.go
@@ -740,6 +740,25 @@ func LinkCreateNetfilter(attr *LinkCreateNetfilterAttr) (*FD, error) {
 	return NewFD(int(fd))
 }
 
+type LinkCreateNetkitAttr struct {
+	ProgFd           uint32
+	TargetIfindex    uint32
+	AttachType       AttachType
+	Flags            uint32
+	RelativeFdOrId   uint32
+	_                [4]byte
+	ExpectedRevision uint64
+	_                [32]byte
+}
+
+func LinkCreateNetkit(attr *LinkCreateNetkitAttr) (*FD, error) {
+	fd, err := BPF(BPF_LINK_CREATE, unsafe.Pointer(attr), unsafe.Sizeof(*attr))
+	if err != nil {
+		return nil, err
+	}
+	return NewFD(int(fd))
+}
+
 type LinkCreatePerfEventAttr struct {
 	ProgFd     uint32
 	TargetFd   uint32
@@ -1226,6 +1245,11 @@ type NetfilterLinkInfo struct {
 	Hooknum  uint32
 	Priority int32
 	Flags    uint32
+}
+
+type NetkitLinkInfo struct {
+	Ifindex    uint32
+	AttachType AttachType
 }
 
 type RawTracepointLinkInfo struct {

--- a/link/link.go
+++ b/link/link.go
@@ -104,6 +104,8 @@ func wrapRawLink(raw *RawLink) (_ Link, err error) {
 		return &tcxLink{*raw}, nil
 	case NetfilterType:
 		return &netfilterLink{*raw}, nil
+	case NetkitType:
+		return &netkitLink{*raw}, nil
 	default:
 		return raw, nil
 	}
@@ -140,6 +142,7 @@ type NetNsInfo sys.NetNsLinkInfo
 type XDPInfo sys.XDPLinkInfo
 type TCXInfo sys.TcxLinkInfo
 type NetfilterInfo sys.NetfilterLinkInfo
+type NetkitInfo sys.NetkitLinkInfo
 
 // Tracing returns tracing type-specific link info.
 //
@@ -343,6 +346,8 @@ func (l *RawLink) Info() (*Info, error) {
 		extra = &TCXInfo{}
 	case NetfilterType:
 		extra = &NetfilterInfo{}
+	case NetkitType:
+		extra = &NetkitInfo{}
 	default:
 		return nil, fmt.Errorf("unknown link info type: %d", info.Type)
 	}

--- a/link/netkit.go
+++ b/link/netkit.go
@@ -1,0 +1,71 @@
+package link
+
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/internal/sys"
+)
+
+type NetkitOptions struct {
+	// Index of the interface to attach to.
+	Interface int
+	// Program to attach.
+	Program *ebpf.Program
+	// One of the AttachNetkit* constants.
+	Attach ebpf.AttachType
+	// Attach relative to an anchor. Optional.
+	Anchor Anchor
+	// Only attach if the expected revision matches.
+	ExpectedRevision uint64
+	// Flags control the attach behaviour. Specify an Anchor instead of
+	// F_LINK, F_ID, F_BEFORE, F_AFTER and R_REPLACE. Optional.
+	Flags uint32
+}
+
+func AttachNetkit(opts NetkitOptions) (Link, error) {
+	if opts.Interface < 0 {
+		return nil, fmt.Errorf("interface %d is out of bounds", opts.Interface)
+	}
+
+	if opts.Flags&anchorFlags != 0 {
+		return nil, fmt.Errorf("disallowed flags: use Anchor to specify attach target")
+	}
+
+	attr := sys.LinkCreateNetkitAttr{
+		ProgFd:           uint32(opts.Program.FD()),
+		AttachType:       sys.AttachType(opts.Attach),
+		TargetIfindex:    uint32(opts.Interface),
+		ExpectedRevision: opts.ExpectedRevision,
+		Flags:            opts.Flags,
+	}
+
+	if opts.Anchor != nil {
+		fdOrID, flags, err := opts.Anchor.anchor()
+		if err != nil {
+			return nil, fmt.Errorf("attach netkit link: %w", err)
+		}
+
+		attr.RelativeFdOrId = fdOrID
+		attr.Flags |= flags
+	}
+
+	fd, err := sys.LinkCreateNetkit(&attr)
+	runtime.KeepAlive(opts.Program)
+	runtime.KeepAlive(opts.Anchor)
+	if err != nil {
+		if haveFeatErr := haveNetkit(); haveFeatErr != nil {
+			return nil, haveFeatErr
+		}
+		return nil, fmt.Errorf("attach netkit link: %w", err)
+	}
+
+	return &netkitLink{RawLink{fd, ""}}, nil
+}
+
+type netkitLink struct {
+	RawLink
+}
+
+var _ Link = (*netkitLink)(nil)

--- a/link/syscalls.go
+++ b/link/syscalls.go
@@ -27,6 +27,7 @@ const (
 	TCXType           = sys.BPF_LINK_TYPE_TCX
 	UprobeMultiType   = sys.BPF_LINK_TYPE_UPROBE_MULTI
 	NetfilterType     = sys.BPF_LINK_TYPE_NETFILTER
+	NetkitType        = sys.BPF_LINK_TYPE_NETKIT
 )
 
 var haveProgAttach = internal.NewFeatureTest("BPF_PROG_ATTACH", "4.10", func() error {
@@ -153,6 +154,41 @@ var haveTCX = internal.NewFeatureTest("tcx", "6.6", func() error {
 	}
 
 	_, err = sys.LinkCreateTcx(&attr)
+
+	if errors.Is(err, unix.ENODEV) {
+		return nil
+	}
+	if err != nil {
+		return ErrNotSupported
+	}
+	return errors.New("syscall succeeded unexpectedly")
+})
+
+var haveNetkit = internal.NewFeatureTest("netkit", "6.7", func() error {
+	prog, err := ebpf.NewProgram(&ebpf.ProgramSpec{
+		Type:    ebpf.SchedCLS,
+		License: "MIT",
+		Instructions: asm.Instructions{
+			asm.Mov.Imm(asm.R0, 0),
+			asm.Return(),
+		},
+	})
+
+	if err != nil {
+		return internal.ErrNotSupported
+	}
+
+	defer prog.Close()
+	attr := sys.LinkCreateNetkitAttr{
+		// We rely on this being checked during the syscall.
+		// With an otherwise correct payload we expect ENODEV here
+		// as an indication that the feature is present.
+		TargetIfindex: ^uint32(0),
+		ProgFd:        uint32(prog.FD()),
+		AttachType:    sys.AttachType(ebpf.AttachNetkitPrimary),
+	}
+
+	_, err = sys.LinkCreateNetkit(&attr)
 
 	if errors.Is(err, unix.ENODEV) {
 		return nil

--- a/link/syscalls_test.go
+++ b/link/syscalls_test.go
@@ -25,3 +25,7 @@ func TestHaveProgQuery(t *testing.T) {
 func TestHaveTCX(t *testing.T) {
 	testutils.CheckFeatureTest(t, haveTCX)
 }
+
+func TestHaveNetkit(t *testing.T) {
+	testutils.CheckFeatureTest(t, haveNetkit)
+}

--- a/types.go
+++ b/types.go
@@ -220,6 +220,13 @@ const (
 	AttachTCXIngress                 = AttachType(sys.BPF_TCX_INGRESS)
 	AttachTCXEgress                  = AttachType(sys.BPF_TCX_EGRESS)
 	AttachTraceUprobeMulti           = AttachType(sys.BPF_TRACE_UPROBE_MULTI)
+	AttachCgroupUnixConnect          = AttachType(sys.BPF_CGROUP_UNIX_CONNECT)
+	AttachCgroupUnixSendmsg          = AttachType(sys.BPF_CGROUP_UNIX_SENDMSG)
+	AttachCgroupUnixRecvmsg          = AttachType(sys.BPF_CGROUP_UNIX_RECVMSG)
+	AttachCgroupUnixGetpeername      = AttachType(sys.BPF_CGROUP_UNIX_GETPEERNAME)
+	AttachCgroupUnixGetsockname      = AttachType(sys.BPF_CGROUP_UNIX_GETSOCKNAME)
+	AttachNetkitPrimary              = AttachType(sys.BPF_NETKIT_PRIMARY)
+	AttachNetkitPeer                 = AttachType(sys.BPF_NETKIT_PEER)
 )
 
 // AttachFlags of the eBPF program used in BPF_PROG_ATTACH command


### PR DESCRIPTION
Adds support for attaching bpf programs to [netkit devices](https://git.kernel.org/pub/scm/linux/kernel/git/bpf/bpf-next.git/commit/?id=22360fad5889cbefe1eca695b0cc0273ab280b56) using bpf links.

Generated code is currently based on `6.7-rc4`

TODO : 

- [x] Decide on a way to create `netkit` device in CI for testing.
- [x] Re-gen code once `6.7` is out and validate for any changes.