### PR TITLE
run-tests: fetch kernels and selftests from containers

### DIFF
--- a/docs/ebpf/contributing/index.md
+++ b/docs/ebpf/contributing/index.md
@@ -15,7 +15,7 @@ go test -exec sudo ./...
 ```
 
 To test the current package with a different kernel version you can use the [run-tests.sh] script.
-It requires [virtme] and qemu to be installed.
+It requires [virtme], qemu and docker to be installed.
 Unfortunately virtme is not well maintained at the moment, so we recommend installing
 a known working version:
 

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -96,8 +96,8 @@ elif [[ "${1:-}" = "--exec-test" ]]; then
   mount -t bpf bpf /sys/fs/bpf
   mount -t tracefs tracefs /sys/kernel/debug/tracing
 
-  if [[ -d "/run/input/bpf" ]]; then
-    export KERNEL_SELFTESTS="/run/input/bpf"
+  if [[ -d "/run/input/usr/src/linux/tools/testing/selftests/bpf" ]]; then
+    export KERNEL_SELFTESTS="/run/input/usr/src/linux/tools/testing/selftests/bpf"
   fi
 
   if [[ -d "/run/input/lib/modules" ]]; then
@@ -117,48 +117,41 @@ if [[ -z "${1:-}" ]]; then
   exit 1
 fi
 
-readonly input="$(mktemp -d)"
-readonly tmp_dir="${TMPDIR:-/tmp}"
+input="$(mktemp -d)"
+readonly input
 
-fetch() {
-    echo Fetching "${1}"
-    pushd "${tmp_dir}" > /dev/null
-    curl --no-progress-meter -L -O --fail --etag-compare "${1}.etag" --etag-save "${1}.etag" "https://github.com/cilium/ci-kernels/raw/${BRANCH:-master}/${1}"
-    local ret=$?
-    popd > /dev/null
-    return $ret
-}
+readonly docker="${CONTAINER_ENGINE:-docker}"
 
-machine="$(uname -m)"
-readonly machine
+extract_oci_image() {
+  local image_name=$1
+  local target_directory=$2
 
-if [[ -f "${1}" ]]; then
-  readonly kernel="${1}"
-  cp "${1}" "${input}/bzImage"
-else
-# LINUX_VERSION_CODE test compares this to discovered value.
-  export KERNEL_VERSION="${1}"
+  echo -n "Fetching $image_name... "
 
-  if [ "${machine}" = "x86_64" ]; then
-    readonly kernel="linux-${1}-amd64.tgz"
-    readonly selftests="linux-${1}-amd64-selftests-bpf.tgz"
-  elif [ "${machine}" = "aarch64" ]; then
-    readonly kernel="linux-${1}-arm64.tgz"
-    readonly selftests=""
-  else
-    echo "Arch ${machine} is not supported"
-    exit 1
+  # We abuse the --output flag of docker buildx to obtain a copy of the image.
+  # This is simpler than creating a temporary container and using docker cp.
+  # It also automatically fetches the image for us if necessary.
+  if ! echo "FROM $image_name" | "$docker" buildx build --quiet --pull --output="$target_directory" - &> /dev/null; then
+    echo "failed"
+    return 1
   fi
 
-  fetch "${kernel}"
-  tar xf "${tmp_dir}/${kernel}" -C "${input}"
+  echo "ok"
+  return 0
+}
 
-  if [ -n "${selftests}" ] && fetch "${selftests}"; then
-    echo "Decompressing selftests"
-    mkdir "${input}/bpf"
-    tar --strip-components=5 -xf "${tmp_dir}/${selftests}" -C "${input}/bpf"
-  else
-    echo "No selftests found, disabling"
+if [[ -f "${1}" ]]; then
+  # First argument is a local file.
+  readonly kernel="${1}"
+  cp "${1}" "${input}/boot/vmlinuz"
+else
+  readonly kernel="${1}"
+
+  # LINUX_VERSION_CODE test compares this to discovered value.
+  export KERNEL_VERSION="${1}"
+
+  if ! extract_oci_image "ghcr.io/cilium/ci-kernels:${kernel}-selftests" "${input}"; then
+    extract_oci_image "ghcr.io/cilium/ci-kernels:${kernel}" "${input}"
   fi
 fi
 shift


### PR DESCRIPTION
Use the new GH Actions built containers as a source for run-tests.sh.

Fixes: https://github.com/cilium/ebpf/issues/1258