### PR TITLE
cmd/bpf2go: rephrase GOPACKAGE error message

### DIFF
--- a/cmd/bpf2go/main.go
+++ b/cmd/bpf2go/main.go
@@ -149,7 +149,7 @@ func newB2G(stdout io.Writer, pkg, outputDir string, args []string) (*bpf2go, er
 	}
 
 	if b2g.pkg == "" {
-		return nil, errors.New("missing package, are you running via go generate?")
+		return nil, errors.New("missing package, have you set GOPACKAGE?")
 	}
 
 	if b2g.cc == "" {
@@ -484,6 +484,8 @@ func collectTargets(targets []string) (map[target][]string, error) {
 	return result, nil
 }
 
+const gopackageEnv = "GOPACKAGE"
+
 func main() {
 	outputDir, err := os.Getwd()
 	if err != nil {
@@ -491,7 +493,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err := run(os.Stdout, os.Getenv("GOPACKAGE"), outputDir, os.Args[1:]); err != nil {
+	if err := run(os.Stdout, os.Getenv(gopackageEnv), outputDir, os.Args[1:]); err != nil {
 		fmt.Fprintln(os.Stderr, "Error:", err)
 		os.Exit(1)
 	}

--- a/cmd/bpf2go/main_test.go
+++ b/cmd/bpf2go/main_test.go
@@ -105,6 +105,11 @@ func TestHelp(t *testing.T) {
 	}
 }
 
+func TestErrorMentionsEnvVar(t *testing.T) {
+	err := run(io.Discard, "", "", nil)
+	qt.Assert(t, qt.StringContains(err.Error(), gopackageEnv), qt.Commentf("Error should include name of environment variable"))
+}
+
 func TestDisableStripping(t *testing.T) {
 	dir := mustWriteTempFile(t, "test.c", minimalSocketFilter)
 


### PR DESCRIPTION
The current error message makes people think that bpf2go can only be invoked via go generate. In fact we just expect to find the package name in GOPACKAGE.

Reword the error and add a test to make sure that the error message mentions the variable.