### PR TITLE
link: fix TestUprobeExtWithOpts address

### DIFF
--- a/link/uprobe_test.go
+++ b/link/uprobe_test.go
@@ -117,9 +117,8 @@ func TestUprobeExtWithOpts(t *testing.T) {
 	// NB: It's not possible to invoke the uprobe since we use an arbitrary
 	// address.
 	up, err := bashEx.Uprobe("open", prog, &UprobeOptions{
-		// arm64 doesn't seem to allow addresses on the first page. Use
-		// the first byte of the second page.
-		Address: uint64(os.Getpagesize()),
+		// arm64 requires the addresses to be aligned (a multiple of 4)
+		Address: 0x4,
 	})
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
In c035e6ac we changed the address we pass when creating a perf_event uprobe to the first byte of the second page to support arm64. This however fails consistenly on my local setup (older intel machine). After some investigation, it turns out arm64 doesn't require the address to not be in the first page, but to be aligned with a multiple of 4.