### PR TITLE
program: fix raw_tracepoint run repeat check bug

### DIFF
--- a/prog.go
+++ b/prog.go
@@ -721,10 +721,6 @@ func (p *Program) run(opts *RunOptions) (uint32, time.Duration, error) {
 		Cpu:         opts.CPU,
 	}
 
-	if attr.Repeat == 0 {
-		attr.Repeat = 1
-	}
-
 retry:
 	for {
 		err := sys.ProgRun(&attr)
@@ -733,7 +729,7 @@ retry:
 		}
 
 		if errors.Is(err, unix.EINTR) {
-			if attr.Repeat == 1 {
+			if attr.Repeat <= 1 {
 				// Older kernels check whether enough repetitions have been
 				// executed only after checking for pending signals.
 				//

--- a/prog_test.go
+++ b/prog_test.go
@@ -136,6 +136,37 @@ func TestProgramRunWithOptions(t *testing.T) {
 	}
 }
 
+func TestProgramRunRawTracepoint(t *testing.T) {
+	testutils.SkipOnOldKernel(t, "5.10", "RawTracepoint test run")
+
+	ins := asm.Instructions{
+		// Return 0
+		asm.LoadImm(asm.R0, 0, asm.DWord),
+		asm.Return(),
+	}
+
+	prog, err := NewProgram(&ProgramSpec{
+		Name:         "test",
+		Type:         RawTracepoint,
+		Instructions: ins,
+		License:      "MIT",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer prog.Close()
+
+	ret, err := prog.Run(&RunOptions{})
+	testutils.SkipIfNotSupported(t, err)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if ret != 0 {
+		t.Error("Expected return value to be 0, got", ret)
+	}
+}
+
 func TestProgramRunEmptyData(t *testing.T) {
 	testutils.SkipOnOldKernel(t, "5.13", "sk_lookup BPF_PROG_RUN")
 


### PR DESCRIPTION
The `bpf_prog_test_run_raw_tp` function has a lazy check on `bpf_attr->test.repeat`: it checks that it's equal to 0 while it could check for <= 1.

```C
/* doesn't support data_in/out, ctx_out, duration, or repeat */
if (kattr->test.data_in || kattr->test.data_out ||
    kattr->test.ctx_out || kattr->test.duration ||
    kattr->test.repeat || kattr->test.batch_size)
	return -EINVAL;
```

Program.run was hard setting the repeat value to 1 in case of 0, preventing running any raw_tracepoint program. Now it handles special cases with repeat <= 0, and does not touch the value, letting the kernel handle the 0 value.