### PR TITLE
fix: add testcast for PutInteger

### DIFF
--- a/internal/kconfig/kconfig.go
+++ b/internal/kconfig/kconfig.go
@@ -263,6 +263,21 @@ func PutInteger(data []byte, integer *btf.Int, n uint64) error {
 		return fmt.Errorf("invalid boolean value: %d", n)
 	}
 
+	if len(data) < int(integer.Size) {
+		return fmt.Errorf("byte array size %d is less than the integer size %d", len(data), integer.Size)
+	}
+
+	upperBound := uint64(1<<(8*integer.Size) - 1)
+	lowerBound := uint64(math.MaxUint64)
+	if integer.Encoding == btf.Signed {
+		upperBound = uint64(1<<(8*integer.Size-1) - 1)
+		lowerBound = lowerBound - upperBound - 1
+	}
+
+	if !(n <= upperBound || lowerBound < n) {
+		return fmt.Errorf("%d exceeded the given byte range %d bytes size", n, integer.Size)
+	}
+
 	switch integer.Size {
 	case 1:
 		data[0] = byte(n)

--- a/internal/kconfig/kconfig.go
+++ b/internal/kconfig/kconfig.go
@@ -264,26 +264,24 @@ func PutInteger(data []byte, integer *btf.Int, n uint64) error {
 	}
 
 	if len(data) < int(integer.Size) {
-		return fmt.Errorf("byte array size %d is less than the integer size %d", len(data), integer.Size)
-	}
-
-	upperBound := uint64(1<<(8*integer.Size) - 1)
-	lowerBound := uint64(math.MaxUint64)
-	if integer.Encoding == btf.Signed {
-		upperBound = uint64(1<<(8*integer.Size-1) - 1)
-		lowerBound = lowerBound - upperBound - 1
-	}
-
-	if !(n <= upperBound || lowerBound < n) {
-		return fmt.Errorf("%d exceeded the given byte range %d bytes size", n, integer.Size)
+		return fmt.Errorf("can't fit an integer of size %d into a byte slice of length %d", integer.Size, len(data))
 	}
 
 	switch integer.Size {
 	case 1:
+		if integer.Encoding == btf.Signed && (n > math.MaxInt8 && n < math.MaxUint64-math.MaxInt8) {
+			return fmt.Errorf("can't represent %d as a signed integer of size %d", n, integer.Size)
+		}
 		data[0] = byte(n)
 	case 2:
+		if integer.Encoding == btf.Signed && (n > math.MaxInt16 && n < math.MaxUint64-math.MaxInt16) {
+			return fmt.Errorf("can't represent %d as a signed integer of size %d", n, integer.Size)
+		}
 		internal.NativeEndian.PutUint16(data, uint16(n))
 	case 4:
+		if integer.Encoding == btf.Signed && (n > math.MaxInt32 && n < math.MaxUint64-math.MaxInt32) {
+			return fmt.Errorf("can't represent %d as a signed integer of size %d", n, integer.Size)
+		}
 		internal.NativeEndian.PutUint32(data, uint32(n))
 	case 8:
 		internal.NativeEndian.PutUint64(data, uint64(n))


### PR DESCRIPTION
I've implemented three parts to catch errors.

1. Receive an error if the len(data) is less than integer.size.
2. if integer.Encoding is not signed, throw error if it exceeds the maximum value of the unsigned size.
3. if integer.Encoding is signed, throw error when n is in a range that cannot be converted from uint64.

![image](https://github.com/cilium/ebpf/assets/52873067/ef0a0fdb-c763-4566-a55d-b64db18ac0b5)

For example, the red part below throws an error.