### PR TITLE
examples: avoid depending on internal packages

### DIFF
--- a/examples/tcprtt/main.go
+++ b/examples/tcprtt/main.go
@@ -24,7 +24,6 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/cilium/ebpf/internal"
 	"github.com/cilium/ebpf/link"
 	"github.com/cilium/ebpf/ringbuf"
 	"github.com/cilium/ebpf/rlimit"
@@ -90,7 +89,7 @@ func readLoop(rd *ringbuf.Reader) {
 		}
 
 		// Parse the ringbuf event entry into a bpfEvent structure.
-		if err := binary.Read(bytes.NewBuffer(record.RawSample), internal.NativeEndian, &event); err != nil {
+		if err := binary.Read(bytes.NewBuffer(record.RawSample), binary.NativeEndian, &event); err != nil {
 			log.Printf("parsing ringbuf event: %s", err)
 			continue
 		}
@@ -108,6 +107,6 @@ func readLoop(rd *ringbuf.Reader) {
 // intToIP converts IPv4 number to net.IP
 func intToIP(ipNum uint32) net.IP {
 	ip := make(net.IP, 4)
-	internal.NativeEndian.PutUint32(ip, ipNum)
+	binary.NativeEndian.PutUint32(ip, ipNum)
 	return ip
 }

--- a/examples/tcprtt_sockops/main.go
+++ b/examples/tcprtt_sockops/main.go
@@ -32,7 +32,6 @@ import (
 	"syscall"
 
 	"github.com/cilium/ebpf"
-	"github.com/cilium/ebpf/internal"
 	"github.com/cilium/ebpf/link"
 	"github.com/cilium/ebpf/ringbuf"
 	"github.com/cilium/ebpf/rlimit"
@@ -126,7 +125,7 @@ func readLoop(rd *ringbuf.Reader) {
 		}
 
 		// Parse the ringbuf event entry into a bpfRttEvent structure.
-		if err := binary.Read(bytes.NewBuffer(record.RawSample), internal.NativeEndian, &event); err != nil {
+		if err := binary.Read(bytes.NewBuffer(record.RawSample), binary.NativeEndian, &event); err != nil {
 			log.Printf("parsing ringbuf event: %s", err)
 			continue
 		}


### PR DESCRIPTION
Technically this builds fine in CI, but these are supposed to function from outside the repo's ebpf module as well. These internal references were added after we removed the separate Go module from examples/.

Supersedes #1288

Thanks @antoniomerlin for reporting!