### PR TITLE
Add link.Info.TCX method

### DIFF
--- a/link/link.go
+++ b/link/link.go
@@ -168,6 +168,14 @@ func (r Info) XDP() *XDPInfo {
 	return e
 }
 
+// TCX returns TCX type-specific link info.
+//
+// Returns nil if the type-specific link info isn't available.
+func (r Info) TCX() *TCXInfo {
+	e, _ := r.extra.(*TCXInfo)
+	return e
+}
+
 // RawLink is the low-level API to bpf_link.
 //
 // You should consider using the higher level interfaces in this

--- a/link/link_test.go
+++ b/link/link_test.go
@@ -204,6 +204,11 @@ func testLink(t *testing.T, link Link, prog *ebpf.Program) {
 			if xdp.Ifindex == 0 {
 				t.Fatalf("Failed to get link XDP extra info")
 			}
+		case sys.BPF_LINK_TYPE_TCX:
+			tcx := info.TCX()
+			if tcx.Ifindex == 0 {
+				t.Fatalf("Failed to get link TCX extra info")
+			}
 		}
 	})
 


### PR DESCRIPTION
Just like for other link types, this commit adds a method for retrieving TCX link specific extra metadata info.