### PR TITLE
link: add feature test for tcx

### DIFF
--- a/link/syscalls.go
+++ b/link/syscalls.go
@@ -125,3 +125,24 @@ var haveProgQuery = internal.NewFeatureTest("BPF_PROG_QUERY", "4.15", func() err
 	}
 	return errors.New("syscall succeeded unexpectedly")
 })
+
+var haveTCX = internal.NewFeatureTest("tcx", "6.6", func() error {
+	attr := sys.LinkCreateTcxAttr{
+		// We rely on this being checked during the syscall.
+		// With an otherwise correct payload we expect EBADF here
+		// as an indication that the feature is present.
+		ProgFd:        ^uint32(0),
+		TargetIfindex: ^uint32(0),
+		AttachType:    sys.AttachType(ebpf.AttachTCXIngress),
+	}
+
+	_, err := sys.LinkCreateTcx(&attr)
+
+	if errors.Is(err, unix.EBADF) {
+		return nil
+	}
+	if err != nil {
+		return ErrNotSupported
+	}
+	return errors.New("syscall succeeded unexpectedly")
+})

--- a/link/syscalls_test.go
+++ b/link/syscalls_test.go
@@ -21,3 +21,7 @@ func TestHaveBPFLink(t *testing.T) {
 func TestHaveProgQuery(t *testing.T) {
 	testutils.CheckFeatureTest(t, haveProgQuery)
 }
+
+func TestHaveTCX(t *testing.T) {
+	testutils.CheckFeatureTest(t, haveTCX)
+}

--- a/link/tcx.go
+++ b/link/tcx.go
@@ -55,6 +55,9 @@ func AttachTCX(opts TCXOptions) (Link, error) {
 	runtime.KeepAlive(opts.Program)
 	runtime.KeepAlive(opts.Anchor)
 	if err != nil {
+		if haveFeatErr := haveTCX(); haveFeatErr != nil {
+			return nil, haveFeatErr
+		}
 		return nil, fmt.Errorf("attach tcx link: %w", err)
 	}
 


### PR DESCRIPTION
As with many of the other existing APIs, this adds a feature test for tcx to indicate to the user if the underlying kernel APIs are available in the running kernel.