### PR TITLE
Add support to retrieve missed counts from probes

### DIFF
--- a/internal/sys/syscall.go
+++ b/internal/sys/syscall.go
@@ -99,6 +99,10 @@ func (i *NetkitLinkInfo) info() (unsafe.Pointer, uint32) {
 	return unsafe.Pointer(i), uint32(unsafe.Sizeof(*i))
 }
 
+func (i *KprobeMultiLinkInfo) info() (unsafe.Pointer, uint32) {
+	return unsafe.Pointer(i), uint32(unsafe.Sizeof(*i))
+}
+
 var _ Info = (*BtfInfo)(nil)
 
 func (i *BtfInfo) info() (unsafe.Pointer, uint32) {

--- a/internal/sys/syscall.go
+++ b/internal/sys/syscall.go
@@ -105,6 +105,10 @@ func (i *BtfInfo) info() (unsafe.Pointer, uint32) {
 	return unsafe.Pointer(i), uint32(unsafe.Sizeof(*i))
 }
 
+func (i *PerfEventLinkInfo) info() (unsafe.Pointer, uint32) {
+	return unsafe.Pointer(i), uint32(unsafe.Sizeof(*i))
+}
+
 // ObjInfo retrieves information about a BPF Fd.
 //
 // info may be one of MapInfo, ProgInfo, LinkInfo and BtfInfo.

--- a/internal/sys/syscall.go
+++ b/internal/sys/syscall.go
@@ -103,6 +103,10 @@ func (i *KprobeMultiLinkInfo) info() (unsafe.Pointer, uint32) {
 	return unsafe.Pointer(i), uint32(unsafe.Sizeof(*i))
 }
 
+func (i *KprobeLinkInfo) info() (unsafe.Pointer, uint32) {
+	return unsafe.Pointer(i), uint32(unsafe.Sizeof(*i))
+}
+
 var _ Info = (*BtfInfo)(nil)
 
 func (i *BtfInfo) info() (unsafe.Pointer, uint32) {

--- a/internal/sys/types.go
+++ b/internal/sys/types.go
@@ -402,6 +402,18 @@ const (
 	BPF_MAP_TYPE_CGRP_STORAGE                     MapType = 32
 )
 
+type PerfEventType uint32
+
+const (
+	BPF_PERF_EVENT_UNSPEC     PerfEventType = 0
+	BPF_PERF_EVENT_UPROBE     PerfEventType = 1
+	BPF_PERF_EVENT_URETPROBE  PerfEventType = 2
+	BPF_PERF_EVENT_KPROBE     PerfEventType = 3
+	BPF_PERF_EVENT_KRETPROBE  PerfEventType = 4
+	BPF_PERF_EVENT_TRACEPOINT PerfEventType = 5
+	BPF_PERF_EVENT_EVENT      PerfEventType = 6
+)
+
 type ProgType uint32
 
 const (
@@ -1263,6 +1275,32 @@ type IterLinkInfo struct {
 	TargetNameLen uint32
 }
 
+type KprobeLinkInfo struct {
+	Type          LinkType
+	Id            LinkID
+	ProgId        uint32
+	_             [4]byte
+	PerfEventType PerfEventType
+	_             [4]byte
+	FuncName      Pointer
+	NameLen       uint32
+	Offset        uint32
+	Addr          uint64
+	Missed        uint64
+}
+
+type KprobeMultiLinkInfo struct {
+	Type   LinkType
+	Id     LinkID
+	ProgId uint32
+	_      [4]byte
+	Addrs  Pointer
+	Count  uint32
+	Flags  uint32
+	Missed uint64
+	_      [16]byte
+}
+
 type NetNsLinkInfo struct {
 	Type       LinkType
 	Id         LinkID
@@ -1293,6 +1331,14 @@ type NetkitLinkInfo struct {
 	Ifindex    uint32
 	AttachType AttachType
 	_          [32]byte
+}
+
+type PerfEventLinkInfo struct {
+	Type          LinkType
+	Id            LinkID
+	ProgId        uint32
+	_             [4]byte
+	PerfEventType PerfEventType
 }
 
 type RawTracepointLinkInfo struct {

--- a/link/link_test.go
+++ b/link/link_test.go
@@ -286,6 +286,21 @@ func testLink(t *testing.T, link Link, prog *ebpf.Program) {
 				// NB: We don't check that missed is actually correct
 				// since it's not easy to trigger from tests.
 			}
+		case sys.BPF_LINK_TYPE_PERF_EVENT:
+			// test default Info data
+			pevent := info.PerfEvent()
+			switch pevent.Type {
+			case sys.BPF_PERF_EVENT_KPROBE, sys.BPF_PERF_EVENT_KRETPROBE:
+				kp := pevent.Kprobe()
+				if addr, ok := kp.Address(); ok {
+					qt.Assert(t, qt.Not(qt.Equals(addr, 0)))
+
+					_, ok := kp.Missed()
+					qt.Assert(t, qt.IsTrue(ok))
+					// NB: We don't check that missed is actually correct
+					// since it's not easy to trigger from tests.
+				}
+			}
 		}
 	})
 

--- a/link/link_test.go
+++ b/link/link_test.go
@@ -275,6 +275,17 @@ func testLink(t *testing.T, link Link, prog *ebpf.Program) {
 			if nf.Priority == 0 {
 				t.Fatalf("Failed to get link Netfilter extra info")
 			}
+		case sys.BPF_LINK_TYPE_KPROBE_MULTI:
+			// test default Info data
+			kmulti := info.KprobeMulti()
+			if count, ok := kmulti.AddressCount(); ok {
+				qt.Assert(t, qt.Not(qt.Equals(count, 0)))
+
+				_, ok = kmulti.Missed()
+				qt.Assert(t, qt.IsTrue(ok))
+				// NB: We don't check that missed is actually correct
+				// since it's not easy to trigger from tests.
+			}
 		}
 	})
 


### PR DESCRIPTION
adding support to get info data from kprobe_multi/perf_events probes, using it in tetragon [1941](https://github.com/cilium/tetragon/pull/1941)