### PR TITLE
cmd/bpf2go: Make LoongArch a supported target

### DIFF
--- a/cmd/bpf2go/main.go
+++ b/cmd/bpf2go/main.go
@@ -53,7 +53,7 @@ var targetByGoArch = map[string]target{
 	"amd64p32":    {"bpfel", ""},
 	"arm":         {"bpfel", "arm"},
 	"arm64":       {"bpfel", "arm64"},
-	"loong64":     {"bpfel", ""},
+	"loong64":     {"bpfel", "loongarch"},
 	"mipsle":      {"bpfel", ""},
 	"mips64le":    {"bpfel", ""},
 	"mips64p32le": {"bpfel", ""},


### PR DESCRIPTION
In #975, someone added support for the loong64 GOARCH, but did't provide a Linux string for it. Since the upstream support ([0]) has already landed, let's add the missing Linux string and make LoongArch a supported target.

  [0]: https://github.com/torvalds/linux/commit/00883922ab40