### PR TITLE
Add support to test update library with local kernel

### DIFF
--- a/docs/ebpf/contributing/index.md
+++ b/docs/ebpf/contributing/index.md
@@ -67,6 +67,16 @@ from upstream kernel versions. You can update them to the latest version by:
 
 Finally, bump the tested kernels in `.github/workflows/ci.yml`
 
+Note it's possible to set `KERNEL_VERSION` to location of kernel build artifacts
+and update the kernel dependencies to your local kernel build, like:
+
+  ```shell-session
+  $ ls ../data/
+  bpf_testmod.ko  libbpf.c  vmlinux
+
+  $ make update-kernel-deps KERNEL_VERSION=../data
+  ```
+
 ## Project permissions
 
 If you'd like to contribute to the library more regularly, one of the

--- a/testdata/sh/update-kernel-deps.sh
+++ b/testdata/sh/update-kernel-deps.sh
@@ -12,14 +12,25 @@ cleanup() {
 
 trap cleanup EXIT
 
-# Download and process libbpf.c
-curl -fL "https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/plain/tools/lib/bpf/libbpf.c?h=v$KERNEL_VERSION" -o "$tmp/libbpf.c"
+if [ -d $KERNEL_VERSION ]; then
+  # Copy libbpf/vmlinux/bpf_testmod from local directory
+  cp $KERNEL_VERSION/libbpf.c $tmp
+  cp $KERNEL_VERSION/vmlinux $tmp
+  mkdir -p $tmp/lib/modules
+  cp $KERNEL_VERSION/bpf_testmod.ko $tmp/lib/modules
+else
+  # Download libbpf.c
+  curl -fL "https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/plain/tools/lib/bpf/libbpf.c?h=v$KERNEL_VERSION" -o "$tmp/libbpf.c"
+
+  # Download vmlinux and btf_testmod
+  extract_oci_image "ghcr.io/cilium/ci-kernels:$KERNEL_VERSION" "$tmp"
+
+  "/lib/modules/$(uname -r)/build/scripts/extract-vmlinux" "$tmp/boot/vmlinuz" > "$tmp/vmlinux"
+fi
+
+# Process libbpf.c
 "./internal/cmd/gensections.awk" "$tmp/libbpf.c" | gofmt > "./elf_sections.go"
 
-# Download and process vmlinux and btf_testmod
-extract_oci_image "ghcr.io/cilium/ci-kernels:$KERNEL_VERSION" "$tmp"
-
-"/lib/modules/$(uname -r)/build/scripts/extract-vmlinux" "$tmp/boot/vmlinuz" > "$tmp/vmlinux"
-
+# Process vmlinux and btf_testmod
 objcopy --dump-section .BTF=/dev/stdout "$tmp/vmlinux" /dev/null | gzip > "btf/testdata/vmlinux.btf.gz"
 find "$tmp/lib/modules" -type f -name bpf_testmod.ko -exec objcopy --dump-section .BTF="btf/testdata/btf_testmod.btf" {} /dev/null \;


### PR DESCRIPTION
Adding support to update update library with local kernel by passing local directory through KERNEL_VERSION, like:

```
  $ ls ../data/
  bpf_testmod.ko  libbpf.c  vmlinux

  $ make update-kernel-deps KERNEL_VERSION=../data
```

This allows to test latest kernel uapi changes with ebpf/cilium library and tetragon.