### PR TITLE
For s390x arch the auto generated go object's name needs to have s390x prefix

### DIFF
--- a/cmd/bpf2go/main.go
+++ b/cmd/bpf2go/main.go
@@ -309,7 +309,12 @@ func (b2g *bpf2go) convert(tgt target, goarches []goarch) (err error) {
 	}
 	stem := fmt.Sprintf("%s_%s", outputStem, tgt.clang)
 	if tgt.linux != "" {
-		stem = fmt.Sprintf("%s_%s_%s", outputStem, tgt.clang, tgt.linux)
+		// for s390 target GOARCH has to be s390x
+		if tgt.linux == "390" {
+			stem = fmt.Sprintf("%s_%s_%s", outputStem, tgt.clang, "s390x")
+		} else {
+			stem = fmt.Sprintf("%s_%s_%s", outputStem, tgt.clang, tgt.linux)
+		}
 	}
 
 	objFileName := filepath.Join(b2g.outputDir, stem+".o")

--- a/cmd/bpf2go/main_test.go
+++ b/cmd/bpf2go/main_test.go
@@ -187,6 +187,12 @@ func TestCollectTargets(t *testing.T) {
 			},
 		},
 		{
+			[]string{"s390x"},
+			map[target][]goarch{
+				{"bpfeb", "s390"}: linuxArchesBE["s390"],
+			},
+		},
+		{
 			[]string{"native"},
 			nativeTarget,
 		},


### PR DESCRIPTION
`s390` is not a valid `GOARCH` changing yje auto generated go file to use `s390x` arch instead.
fix #1307 