### PR TITLE
cmd/bpf2go: enable building custom tools (wip)

### DIFF
--- a/cmd/bpf2go/compile.go
+++ b/cmd/bpf2go/compile.go
@@ -28,7 +28,7 @@ type compileArgs struct {
 	dep io.Writer
 }
 
-func compile(args compileArgs) error {
+func compile(args compileArgs, tc TargetCustomisations) error {
 	// Default cflags that can be overridden by args.cFlags
 	overrideFlags := []string{
 		// Code needs to be optimized, otherwise the verifier will often fail
@@ -90,7 +90,7 @@ func compile(args compileArgs) error {
 		)
 	}
 
-	if err := cmd.Run(); err != nil {
+	if err := tc.Compile(cmd); err != nil {
 		return fmt.Errorf("can't execute %s: %s", args.cc, err)
 	}
 
@@ -200,10 +200,10 @@ func parseDependencies(baseDir string, in io.Reader) ([]dependency, error) {
 }
 
 // strip DWARF debug info from file by executing exe.
-func strip(exe, file string) error {
+func strip(exe, file string, tc TargetCustomisations) error {
 	cmd := exec.Command(exe, "-g", file)
 	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
+	if err := tc.Strip(cmd); err != nil {
 		return fmt.Errorf("%s: %s", exe, err)
 	}
 	return nil

--- a/cmd/bpf2go/compile_test.go
+++ b/cmd/bpf2go/compile_test.go
@@ -22,7 +22,7 @@ func TestCompile(t *testing.T) {
 		source: filepath.Join(dir, "test.c"),
 		dest:   filepath.Join(dir, "test.o"),
 		dep:    &dep,
-	})
+	}, &CustomisationsBase{})
 	if err != nil {
 		t.Fatal("Can't compile:", err)
 	}
@@ -55,7 +55,7 @@ func TestReproducibleCompile(t *testing.T) {
 		dir:    dir,
 		source: filepath.Join(dir, "test.c"),
 		dest:   filepath.Join(dir, "a.o"),
-	})
+	}, &CustomisationsBase{})
 	if err != nil {
 		t.Fatal("Can't compile:", err)
 	}
@@ -65,7 +65,7 @@ func TestReproducibleCompile(t *testing.T) {
 		dir:    dir,
 		source: filepath.Join(dir, "test.c"),
 		dest:   filepath.Join(dir, "b.o"),
-	})
+	}, &CustomisationsBase{})
 	if err != nil {
 		t.Fatal("Can't compile:", err)
 	}
@@ -94,7 +94,7 @@ func TestTriggerMissingTarget(t *testing.T) {
 		dir:    dir,
 		source: filepath.Join(dir, "test.c"),
 		dest:   filepath.Join(dir, "a.o"),
-	})
+	}, &CustomisationsBase{})
 
 	if err == nil {
 		t.Fatal("No error when compiling __BPF_TARGET_MISSING")

--- a/cmd/bpf2go/customisations.go
+++ b/cmd/bpf2go/customisations.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"flag"
+	"io"
+	"os/exec"
+
+	"github.com/cilium/ebpf"
+)
+
+// Run implements bpf2go tool; leverage bpf2go and build custom tools on
+// top by providing Customisations
+func Run(stdout io.Writer, pkg, outputDir string, args []string, c Customisations) (err error) {
+	return run(stdout, pkg, outputDir, args, c)
+}
+
+// Customisations enables building custom tools on top of bpf2go
+type Customisations interface {
+	// ModifyFlags adds custom tool's own flags
+	ModifyFlags(*flag.FlagSet)
+
+	// NewTarget provides decdicated TargetCustomisations per target; a
+	// custom tool implements further customisations via
+	// TargetCustomisations (can contain target-specific state)
+	NewTarget(target) TargetCustomisations
+}
+
+// TargetCustomisations enables building custom tools on top of bpf2go
+type TargetCustomisations interface {
+	// Compile compiles C source code; instead of running the provided
+	// command as is, a custom tool could do something more exciting,
+	// such as transparently running compiler in a Docker container or
+	// implement a cache, or even run a custom preprocessor to have
+	// e.g. golang package-aware includes
+	Compile(*exec.Cmd) error
+
+	// Strip strips the object file; instead of running the provided
+	// command as is, a custom tool could do something more exciting
+	// such as transparently running strip in a Docker container or
+	// implement a cache
+	Strip(*exec.Cmd) error
+
+	// AugmentSpec optionally adds to the spec; e.g. a custom tool could
+	// add types from DWARF debug info so that the tool could generate
+	// golang type even when C type is not included in BTF
+	AugmentSpec(*ebpf.CollectionSpec) error
+}
+
+// CustomisationsBase is a baseline implementation of Cusomisations,
+// TargetCustomisations
+type CustomisationsBase struct{}
+
+func (cb *CustomisationsBase) ModifyFlags(fs *flag.FlagSet) {}
+
+func (cb *CustomisationsBase) NewTarget(target) TargetCustomisations { return cb }
+
+func (cb *CustomisationsBase) Compile(cmd *exec.Cmd) error {
+	return cmd.Run()
+}
+
+func (cb *CustomisationsBase) Strip(cmd *exec.Cmd) error {
+	return cmd.Run()
+}
+
+func (cb *CustomisationsBase) AugmentSpec(*ebpf.CollectionSpec) error {
+	return nil
+}

--- a/cmd/bpf2go/main_test.go
+++ b/cmd/bpf2go/main_test.go
@@ -66,7 +66,7 @@ func TestRun(t *testing.T) {
 		"-target", strings.Join(goarches, ","),
 		"bar",
 		filepath.Join(dir, "test.c"),
-	})
+	}, &CustomisationsBase{})
 
 	if err != nil {
 		t.Fatal("Can't run:", err)
@@ -102,7 +102,7 @@ func main() {
 
 func TestHelp(t *testing.T) {
 	var stdout bytes.Buffer
-	err := run(&stdout, "", "", []string{"-help"})
+	err := run(&stdout, "", "", []string{"-help"}, &CustomisationsBase{})
 	if err != nil {
 		t.Fatal("Can't execute -help")
 	}
@@ -113,7 +113,7 @@ func TestHelp(t *testing.T) {
 }
 
 func TestErrorMentionsEnvVar(t *testing.T) {
-	err := run(io.Discard, "", "", nil)
+	err := run(io.Discard, "", "", nil, &CustomisationsBase{})
 	qt.Assert(t, qt.StringContains(err.Error(), gopackageEnv), qt.Commentf("Error should include name of environment variable"))
 }
 
@@ -127,7 +127,7 @@ func TestDisableStripping(t *testing.T) {
 		"-no-strip",
 		"bar",
 		filepath.Join(dir, "test.c"),
-	})
+	}, &CustomisationsBase{})
 
 	if err != nil {
 		t.Fatal("Can't run with stripping disabled:", err)
@@ -251,6 +251,7 @@ func TestConvertGOARCH(t *testing.T) {
 		disableStripping: true,
 		sourceFile:       tmp + "/test.c",
 		outputDir:        tmp,
+		customisations:   &CustomisationsBase{},
 	}
 
 	if err := b2g.convert(targetByGoArch["amd64"], nil); err != nil {
@@ -299,11 +300,12 @@ func TestParseArgs(t *testing.T) {
 		csource   = "testdata/minimal.c"
 		stem      = "a"
 	)
+	c := &CustomisationsBase{}
 
 	t.Run("makebase", func(t *testing.T) {
 		basePath, _ := filepath.Abs("barfoo")
 		args := []string{"-makebase", basePath, stem, csource}
-		b2g, err := newB2G(&bytes.Buffer{}, pkg, outputDir, args)
+		b2g, err := newB2G(&bytes.Buffer{}, pkg, outputDir, args, c)
 		qt.Assert(t, qt.IsNil(err))
 		qt.Assert(t, qt.Equals(b2g.makeBase, basePath))
 	})
@@ -312,7 +314,7 @@ func TestParseArgs(t *testing.T) {
 		basePath, _ := filepath.Abs("barfoo")
 		args := []string{stem, csource}
 		t.Setenv("BPF2GO_MAKEBASE", basePath)
-		b2g, err := newB2G(&bytes.Buffer{}, pkg, outputDir, args)
+		b2g, err := newB2G(&bytes.Buffer{}, pkg, outputDir, args, c)
 		qt.Assert(t, qt.IsNil(err))
 		qt.Assert(t, qt.Equals(b2g.makeBase, basePath))
 	})
@@ -322,21 +324,21 @@ func TestParseArgs(t *testing.T) {
 		basePathEnv, _ := filepath.Abs("foobar")
 		args := []string{"-makebase", basePathFlag, stem, csource}
 		t.Setenv("BPF2GO_MAKEBASE", basePathEnv)
-		b2g, err := newB2G(&bytes.Buffer{}, pkg, outputDir, args)
+		b2g, err := newB2G(&bytes.Buffer{}, pkg, outputDir, args, c)
 		qt.Assert(t, qt.IsNil(err))
 		qt.Assert(t, qt.Equals(b2g.makeBase, basePathFlag))
 	})
 
 	t.Run("cc defaults to clang", func(t *testing.T) {
 		args := []string{stem, csource}
-		b2g, err := newB2G(&bytes.Buffer{}, pkg, outputDir, args)
+		b2g, err := newB2G(&bytes.Buffer{}, pkg, outputDir, args, c)
 		qt.Assert(t, qt.IsNil(err))
 		qt.Assert(t, qt.Equals(b2g.cc, "clang"))
 	})
 
 	t.Run("cc", func(t *testing.T) {
 		args := []string{"-cc", "barfoo", stem, csource}
-		b2g, err := newB2G(&bytes.Buffer{}, pkg, outputDir, args)
+		b2g, err := newB2G(&bytes.Buffer{}, pkg, outputDir, args, c)
 		qt.Assert(t, qt.IsNil(err))
 		qt.Assert(t, qt.Equals(b2g.cc, "barfoo"))
 	})
@@ -344,7 +346,7 @@ func TestParseArgs(t *testing.T) {
 	t.Run("cc from env", func(t *testing.T) {
 		args := []string{stem, csource}
 		t.Setenv("BPF2GO_CC", "barfoo")
-		b2g, err := newB2G(&bytes.Buffer{}, pkg, outputDir, args)
+		b2g, err := newB2G(&bytes.Buffer{}, pkg, outputDir, args, c)
 		qt.Assert(t, qt.IsNil(err))
 		qt.Assert(t, qt.Equals(b2g.cc, "barfoo"))
 	})
@@ -352,21 +354,21 @@ func TestParseArgs(t *testing.T) {
 	t.Run("cc flag overrides env", func(t *testing.T) {
 		args := []string{"-cc", "barfoo", stem, csource}
 		t.Setenv("BPF2GO_CC", "foobar")
-		b2g, err := newB2G(&bytes.Buffer{}, pkg, outputDir, args)
+		b2g, err := newB2G(&bytes.Buffer{}, pkg, outputDir, args, c)
 		qt.Assert(t, qt.IsNil(err))
 		qt.Assert(t, qt.Equals(b2g.cc, "barfoo"))
 	})
 
 	t.Run("strip defaults to llvm-strip", func(t *testing.T) {
 		args := []string{stem, csource}
-		b2g, err := newB2G(&bytes.Buffer{}, pkg, outputDir, args)
+		b2g, err := newB2G(&bytes.Buffer{}, pkg, outputDir, args, c)
 		qt.Assert(t, qt.IsNil(err))
 		qt.Assert(t, qt.Equals(b2g.strip, "llvm-strip"))
 	})
 
 	t.Run("strip", func(t *testing.T) {
 		args := []string{"-strip", "barfoo", stem, csource}
-		b2g, err := newB2G(&bytes.Buffer{}, pkg, outputDir, args)
+		b2g, err := newB2G(&bytes.Buffer{}, pkg, outputDir, args, c)
 		qt.Assert(t, qt.IsNil(err))
 		qt.Assert(t, qt.Equals(b2g.strip, "barfoo"))
 	})
@@ -374,7 +376,7 @@ func TestParseArgs(t *testing.T) {
 	t.Run("strip from env", func(t *testing.T) {
 		args := []string{stem, csource}
 		t.Setenv("BPF2GO_STRIP", "barfoo")
-		b2g, err := newB2G(&bytes.Buffer{}, pkg, outputDir, args)
+		b2g, err := newB2G(&bytes.Buffer{}, pkg, outputDir, args, c)
 		qt.Assert(t, qt.IsNil(err))
 		qt.Assert(t, qt.Equals(b2g.strip, "barfoo"))
 	})
@@ -382,42 +384,42 @@ func TestParseArgs(t *testing.T) {
 	t.Run("strip flag overrides env", func(t *testing.T) {
 		args := []string{"-strip", "barfoo", stem, csource}
 		t.Setenv("BPF2GO_STRIP", "foobar")
-		b2g, err := newB2G(&bytes.Buffer{}, pkg, outputDir, args)
+		b2g, err := newB2G(&bytes.Buffer{}, pkg, outputDir, args, c)
 		qt.Assert(t, qt.IsNil(err))
 		qt.Assert(t, qt.Equals(b2g.strip, "barfoo"))
 	})
 
 	t.Run("no strip defaults to false", func(t *testing.T) {
 		args := []string{stem, csource}
-		b2g, err := newB2G(&bytes.Buffer{}, pkg, outputDir, args)
+		b2g, err := newB2G(&bytes.Buffer{}, pkg, outputDir, args, c)
 		qt.Assert(t, qt.IsNil(err))
 		qt.Assert(t, qt.IsFalse(b2g.disableStripping))
 	})
 
 	t.Run("no strip", func(t *testing.T) {
 		args := []string{"-no-strip", stem, csource}
-		b2g, err := newB2G(&bytes.Buffer{}, pkg, outputDir, args)
+		b2g, err := newB2G(&bytes.Buffer{}, pkg, outputDir, args, c)
 		qt.Assert(t, qt.IsNil(err))
 		qt.Assert(t, qt.IsTrue(b2g.disableStripping))
 	})
 
 	t.Run("cflags flag", func(t *testing.T) {
 		args := []string{"-cflags", "x y z", stem, csource}
-		b2g, err := newB2G(&bytes.Buffer{}, pkg, outputDir, args)
+		b2g, err := newB2G(&bytes.Buffer{}, pkg, outputDir, args, c)
 		qt.Assert(t, qt.IsNil(err))
 		qt.Assert(t, qt.DeepEquals(b2g.cFlags, []string{"x", "y", "z"}))
 	})
 
 	t.Run("cflags multi flag", func(t *testing.T) {
 		args := []string{"-cflags", "x y z", "-cflags", "u v", stem, csource}
-		b2g, err := newB2G(&bytes.Buffer{}, pkg, outputDir, args)
+		b2g, err := newB2G(&bytes.Buffer{}, pkg, outputDir, args, c)
 		qt.Assert(t, qt.IsNil(err))
 		qt.Assert(t, qt.DeepEquals(b2g.cFlags, []string{"u", "v"}))
 	})
 
 	t.Run("cflags flag and args", func(t *testing.T) {
 		args := []string{"-cflags", "x y z", "stem", csource, "--", "u", "v"}
-		b2g, err := newB2G(&bytes.Buffer{}, pkg, outputDir, args)
+		b2g, err := newB2G(&bytes.Buffer{}, pkg, outputDir, args, c)
 		qt.Assert(t, qt.IsNil(err))
 		qt.Assert(t, qt.DeepEquals(b2g.cFlags, []string{"x", "y", "z", "u", "v"}))
 	})
@@ -425,7 +427,7 @@ func TestParseArgs(t *testing.T) {
 	t.Run("cflags from env", func(t *testing.T) {
 		args := []string{stem, csource}
 		t.Setenv("BPF2GO_CFLAGS", "x y z")
-		b2g, err := newB2G(&bytes.Buffer{}, pkg, outputDir, args)
+		b2g, err := newB2G(&bytes.Buffer{}, pkg, outputDir, args, c)
 		qt.Assert(t, qt.IsNil(err))
 		qt.Assert(t, qt.DeepEquals(b2g.cFlags, []string{"x", "y", "z"}))
 	})
@@ -433,7 +435,7 @@ func TestParseArgs(t *testing.T) {
 	t.Run("cflags flag overrides env", func(t *testing.T) {
 		args := []string{"-cflags", "u v", stem, csource}
 		t.Setenv("BPF2GO_CFLAGS", "x y z")
-		b2g, err := newB2G(&bytes.Buffer{}, pkg, outputDir, args)
+		b2g, err := newB2G(&bytes.Buffer{}, pkg, outputDir, args, c)
 		qt.Assert(t, qt.IsNil(err))
 		qt.Assert(t, qt.DeepEquals(b2g.cFlags, []string{"u", "v"}))
 	})


### PR DESCRIPTION
lmb once said: My personal preference would be to make the parts of bpf2go that are useful available via Go API so that power users can build their own tools.

Turning bpf2go code into a library of reusable components is a massive effort. The resulting API surface would be quite large and it will be hard to commit to API stability.

Explore the next best option:

 - expose bpf2go Run for use by custom tools built on top;

 - provide hooks to make it possible to customise certain aspects of bpf2go.

Hook interface is purposedly minimal, based on demand, and gives no API stability guarantees.

It will enable the community to experiment with new powerful features and immediately benefit from these new features in their projects. Hopefully, users will still work towards getting their features accepted.

If it so happens that a feature is not in line with cilium/ebpf goals users could stick to their custom tool while benefitting from the upstream effort going into improving bpf2go.