### PR TITLE
bump minimum Go to 1.21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,8 @@ env:
   TMPDIR: /tmp
   CI_MAX_KERNEL_VERSION: '6.6'
   CI_MIN_CLANG_VERSION: '11'
-  go_version: '~1.21'
-  prev_go_version: '~1.20'
+  go_version: '~1.22'
+  prev_go_version: '~1.21'
   # This needs to match whatever Netlify supports.
   # Also defined in Pipfile.
   python_version: '~3.8'

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cilium/ebpf
 
-go 1.20
+go 1.21.0
 
 require (
 	github.com/go-quicktest/qt v1.101.0


### PR DESCRIPTION
1.22 has been released, bump minimum version to 1.21.