### PR TITLE
dependabot: onboard github actions upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,7 @@ updates:
       # dependencies only appearing in Pipfile.lock.
       - dependency-name: "*"
         dependency-type: "direct"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
We currently have a lot of github actions missing upgrades, resulting in some 
```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/setup-go@v4 ...
```
[warnings](https://github.com/cilium/ebpf/actions/runs/7817377529).

This PR onboards the github actions workflows into dependabot, which should make our life updating those easier.