### PR TITLE
map: rename BatchCursor to MapBatchCursor

### DIFF
--- a/map.go
+++ b/map.go
@@ -975,7 +975,7 @@ func (m *Map) guessNonExistentKey() ([]byte, error) {
 // ErrKeyNotExist is returned when the batch lookup has reached
 // the end of all possible results, even when partial results
 // are returned. It should be used to evaluate when lookup is "done".
-func (m *Map) BatchLookup(cursor *BatchCursor, keysOut, valuesOut interface{}, opts *BatchOptions) (int, error) {
+func (m *Map) BatchLookup(cursor *MapBatchCursor, keysOut, valuesOut interface{}, opts *BatchOptions) (int, error) {
 	return m.batchLookup(sys.BPF_MAP_LOOKUP_BATCH, cursor, keysOut, valuesOut, opts)
 }
 
@@ -995,17 +995,17 @@ func (m *Map) BatchLookup(cursor *BatchCursor, keysOut, valuesOut interface{}, o
 // ErrKeyNotExist is returned when the batch lookup has reached
 // the end of all possible results, even when partial results
 // are returned. It should be used to evaluate when lookup is "done".
-func (m *Map) BatchLookupAndDelete(cursor *BatchCursor, keysOut, valuesOut interface{}, opts *BatchOptions) (int, error) {
+func (m *Map) BatchLookupAndDelete(cursor *MapBatchCursor, keysOut, valuesOut interface{}, opts *BatchOptions) (int, error) {
 	return m.batchLookup(sys.BPF_MAP_LOOKUP_AND_DELETE_BATCH, cursor, keysOut, valuesOut, opts)
 }
 
-// BatchCursor represents a starting point for a batch operation.
-type BatchCursor struct {
+// MapBatchCursor represents a starting point for a batch operation.
+type MapBatchCursor struct {
 	m      *Map
 	opaque []byte
 }
 
-func (m *Map) batchLookup(cmd sys.Cmd, cursor *BatchCursor, keysOut, valuesOut interface{}, opts *BatchOptions) (int, error) {
+func (m *Map) batchLookup(cmd sys.Cmd, cursor *MapBatchCursor, keysOut, valuesOut interface{}, opts *BatchOptions) (int, error) {
 	if m.typ.hasPerCPUValue() {
 		return m.batchLookupPerCPU(cmd, cursor, keysOut, valuesOut, opts)
 	}
@@ -1030,7 +1030,7 @@ func (m *Map) batchLookup(cmd sys.Cmd, cursor *BatchCursor, keysOut, valuesOut i
 	return n, nil
 }
 
-func (m *Map) batchLookupPerCPU(cmd sys.Cmd, cursor *BatchCursor, keysOut, valuesOut interface{}, opts *BatchOptions) (int, error) {
+func (m *Map) batchLookupPerCPU(cmd sys.Cmd, cursor *MapBatchCursor, keysOut, valuesOut interface{}, opts *BatchOptions) (int, error) {
 	count, err := sliceLen(keysOut)
 	if err != nil {
 		return 0, fmt.Errorf("keys: %w", err)
@@ -1052,7 +1052,7 @@ func (m *Map) batchLookupPerCPU(cmd sys.Cmd, cursor *BatchCursor, keysOut, value
 	return n, sysErr
 }
 
-func (m *Map) batchLookupCmd(cmd sys.Cmd, cursor *BatchCursor, count int, keysOut any, valuePtr sys.Pointer, opts *BatchOptions) (int, error) {
+func (m *Map) batchLookupCmd(cmd sys.Cmd, cursor *MapBatchCursor, count int, keysOut any, valuePtr sys.Pointer, opts *BatchOptions) (int, error) {
 	cursorLen := int(m.keySize)
 	if cursorLen < 4 {
 		// * generic_map_lookup_batch requires that batch_out is key_size bytes.

--- a/map_test.go
+++ b/map_test.go
@@ -156,7 +156,7 @@ func TestMapBatch(t *testing.T) {
 			lookupKeys := make([]uint32, n)
 			lookupValues := make([]uint32, n*possibleCPU)
 
-			var cursor BatchCursor
+			var cursor MapBatchCursor
 			var total int
 			for {
 				count, err = m.BatchLookup(&cursor, lookupKeys, lookupValues, nil)
@@ -182,7 +182,7 @@ func TestMapBatch(t *testing.T) {
 				return
 			}
 
-			cursor = BatchCursor{}
+			cursor = MapBatchCursor{}
 			total = 0
 			for {
 				count, err = m.BatchLookupAndDelete(&cursor, lookupKeys, lookupValues, nil)
@@ -236,7 +236,7 @@ func TestMapBatchCursorReuse(t *testing.T) {
 
 	tmp := make([]uint32, 2)
 
-	var cursor BatchCursor
+	var cursor MapBatchCursor
 	_, err = arr1.BatchLookup(&cursor, tmp, tmp, nil)
 	testutils.SkipIfNotSupported(t, err)
 	qt.Assert(t, qt.IsNil(err))
@@ -356,7 +356,7 @@ func TestBatchMapWithLock(t *testing.T) {
 			t.Fatalf("BatchUpdate: expected count, %d, to be %d", count, len(keys))
 		}
 
-		var cursor BatchCursor
+		var cursor MapBatchCursor
 		lookupKeys := make([]uint32, 2)
 		lookupValues := make([]spinLockValue, 2)
 		count, err = m.BatchLookup(&cursor, lookupKeys, lookupValues, &BatchOptions{ElemFlags: uint64(LookupLock)})
@@ -367,7 +367,7 @@ func TestBatchMapWithLock(t *testing.T) {
 			t.Fatalf("BatchLookup: expected two keys, got %d", count)
 		}
 
-		cursor = BatchCursor{}
+		cursor = MapBatchCursor{}
 		deleteKeys := []uint32{0, 1}
 		deleteValues := make([]spinLockValue, 2)
 		count, err = m.BatchLookupAndDelete(&cursor, deleteKeys, deleteValues, nil)
@@ -1146,7 +1146,7 @@ func TestMapBatchLookupAllocations(t *testing.T) {
 	}
 	defer arr.Close()
 
-	var cursor BatchCursor
+	var cursor MapBatchCursor
 	tmp := make([]uint32, 2)
 	input := any(tmp)
 
@@ -2151,7 +2151,7 @@ func BenchmarkIterate(b *testing.B) {
 				b.ResetTimer()
 
 				for i := 0; i < b.N; i++ {
-					var cursor BatchCursor
+					var cursor MapBatchCursor
 					for {
 						_, err := m.BatchLookup(&cursor, k, v, nil)
 						if errors.Is(err, ErrKeyNotExist) {
@@ -2178,7 +2178,7 @@ func BenchmarkIterate(b *testing.B) {
 					}
 					b.StartTimer()
 
-					var cursor BatchCursor
+					var cursor MapBatchCursor
 					for {
 						_, err := m.BatchLookupAndDelete(&cursor, k, v, nil)
 						if errors.Is(err, ErrKeyNotExist) {


### PR DESCRIPTION
All of the other map related types have this prefix, so make BatchCursor the same.