### PR TITLE
fix trusted "Tag breaking changes" workflow

### DIFF
--- a/.github/workflows/trusted.yml
+++ b/.github/workflows/trusted.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            var artifacts = await github.actions.listWorkflowRunArtifacts({
+            var artifacts = await github.rest.actions.listWorkflowRunArtifacts({
                owner: context.repo.owner,
                repo: context.repo.repo,
                run_id: ${{github.event.workflow_run.id }},
@@ -25,7 +25,7 @@ jobs:
             var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
               return artifact.name == "apidiff"
             })[0];
-            var download = await github.actions.downloadArtifact({
+            var download = await github.rest.actions.downloadArtifact({
                owner: context.repo.owner,
                repo: context.repo.repo,
                artifact_id: matchArtifact.id,


### PR DESCRIPTION
This has been broken by https://github.com/cilium/ebpf/commit/4d619bbc8b492e0d2f2a37c369f444da39c9a8db, and the bump to a version higher than v5 (see https://github.com/actions/github-script?tab=readme-ov-file#v5).

Please note: this fix is pretty difficult to test since the job itself uses the workflow definition from the main branch to run