### PR TITLE
btf: fix race due to concurrent read access

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -68,12 +68,12 @@ if [[ "${1:-}" = "--exec-vm" ]]; then
   fi
 
   for ((i = 0; i < 3; i++)); do
-    if ! $sudo virtme-run --kimg "${input}/boot/vmlinuz" --memory 768M --pwd \
+    if ! $sudo virtme-run --kimg "${input}/boot/vmlinuz" --cpus 2 --memory 768M --pwd \
       --rwdir="${testdir}=${testdir}" \
       --rodir=/run/input="${input}" \
       --rwdir=/run/output="${output}" \
-      --script-sh "$(quote_env "${preserved_env[@]}") \"$script\" --exec-test $cmd" \
-      --kopt possible_cpus=2; then # need at least two CPUs for some tests
+      --script-sh "$(quote_env "${preserved_env[@]}") \"$script\" \
+      --exec-test $cmd"; then
       exit 23
     fi
 


### PR DESCRIPTION
Up until the introduction of lazy copying, reading from a Spec concurrently was safe. Now a read may trigger a copy and a write into the Spec, therefore causing a race on mutableTypes.

Fix this by introducing a mutex which protects access to the mutable state. We need to be a bit careful here: copying in mutableTypes.add happens piecemeal, so we need to take a lock for the whole duration of modifyGraph.