### PR TITLE
btf: fix race in mutableTypes.copy

### DIFF
--- a/btf/btf.go
+++ b/btf/btf.go
@@ -118,6 +118,10 @@ func (mt *mutableTypes) copy() mutableTypes {
 		make(map[Type]TypeID, len(mt.copiedTypeIDs)),
 	}
 
+	// Prevent concurrent modification of mt.copiedTypeIDs.
+	mt.mu.RLock()
+	defer mt.mu.RUnlock()
+
 	copies := make(map[Type]Type, len(mt.copies))
 	for orig, copy := range mt.copies {
 		// NB: We make a copy of copy, not orig, so that changes to mutable types

--- a/btf/btf_test.go
+++ b/btf/btf_test.go
@@ -542,12 +542,16 @@ func TestSpecConcurrentAccess(t *testing.T) {
 		go func() {
 			defer wg.Done()
 
-			cond.Add(1)
+			n := cond.Add(1)
 			for cond.Load() != int64(maxprocs) {
 				// Spin to increase the chances of a race.
 			}
 
-			_, _ = spec.AnyTypeByName("gov_update_cpu_data")
+			if n%2 == 0 {
+				_, _ = spec.AnyTypeByName("gov_update_cpu_data")
+			} else {
+				_ = spec.Copy()
+			}
 		}()
 
 		// Try to get the Goroutines scheduled and spinning.


### PR DESCRIPTION
We reference mt.copiedTypeIDs during copy to be able to figure out the correct ID for a copied type. This access can currently race with mutableTypes.add since we don't protect mt.copiedTypeIDs.

Take a read lock to prevent modification.