### PR TITLE
link, internal: generate full linkinfo for union subtypes

### DIFF
--- a/internal/sys/syscall.go
+++ b/internal/sys/syscall.go
@@ -71,6 +71,34 @@ func (i *LinkInfo) info() (unsafe.Pointer, uint32) {
 	return unsafe.Pointer(i), uint32(unsafe.Sizeof(*i))
 }
 
+func (i *TracingLinkInfo) info() (unsafe.Pointer, uint32) {
+	return unsafe.Pointer(i), uint32(unsafe.Sizeof(*i))
+}
+
+func (i *CgroupLinkInfo) info() (unsafe.Pointer, uint32) {
+	return unsafe.Pointer(i), uint32(unsafe.Sizeof(*i))
+}
+
+func (i *NetNsLinkInfo) info() (unsafe.Pointer, uint32) {
+	return unsafe.Pointer(i), uint32(unsafe.Sizeof(*i))
+}
+
+func (i *XDPLinkInfo) info() (unsafe.Pointer, uint32) {
+	return unsafe.Pointer(i), uint32(unsafe.Sizeof(*i))
+}
+
+func (i *TcxLinkInfo) info() (unsafe.Pointer, uint32) {
+	return unsafe.Pointer(i), uint32(unsafe.Sizeof(*i))
+}
+
+func (i *NetfilterLinkInfo) info() (unsafe.Pointer, uint32) {
+	return unsafe.Pointer(i), uint32(unsafe.Sizeof(*i))
+}
+
+func (i *NetkitLinkInfo) info() (unsafe.Pointer, uint32) {
+	return unsafe.Pointer(i), uint32(unsafe.Sizeof(*i))
+}
+
 var _ Info = (*BtfInfo)(nil)
 
 func (i *BtfInfo) info() (unsafe.Pointer, uint32) {

--- a/internal/sys/types.go
+++ b/internal/sys/types.go
@@ -1225,48 +1225,92 @@ func RawTracepointOpen(attr *RawTracepointOpenAttr) (*FD, error) {
 }
 
 type CgroupLinkInfo struct {
+	Type       LinkType
+	Id         LinkID
+	ProgId     uint32
+	_          [4]byte
 	CgroupId   uint64
 	AttachType AttachType
-	_          [4]byte
+	_          [28]byte
 }
 
 type IterLinkInfo struct {
+	Type          LinkType
+	Id            LinkID
+	ProgId        uint32
+	_             [4]byte
 	TargetName    Pointer
 	TargetNameLen uint32
 }
 
 type NetNsLinkInfo struct {
+	Type       LinkType
+	Id         LinkID
+	ProgId     uint32
+	_          [4]byte
 	NetnsIno   uint32
 	AttachType AttachType
+	_          [32]byte
 }
 
 type NetfilterLinkInfo struct {
+	Type     LinkType
+	Id       LinkID
+	ProgId   uint32
+	_        [4]byte
 	Pf       uint32
 	Hooknum  uint32
 	Priority int32
 	Flags    uint32
+	_        [24]byte
 }
 
 type NetkitLinkInfo struct {
+	Type       LinkType
+	Id         LinkID
+	ProgId     uint32
+	_          [4]byte
 	Ifindex    uint32
 	AttachType AttachType
+	_          [32]byte
 }
 
 type RawTracepointLinkInfo struct {
+	Type      LinkType
+	Id        LinkID
+	ProgId    uint32
+	_         [4]byte
 	TpName    Pointer
 	TpNameLen uint32
-	_         [4]byte
+	_         [28]byte
 }
 
 type TcxLinkInfo struct {
+	Type       LinkType
+	Id         LinkID
+	ProgId     uint32
+	_          [4]byte
 	Ifindex    uint32
 	AttachType AttachType
+	_          [32]byte
 }
 
 type TracingLinkInfo struct {
+	Type        LinkType
+	Id          LinkID
+	ProgId      uint32
+	_           [4]byte
 	AttachType  AttachType
 	TargetObjId uint32
 	TargetBtfId TypeID
+	_           [28]byte
 }
 
-type XDPLinkInfo struct{ Ifindex uint32 }
+type XDPLinkInfo struct {
+	Type    LinkType
+	Id      LinkID
+	ProgId  uint32
+	_       [4]byte
+	Ifindex uint32
+	_       [36]byte
+}

--- a/link/link.go
+++ b/link/link.go
@@ -136,13 +136,43 @@ type Info struct {
 	extra   interface{}
 }
 
-type TracingInfo sys.TracingLinkInfo
-type CgroupInfo sys.CgroupLinkInfo
-type NetNsInfo sys.NetNsLinkInfo
-type XDPInfo sys.XDPLinkInfo
-type TCXInfo sys.TcxLinkInfo
-type NetfilterInfo sys.NetfilterLinkInfo
-type NetkitInfo sys.NetkitLinkInfo
+type TracingInfo struct {
+	AttachType  sys.AttachType
+	TargetObjId uint32
+	TargetBtfId sys.TypeID
+}
+
+type CgroupInfo struct {
+	CgroupId   uint64
+	AttachType sys.AttachType
+	_          [4]byte
+}
+
+type NetNsInfo struct {
+	NetnsIno   uint32
+	AttachType sys.AttachType
+}
+
+type TCXInfo struct {
+	Ifindex    uint32
+	AttachType sys.AttachType
+}
+
+type XDPInfo struct {
+	Ifindex uint32
+}
+
+type NetfilterInfo struct {
+	Pf       uint32
+	Hooknum  uint32
+	Priority int32
+	Flags    uint32
+}
+
+type NetkitInfo struct {
+	Ifindex    uint32
+	AttachType sys.AttachType
+}
 
 // Tracing returns tracing type-specific link info.
 //

--- a/link/link.go
+++ b/link/link.go
@@ -220,6 +220,14 @@ func (r Info) Netfilter() *NetfilterInfo {
 	return e
 }
 
+// Netkit returns netkit type-specific link info.
+//
+// Returns nil if the type-specific link info isn't available.
+func (r Info) Netkit() *NetkitInfo {
+	e, _ := r.extra.(*NetkitInfo)
+	return e
+}
+
 // RawLink is the low-level API to bpf_link.
 //
 // You should consider using the higher level interfaces in this


### PR DESCRIPTION
The current generic abstraction of `bpf_link_info` makes it harder to implement features like #1295. Instead of splitting LinkInfo into a generic part and having extra structs to represent the fields of union members in `bpf_link_info`, with this PR we generate the full LinkInfo struct for each member the union in `bpf_link_info`.