### PR TITLE
btf: use recursion in coreAreTypesCompatible

### DIFF
--- a/btf/core_test.go
+++ b/btf/core_test.go
@@ -21,42 +21,6 @@ func TestCheckTypeCompatibility(t *testing.T) {
 		a, b       Type
 		compatible bool
 	}{
-		{&FuncProto{Return: &Typedef{Type: &Int{}}}, &FuncProto{Return: &Int{}}, true},
-		{&FuncProto{Return: &Typedef{Type: &Int{}}}, &FuncProto{Return: &Void{}}, false},
-	}
-	for _, test := range tests {
-		err := CheckTypeCompatibility(test.a, test.b)
-		if test.compatible {
-			if err != nil {
-				t.Errorf("Expected types to be compatible: %s\na = %#v\nb = %#v", err, test.a, test.b)
-				continue
-			}
-		} else {
-			if !errors.Is(err, errIncompatibleTypes) {
-				t.Errorf("Expected types to be incompatible: %s\na = %#v\nb = %#v", err, test.a, test.b)
-				continue
-			}
-		}
-
-		err = CheckTypeCompatibility(test.b, test.a)
-		if test.compatible {
-			if err != nil {
-				t.Errorf("Expected reversed types to be compatible: %s\na = %#v\nb = %#v", err, test.a, test.b)
-			}
-		} else {
-			if !errors.Is(err, errIncompatibleTypes) {
-				t.Errorf("Expected reversed types to be incompatible: %s\na = %#v\nb = %#v", err, test.a, test.b)
-			}
-		}
-	}
-
-}
-
-func TestCOREAreTypesCompatible(t *testing.T) {
-	tests := []struct {
-		a, b       Type
-		compatible bool
-	}{
 		{&Void{}, &Void{}, true},
 		{&Struct{Name: "a"}, &Struct{Name: "b"}, true},
 		{&Union{Name: "a"}, &Union{Name: "b"}, true},
@@ -84,10 +48,12 @@ func TestCOREAreTypesCompatible(t *testing.T) {
 			&FuncProto{Return: &Void{}, Params: []FuncParam{{Type: &Void{}}}},
 			false,
 		},
+		{&FuncProto{Return: &Typedef{Type: &Int{}}}, &FuncProto{Return: &Int{}}, true},
+		{&FuncProto{Return: &Typedef{Type: &Int{}}}, &FuncProto{Return: &Void{}}, false},
 	}
 
 	for _, test := range tests {
-		err := coreAreTypesCompatible(test.a, test.b)
+		err := CheckTypeCompatibility(test.a, test.b)
 		if test.compatible {
 			if err != nil {
 				t.Errorf("Expected types to be compatible: %s\na = %#v\nb = %#v", err, test.a, test.b)
@@ -100,7 +66,7 @@ func TestCOREAreTypesCompatible(t *testing.T) {
 			}
 		}
 
-		err = coreAreTypesCompatible(test.b, test.a)
+		err = CheckTypeCompatibility(test.b, test.a)
 		if test.compatible {
 			if err != nil {
 				t.Errorf("Expected reversed types to be compatible: %s\na = %#v\nb = %#v", err, test.a, test.b)
@@ -113,7 +79,7 @@ func TestCOREAreTypesCompatible(t *testing.T) {
 	}
 
 	for _, invalid := range []Type{&Var{}, &Datasec{}} {
-		err := coreAreTypesCompatible(invalid, invalid)
+		err := CheckTypeCompatibility(invalid, invalid)
 		if errors.Is(err, errIncompatibleTypes) {
 			t.Errorf("Expected an error for %T, not errIncompatibleTypes", invalid)
 		} else if err == nil {


### PR DESCRIPTION
coreAreTypesCompatible currently uses two manually maintained stacks to traverse two types to compare. The original idea was that using stacks would somehow be more efficient or it'd be easier to understand than the recursive approach. Time has shown that this was probably not true. Using the stacks is both harder to understand and probably less performant than using recursion. This is because the runtime maintains a stack for us, which can be reused across many invocations. Allocating on the (goroutine) stack is also incredibly cheap.

Rewrite coreAreTypesCompatible to use recursion to traverse the two types. Instead of using walkType we simply open code the switch cases for Pointer, Array and FuncProto. This isn't much code and gets rid of a bunch of complexity and allocations, especially for FuncParam.

The depth check is removed completely. It's a hold over from libbpf, which probably uses it to avoid stack overflow. This isn't necessary in Go, since overflowing the stack is guaranteed to panic. Instead, we deal with cyclical types by maintaining a visited map.