### PR TITLE
elf_reader_test: Fix CI by disabling the "test_log_fixup" selftest

### DIFF
--- a/elf_reader_test.go
+++ b/elf_reader_test.go
@@ -1039,6 +1039,8 @@ func TestLibBPFCompat(t *testing.T) {
 		case "linked_maps", "linked_maps1", "linked_maps2", "linked_funcs1", "linked_funcs2",
 			"test_subskeleton", "test_subskeleton_lib":
 			t.Skip("Skipping due to relying on cross ELF linking")
+		case "test_log_fixup":
+			t.Skip("Skipping due to intentionally broken CO-RE relocations")
 		}
 
 		t.Parallel()


### PR DESCRIPTION
The "test_log_fixup" selftest is broken on purpose, with the goal of testing error messages. Due to changes in #1364 we now emit a poison instruction in `bad_relo_subprog` on a instruction which also has a reference to a BPF-to-BPF function. This causes the symbol/reference resolution step to fail.

This error is flaky, it only happens when `bad_relo_subprog` is loaded first. If any other program in the collection is loaded first due to random hash map ordering we skip the test instead due to the test checking for verifier errors.

Since this test is broken on purpose, we previously just always hit this skip condition. This commit disabled this selftest explicitly which resolves the CI flakiness.