### PR TITLE
gh: do not hide internal/sys/types.go in diffs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+internal/sys/types.go linguist-generated=false


### PR DESCRIPTION
Annoyingly, GH hides types.go in diffs by default. Turn off this behaviour.