### PR TITLE
tests: clean up ClangEndian

### DIFF
--- a/btf/core_reloc_test.go
+++ b/btf/core_reloc_test.go
@@ -13,126 +13,111 @@ import (
 )
 
 func TestCORERelocationLoad(t *testing.T) {
-	testutils.Files(t, testutils.Glob(t, "testdata/relocs-*.elf"), func(t *testing.T, file string) {
-		fh, err := os.Open(file)
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer fh.Close()
+	file := testutils.NativeFile(t, "testdata/relocs-%s.elf")
+	fh, err := os.Open(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer fh.Close()
 
-		spec, err := ebpf.LoadCollectionSpecFromReader(fh)
-		if err != nil {
-			t.Fatal(err)
-		}
+	spec, err := ebpf.LoadCollectionSpecFromReader(fh)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-		if spec.ByteOrder != internal.NativeEndian {
-			return
-		}
+	for _, progSpec := range spec.Programs {
+		t.Run(progSpec.Name, func(t *testing.T) {
+			if _, err := fh.Seek(0, io.SeekStart); err != nil {
+				t.Fatal(err)
+			}
 
-		for _, progSpec := range spec.Programs {
-			t.Run(progSpec.Name, func(t *testing.T) {
-				if _, err := fh.Seek(0, io.SeekStart); err != nil {
-					t.Fatal(err)
-				}
-
-				prog, err := ebpf.NewProgramWithOptions(progSpec, ebpf.ProgramOptions{
-					KernelTypes: spec.Types,
-				})
-				testutils.SkipIfNotSupported(t, err)
-
-				if strings.HasPrefix(progSpec.Name, "err_") {
-					if err == nil {
-						prog.Close()
-						t.Fatal("Expected an error")
-					}
-					t.Log("Got expected error:", err)
-					return
-				}
-
-				if err != nil {
-					t.Fatal("Load program:", err)
-				}
-				defer prog.Close()
-
-				ret, _, err := prog.Test(internal.EmptyBPFContext)
-				testutils.SkipIfNotSupported(t, err)
-				if err != nil {
-					t.Fatal("Error when running:", err)
-				}
-
-				if ret != 0 {
-					t.Error("Assertion failed on line", ret)
-				}
+			prog, err := ebpf.NewProgramWithOptions(progSpec, ebpf.ProgramOptions{
+				KernelTypes: spec.Types,
 			})
-		}
-	})
+			testutils.SkipIfNotSupported(t, err)
+
+			if strings.HasPrefix(progSpec.Name, "err_") {
+				if err == nil {
+					prog.Close()
+					t.Fatal("Expected an error")
+				}
+				t.Log("Got expected error:", err)
+				return
+			}
+
+			if err != nil {
+				t.Fatal("Load program:", err)
+			}
+			defer prog.Close()
+
+			ret, _, err := prog.Test(internal.EmptyBPFContext)
+			testutils.SkipIfNotSupported(t, err)
+			if err != nil {
+				t.Fatal("Error when running:", err)
+			}
+
+			if ret != 0 {
+				t.Error("Assertion failed on line", ret)
+			}
+		})
+	}
 }
 
 func TestCORERelocationRead(t *testing.T) {
-	testutils.Files(t, testutils.Glob(t, "testdata/relocs_read-*.elf"), func(t *testing.T, file string) {
-		spec, err := ebpf.LoadCollectionSpec(file)
-		if err != nil {
-			t.Fatal(err)
-		}
+	file := testutils.NativeFile(t, "testdata/relocs_read-%s.elf")
+	spec, err := ebpf.LoadCollectionSpec(file)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-		if spec.ByteOrder != internal.NativeEndian {
-			return
-		}
+	targetFile := testutils.NativeFile(t, "testdata/relocs_read_tgt-%s.elf")
+	targetSpec, err := btf.LoadSpec(targetFile)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-		targetFile := testutils.NativeFile(t, "testdata/relocs_read_tgt-%s.elf")
-		targetSpec, err := btf.LoadSpec(targetFile)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		for _, progSpec := range spec.Programs {
-			t.Run(progSpec.Name, func(t *testing.T) {
-				prog, err := ebpf.NewProgramWithOptions(progSpec, ebpf.ProgramOptions{
-					KernelTypes: targetSpec,
-				})
-				testutils.SkipIfNotSupported(t, err)
-				if err != nil {
-					t.Fatal("Load program:", err)
-				}
-				defer prog.Close()
-
-				ret, _, err := prog.Test(internal.EmptyBPFContext)
-				testutils.SkipIfNotSupported(t, err)
-				if err != nil {
-					t.Fatal("Error when running:", err)
-				}
-
-				if ret != 0 {
-					t.Error("Assertion failed on line", ret)
-				}
+	for _, progSpec := range spec.Programs {
+		t.Run(progSpec.Name, func(t *testing.T) {
+			prog, err := ebpf.NewProgramWithOptions(progSpec, ebpf.ProgramOptions{
+				KernelTypes: targetSpec,
 			})
-		}
-	})
+			testutils.SkipIfNotSupported(t, err)
+			if err != nil {
+				t.Fatal("Load program:", err)
+			}
+			defer prog.Close()
+
+			ret, _, err := prog.Test(internal.EmptyBPFContext)
+			testutils.SkipIfNotSupported(t, err)
+			if err != nil {
+				t.Fatal("Error when running:", err)
+			}
+
+			if ret != 0 {
+				t.Error("Assertion failed on line", ret)
+			}
+		})
+	}
 }
 
 func TestLD64IMMReloc(t *testing.T) {
 	testutils.SkipOnOldKernel(t, "5.4", "vmlinux BTF in sysfs")
 
-	testutils.Files(t, testutils.Glob(t, "testdata/relocs_enum-*.elf"), func(t *testing.T, file string) {
-		fh, err := os.Open(file)
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer fh.Close()
+	file := testutils.NativeFile(t, "testdata/relocs_enum-%s.elf")
+	fh, err := os.Open(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer fh.Close()
 
-		spec, err := ebpf.LoadCollectionSpecFromReader(fh)
-		if err != nil {
-			t.Fatal(err)
-		}
+	spec, err := ebpf.LoadCollectionSpecFromReader(fh)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-		if spec.ByteOrder != internal.NativeEndian {
-			return
-		}
-
-		coll, err := ebpf.NewCollection(spec)
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer coll.Close()
-	})
+	coll, err := ebpf.NewCollection(spec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer coll.Close()
 }

--- a/btf/core_reloc_test.go
+++ b/btf/core_reloc_test.go
@@ -1,7 +1,6 @@
 package btf_test
 
 import (
-	"fmt"
 	"io"
 	"os"
 	"strings"
@@ -80,7 +79,7 @@ func TestCORERelocationRead(t *testing.T) {
 			return
 		}
 
-		targetFile := fmt.Sprintf("testdata/relocs_read_tgt-%s.elf", internal.ClangEndian)
+		targetFile := testutils.NativeFile(t, "testdata/relocs_read_tgt-%s.elf")
 		targetSpec, err := btf.LoadSpec(targetFile)
 		if err != nil {
 			t.Fatal(err)

--- a/cmd/bpf2go/output_test.go
+++ b/cmd/bpf2go/output_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/go-quicktest/qt"
@@ -9,7 +8,7 @@ import (
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/btf"
-	"github.com/cilium/ebpf/internal"
+	"github.com/cilium/ebpf/internal/testutils"
 )
 
 func TestOrderTypes(t *testing.T) {
@@ -69,7 +68,7 @@ var typesEqualComparer = cmp.Comparer(func(a, b btf.Type) bool {
 })
 
 func TestCollectFromSpec(t *testing.T) {
-	spec, err := ebpf.LoadCollectionSpec(fmt.Sprintf("testdata/minimal-%s.elf", internal.ClangEndian))
+	spec, err := ebpf.LoadCollectionSpec(testutils.NativeFile(t, "testdata/minimal-%s.elf"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/collection_test.go
+++ b/collection_test.go
@@ -98,7 +98,7 @@ func TestCollectionSpecCopy(t *testing.T) {
 }
 
 func TestCollectionSpecLoadCopy(t *testing.T) {
-	file := fmt.Sprintf("testdata/loader-%s.elf", internal.ClangEndian)
+	file := testutils.NativeFile(t, "testdata/loader-%s.elf")
 	spec, err := LoadCollectionSpec(file)
 	if err != nil {
 		t.Fatal(err)
@@ -691,7 +691,7 @@ func TestIncompleteLoadAndAssign(t *testing.T) {
 }
 
 func BenchmarkNewCollection(b *testing.B) {
-	file := fmt.Sprintf("testdata/loader-%s.elf", internal.ClangEndian)
+	file := testutils.NativeFile(b, "testdata/loader-%s.elf")
 	spec, err := LoadCollectionSpec(file)
 	if err != nil {
 		b.Fatal(err)
@@ -715,7 +715,7 @@ func BenchmarkNewCollection(b *testing.B) {
 }
 
 func BenchmarkNewCollectionManyProgs(b *testing.B) {
-	file := fmt.Sprintf("testdata/manyprogs-%s.elf", internal.ClangEndian)
+	file := testutils.NativeFile(b, "testdata/manyprogs-%s.elf")
 	spec, err := LoadCollectionSpec(file)
 	if err != nil {
 		b.Fatal(err)
@@ -734,7 +734,7 @@ func BenchmarkNewCollectionManyProgs(b *testing.B) {
 }
 
 func BenchmarkLoadCollectionManyProgs(b *testing.B) {
-	file, err := os.Open(fmt.Sprintf("testdata/manyprogs-%s.elf", internal.ClangEndian))
+	file, err := os.Open(testutils.NativeFile(b, "testdata/manyprogs-%s.elf"))
 	qt.Assert(b, qt.IsNil(err))
 	defer file.Close()
 

--- a/elf_reader_test.go
+++ b/elf_reader_test.go
@@ -228,7 +228,7 @@ func BenchmarkELFLoader(b *testing.B) {
 }
 
 func TestDataSections(t *testing.T) {
-	file := fmt.Sprintf("testdata/loader-%s.elf", internal.ClangEndian)
+	file := testutils.NativeFile(t, "testdata/loader-%s.elf")
 	coll, err := LoadCollectionSpec(file)
 	if err != nil {
 		t.Fatal(err)
@@ -258,7 +258,7 @@ func TestDataSections(t *testing.T) {
 }
 
 func TestInlineASMConstant(t *testing.T) {
-	file := fmt.Sprintf("testdata/loader-%s.elf", internal.ClangEndian)
+	file := testutils.NativeFile(t, "testdata/loader-%s.elf")
 	coll, err := LoadCollectionSpec(file)
 	if err != nil {
 		t.Fatal(err)
@@ -289,7 +289,7 @@ func TestInlineASMConstant(t *testing.T) {
 func TestFreezeRodata(t *testing.T) {
 	testutils.SkipOnOldKernel(t, "5.9", "sk_lookup program type")
 
-	file := fmt.Sprintf("testdata/constants-%s.elf", internal.ClangEndian)
+	file := testutils.NativeFile(t, "testdata/constants-%s.elf")
 	spec, err := LoadCollectionSpec(file)
 	if err != nil {
 		t.Fatal(err)
@@ -470,7 +470,7 @@ func TestLoadInvalidInitializedBTFMap(t *testing.T) {
 }
 
 func TestStringSection(t *testing.T) {
-	file := fmt.Sprintf("testdata/strings-%s.elf", internal.ClangEndian)
+	file := testutils.NativeFile(t, "testdata/strings-%s.elf")
 	spec, err := LoadCollectionSpec(file)
 	if err != nil {
 		t.Fatalf("load collection spec: %s", err)
@@ -784,7 +784,7 @@ func TestInvalidKfunc(t *testing.T) {
 		t.Skip("bpf_testmod not loaded")
 	}
 
-	file := fmt.Sprintf("testdata/invalid-kfunc-%s.elf", internal.ClangEndian)
+	file := testutils.NativeFile(t, "testdata/invalid-kfunc-%s.elf")
 	coll, err := LoadCollection(file)
 	if err == nil {
 		coll.Close()

--- a/info_test.go
+++ b/info_test.go
@@ -371,7 +371,7 @@ func TestHaveProgramInfoMapIDs(t *testing.T) {
 func TestProgInfoExtBTF(t *testing.T) {
 	testutils.SkipOnOldKernel(t, "5.0", "Program BTF (func/line_info)")
 
-	spec, err := LoadCollectionSpec(fmt.Sprintf("testdata/loader-%s.elf", internal.ClangEndian))
+	spec, err := LoadCollectionSpec(testutils.NativeFile(t, "testdata/loader-%s.elf"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/endian_be.go
+++ b/internal/endian_be.go
@@ -7,6 +7,3 @@ import "encoding/binary"
 // NativeEndian is set to either binary.BigEndian or binary.LittleEndian,
 // depending on the host's endianness.
 var NativeEndian = binary.BigEndian
-
-// ClangEndian is set to either "el" or "eb" depending on the host's endianness.
-const ClangEndian = "eb"

--- a/internal/endian_le.go
+++ b/internal/endian_le.go
@@ -7,6 +7,3 @@ import "encoding/binary"
 // NativeEndian is set to either binary.BigEndian or binary.LittleEndian,
 // depending on the host's endianness.
 var NativeEndian = binary.LittleEndian
-
-// ClangEndian is set to either "el" or "eb" depending on the host's endianness.
-const ClangEndian = "el"

--- a/internal/testutils/glob.go
+++ b/internal/testutils/glob.go
@@ -1,8 +1,12 @@
 package testutils
 
 import (
+	"fmt"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	"golang.org/x/sys/cpu"
 )
 
 // Files calls fn for each given file.
@@ -55,4 +59,19 @@ nextFile:
 	}
 
 	return filtered
+}
+
+// NativeFile substitutes %s with an abbreviation of the host endianness.
+func NativeFile(tb testing.TB, path string) string {
+	tb.Helper()
+
+	if !strings.Contains(path, "%s") {
+		tb.Fatalf("File %q doesn't contain %%s", path)
+	}
+
+	if cpu.IsBigEndian {
+		return fmt.Sprintf(path, "eb")
+	}
+
+	return fmt.Sprintf(path, "el")
 }

--- a/link/tracing_test.go
+++ b/link/tracing_test.go
@@ -4,47 +4,41 @@ import (
 	"testing"
 
 	"github.com/cilium/ebpf"
-	"github.com/cilium/ebpf/internal"
 	"github.com/cilium/ebpf/internal/testutils"
 )
 
 func TestFreplace(t *testing.T) {
 	testutils.SkipOnOldKernel(t, "5.10", "freplace")
 
-	testutils.Files(t, testutils.Glob(t, "../testdata/freplace-*.elf"), func(t *testing.T, file string) {
-		spec, err := ebpf.LoadCollectionSpec(file)
-		if err != nil {
-			t.Fatal("Can't parse ELF:", err)
-		}
+	file := testutils.NativeFile(t, "../testdata/freplace-%s.elf")
+	spec, err := ebpf.LoadCollectionSpec(file)
+	if err != nil {
+		t.Fatal("Can't parse ELF:", err)
+	}
 
-		if spec.ByteOrder != internal.NativeEndian {
-			return
-		}
+	target, err := ebpf.NewProgram(spec.Programs["sched_process_exec"])
+	testutils.SkipIfNotSupported(t, err)
+	if err != nil {
+		t.Fatal("Can't create target program:", err)
+	}
+	defer target.Close()
 
-		target, err := ebpf.NewProgram(spec.Programs["sched_process_exec"])
-		testutils.SkipIfNotSupported(t, err)
-		if err != nil {
-			t.Fatal("Can't create target program:", err)
-		}
-		defer target.Close()
+	// Test attachment specified at load time
+	spec.Programs["replacement"].AttachTarget = target
+	replacement, err := ebpf.NewProgram(spec.Programs["replacement"])
+	testutils.SkipIfNotSupported(t, err)
+	if err != nil {
+		t.Fatal("Can't create replacement program:", err)
+	}
+	defer replacement.Close()
 
-		// Test attachment specified at load time
-		spec.Programs["replacement"].AttachTarget = target
-		replacement, err := ebpf.NewProgram(spec.Programs["replacement"])
-		testutils.SkipIfNotSupported(t, err)
-		if err != nil {
-			t.Fatal("Can't create replacement program:", err)
-		}
-		defer replacement.Close()
+	freplace, err := AttachFreplace(nil, "", replacement)
+	testutils.SkipIfNotSupported(t, err)
+	if err != nil {
+		t.Fatal("Can't create freplace:", err)
+	}
 
-		freplace, err := AttachFreplace(nil, "", replacement)
-		testutils.SkipIfNotSupported(t, err)
-		if err != nil {
-			t.Fatal("Can't create freplace:", err)
-		}
-
-		testLink(t, freplace, replacement)
-	})
+	testLink(t, freplace, replacement)
 }
 
 func TestFentryFexit(t *testing.T) {

--- a/link/tracing_test.go
+++ b/link/tracing_test.go
@@ -1,7 +1,6 @@
 package link
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/cilium/ebpf"
@@ -51,7 +50,7 @@ func TestFreplace(t *testing.T) {
 func TestFentryFexit(t *testing.T) {
 	testutils.SkipOnOldKernel(t, "5.5", "fentry")
 
-	spec, err := ebpf.LoadCollectionSpec(fmt.Sprintf("../testdata/fentry_fexit-%s.elf", internal.ClangEndian))
+	spec, err := ebpf.LoadCollectionSpec(testutils.NativeFile(t, "../testdata/fentry_fexit-%s.elf"))
 	if err != nil {
 		t.Fatal("Can't parse ELF:", err)
 	}

--- a/linker_test.go
+++ b/linker_test.go
@@ -59,56 +59,51 @@ func TestFindReferences(t *testing.T) {
 }
 
 func TestForwardFunctionDeclaration(t *testing.T) {
-	testutils.Files(t, testutils.Glob(t, "testdata/fwd_decl-*.elf"), func(t *testing.T, file string) {
-		coll, err := LoadCollectionSpec(file)
-		if err != nil {
-			t.Fatal(err)
-		}
+	file := testutils.NativeFile(t, "testdata/fwd_decl-%s.elf")
+	coll, err := LoadCollectionSpec(file)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-		if coll.ByteOrder != internal.NativeEndian {
-			return
-		}
+	spec := coll.Programs["call_fwd"]
 
-		spec := coll.Programs["call_fwd"]
+	// This program calls an unimplemented forward function declaration.
+	_, err = NewProgram(spec)
+	if !errors.Is(err, asm.ErrUnsatisfiedProgramReference) {
+		t.Fatal("Expected an error wrapping ErrUnsatisfiedProgramReference, got:", err)
+	}
 
-		// This program calls an unimplemented forward function declaration.
-		_, err = NewProgram(spec)
-		if !errors.Is(err, asm.ErrUnsatisfiedProgramReference) {
-			t.Fatal("Expected an error wrapping ErrUnsatisfiedProgramReference, got:", err)
-		}
+	// Append the implementation of fwd().
+	spec.Instructions = append(spec.Instructions,
+		asm.Mov.Imm32(asm.R0, 23).WithSymbol("fwd"),
+		asm.Return(),
+	)
 
-		// Append the implementation of fwd().
-		spec.Instructions = append(spec.Instructions,
-			asm.Mov.Imm32(asm.R0, 23).WithSymbol("fwd"),
-			asm.Return(),
-		)
+	// The body of the subprog we appended does not come with BTF func_infos,
+	// so the verifier will reject it. Load without BTF.
+	for i, ins := range spec.Instructions {
+		if btf.FuncMetadata(&ins) != nil || ins.Source() != nil {
+			sym := ins.Symbol()
+			ref := ins.Reference()
+			ins.Metadata = asm.Metadata{}
+			spec.Instructions[i] = ins.WithSymbol(sym).WithReference(ref)
+		}
+	}
 
-		// The body of the subprog we appended does not come with BTF func_infos,
-		// so the verifier will reject it. Load without BTF.
-		for i, ins := range spec.Instructions {
-			if btf.FuncMetadata(&ins) != nil || ins.Source() != nil {
-				sym := ins.Symbol()
-				ref := ins.Reference()
-				ins.Metadata = asm.Metadata{}
-				spec.Instructions[i] = ins.WithSymbol(sym).WithReference(ref)
-			}
-		}
+	prog, err := NewProgram(spec)
+	testutils.SkipIfNotSupported(t, err)
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+	defer prog.Close()
 
-		prog, err := NewProgram(spec)
-		testutils.SkipIfNotSupported(t, err)
-		if err != nil {
-			t.Fatalf("%+v", err)
-		}
-		defer prog.Close()
-
-		ret, _, err := prog.Test(internal.EmptyBPFContext)
-		if err != nil {
-			t.Fatal("Running program:", err)
-		}
-		if ret != 23 {
-			t.Fatalf("Expected 23, got %d", ret)
-		}
-	})
+	ret, _, err := prog.Test(internal.EmptyBPFContext)
+	if err != nil {
+		t.Fatal("Running program:", err)
+	}
+	if ret != 23 {
+		t.Fatalf("Expected 23, got %d", ret)
+	}
 }
 
 func TestSplitSymbols(t *testing.T) {

--- a/map_test.go
+++ b/map_test.go
@@ -321,101 +321,106 @@ func TestMapClose(t *testing.T) {
 
 func TestBatchMapWithLock(t *testing.T) {
 	testutils.SkipOnOldKernel(t, "5.13", "MAP BATCH BPF_F_LOCK")
-	testutils.Files(t, testutils.Glob(t, "./testdata/map_spin_lock-*.elf"), func(t *testing.T, file string) {
-		spec, err := LoadCollectionSpec(file)
-		if err != nil {
-			t.Fatal("Can't parse ELF:", err)
-		}
-		if spec.ByteOrder != internal.NativeEndian {
-			return
-		}
+	file := testutils.NativeFile(t, "testdata/map_spin_lock-%s.elf")
+	spec, err := LoadCollectionSpec(file)
+	if err != nil {
+		t.Fatal("Can't parse ELF:", err)
+	}
 
-		coll, err := NewCollection(spec)
-		if err != nil {
-			t.Fatal("Can't parse ELF:", err)
-		}
-		defer coll.Close()
+	coll, err := NewCollection(spec)
+	if err != nil {
+		t.Fatal("Can't parse ELF:", err)
+	}
+	defer coll.Close()
 
-		type spinLockValue struct {
-			Cnt     uint32
-			Padding uint32
-		}
+	type spinLockValue struct {
+		Cnt     uint32
+		Padding uint32
+	}
 
-		m, ok := coll.Maps["spin_lock_map"]
-		if !ok {
-			t.Fatal(err)
-		}
+	m, ok := coll.Maps["spin_lock_map"]
+	if !ok {
+		t.Fatal(err)
+	}
 
-		keys := []uint32{0, 1}
-		values := []spinLockValue{{Cnt: 42}, {Cnt: 4242}}
-		count, err := m.BatchUpdate(keys, values, &BatchOptions{ElemFlags: uint64(UpdateLock)})
-		if err != nil {
-			t.Fatalf("BatchUpdate: %v", err)
-		}
-		if count != len(keys) {
-			t.Fatalf("BatchUpdate: expected count, %d, to be %d", count, len(keys))
-		}
+	keys := []uint32{0, 1}
+	values := []spinLockValue{{Cnt: 42}, {Cnt: 4242}}
+	count, err := m.BatchUpdate(keys, values, &BatchOptions{ElemFlags: uint64(UpdateLock)})
+	if err != nil {
+		t.Fatalf("BatchUpdate: %v", err)
+	}
+	if count != len(keys) {
+		t.Fatalf("BatchUpdate: expected count, %d, to be %d", count, len(keys))
+	}
 
-		var cursor MapBatchCursor
-		lookupKeys := make([]uint32, 2)
-		lookupValues := make([]spinLockValue, 2)
-		count, err = m.BatchLookup(&cursor, lookupKeys, lookupValues, &BatchOptions{ElemFlags: uint64(LookupLock)})
-		if !errors.Is(err, ErrKeyNotExist) {
-			t.Fatalf("BatchLookup: %v", err)
-		}
-		if count != 2 {
-			t.Fatalf("BatchLookup: expected two keys, got %d", count)
-		}
+	var cursor MapBatchCursor
+	lookupKeys := make([]uint32, 2)
+	lookupValues := make([]spinLockValue, 2)
+	count, err = m.BatchLookup(&cursor, lookupKeys, lookupValues, &BatchOptions{ElemFlags: uint64(LookupLock)})
+	if !errors.Is(err, ErrKeyNotExist) {
+		t.Fatalf("BatchLookup: %v", err)
+	}
+	if count != 2 {
+		t.Fatalf("BatchLookup: expected two keys, got %d", count)
+	}
 
-		cursor = MapBatchCursor{}
-		deleteKeys := []uint32{0, 1}
-		deleteValues := make([]spinLockValue, 2)
-		count, err = m.BatchLookupAndDelete(&cursor, deleteKeys, deleteValues, nil)
-		if !errors.Is(err, ErrKeyNotExist) {
-			t.Fatalf("BatchLookupAndDelete: %v", err)
-		}
-		if count != 2 {
-			t.Fatalf("BatchLookupAndDelete: expected two keys, got %d", count)
-		}
-	})
+	cursor = MapBatchCursor{}
+	deleteKeys := []uint32{0, 1}
+	deleteValues := make([]spinLockValue, 2)
+	count, err = m.BatchLookupAndDelete(&cursor, deleteKeys, deleteValues, nil)
+	if !errors.Is(err, ErrKeyNotExist) {
+		t.Fatalf("BatchLookupAndDelete: %v", err)
+	}
+	if count != 2 {
+		t.Fatalf("BatchLookupAndDelete: expected two keys, got %d", count)
+	}
 }
 
 func TestMapWithLock(t *testing.T) {
 	testutils.SkipOnOldKernel(t, "5.13", "MAP BPF_F_LOCK")
-	testutils.Files(t, testutils.Glob(t, "./testdata/map_spin_lock-*.elf"), func(t *testing.T, file string) {
-		spec, err := LoadCollectionSpec(file)
-		if err != nil {
-			t.Fatal("Can't parse ELF:", err)
-		}
-		if spec.ByteOrder != internal.NativeEndian {
-			return
-		}
+	file := testutils.NativeFile(t, "testdata/map_spin_lock-%s.elf")
+	spec, err := LoadCollectionSpec(file)
+	if err != nil {
+		t.Fatal("Can't parse ELF:", err)
+	}
 
-		coll, err := NewCollection(spec)
-		if err != nil {
-			t.Fatal("Can't parse ELF:", err)
-		}
-		defer coll.Close()
+	coll, err := NewCollection(spec)
+	if err != nil {
+		t.Fatal("Can't parse ELF:", err)
+	}
+	defer coll.Close()
 
-		type spinLockValue struct {
-			Cnt     uint32
-			Padding uint32
-		}
+	type spinLockValue struct {
+		Cnt     uint32
+		Padding uint32
+	}
 
-		m, ok := coll.Maps["spin_lock_map"]
-		if !ok {
-			t.Fatal(err)
-		}
+	m, ok := coll.Maps["spin_lock_map"]
+	if !ok {
+		t.Fatal(err)
+	}
 
-		key := uint32(1)
-		value := spinLockValue{Cnt: 5}
-		err = m.Update(key, value, UpdateLock)
-		if err != nil {
-			t.Fatal(err)
-		}
+	key := uint32(1)
+	value := spinLockValue{Cnt: 5}
+	err = m.Update(key, value, UpdateLock)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	value.Cnt = 0
+	err = m.LookupWithFlags(&key, &value, LookupLock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if value.Cnt != 5 {
+		t.Fatalf("Want value 5, got %d", value.Cnt)
+	}
+
+	t.Run("LookupAndDelete", func(t *testing.T) {
+		testutils.SkipOnOldKernel(t, "5.14", "LOOKUP_AND_DELETE flags")
 
 		value.Cnt = 0
-		err = m.LookupWithFlags(&key, &value, LookupLock)
+		err = m.LookupAndDeleteWithFlags(&key, &value, LookupLock)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -423,23 +428,10 @@ func TestMapWithLock(t *testing.T) {
 			t.Fatalf("Want value 5, got %d", value.Cnt)
 		}
 
-		t.Run("LookupAndDelete", func(t *testing.T) {
-			testutils.SkipOnOldKernel(t, "5.14", "LOOKUP_AND_DELETE flags")
-
-			value.Cnt = 0
-			err = m.LookupAndDeleteWithFlags(&key, &value, LookupLock)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if value.Cnt != 5 {
-				t.Fatalf("Want value 5, got %d", value.Cnt)
-			}
-
-			err = m.LookupWithFlags(&key, &value, LookupLock)
-			if err != nil && !errors.Is(err, ErrKeyNotExist) {
-				t.Fatal(err)
-			}
-		})
+		err = m.LookupWithFlags(&key, &value, LookupLock)
+		if err != nil && !errors.Is(err, ErrKeyNotExist) {
+			t.Fatal(err)
+		}
 	})
 }
 

--- a/prog_test.go
+++ b/prog_test.go
@@ -954,7 +954,7 @@ func TestProgramInstructions(t *testing.T) {
 
 func BenchmarkNewProgram(b *testing.B) {
 	testutils.SkipOnOldKernel(b, "5.18", "kfunc support")
-	spec, err := LoadCollectionSpec(fmt.Sprintf("testdata/kfunc-%s.elf", internal.ClangEndian))
+	spec, err := LoadCollectionSpec(testutils.NativeFile(b, "testdata/kfunc-%s.elf"))
 	qt.Assert(b, qt.IsNil(err))
 
 	b.ReportAllocs()


### PR DESCRIPTION
internal: remove ClangEndian

    Replace uses of ClangEndian with a NativeFile test utility.

    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>

tests: remove !IsNativeEndian skips

    We have a lot of tests which first glob a list of files containing BPF for
    little and big endian, then parse those files and finally skip a test if the
    files endianness doesn't match the native endianness.

    This is pretty wasteful, since we parse BPF for no good reason and makes the
    tests more verbose than they have to be. Use NativeFile instead and remove
    almost all checks for IsNativeEndian from tests.

    The two remaining cases are in the ELF loader tests, where they do have
    value: we want to make sure that we can parse things from any endianness.

    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>
