### PR TITLE
Fix GitHub edit link on every page

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -5,7 +5,7 @@ site_author: Cilium Community
 # Rendered in header.
 repo_url: https://github.com/cilium/ebpf
 repo_name: cilium/ebpf
-edit_uri: edit/master/docs/ebpf/
+edit_uri: edit/main/docs/ebpf/
 
 # Directory to look for Markdown files within docs/.
 docs_dir: ebpf


### PR DESCRIPTION
master branch was renamed to main, update mkdocs.yml to match.

The link in the top-right corner of every page is currently 404, example: https://github.com/cilium/ebpf/edit/master/docs/ebpf/guides/getting-started.md