### PR TITLE
gh: only cancel pull_request runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ env:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build-and-lint:


### PR DESCRIPTION
GH Actions cancels CI runs on main when merging PRs in quick succession. Try to only cancel pull requests.