### PR TITLE
btf: synthesise instruction comments into line info 

### DIFF
--- a/btf/core.go
+++ b/btf/core.go
@@ -57,13 +57,9 @@ func (f *COREFixup) Apply(ins *asm.Instruction) error {
 
 		// Add context to the kernel verifier output.
 		if source := ins.Source(); source != nil {
-			*ins = ins.WithSource(&Line{
-				line: fmt.Sprintf("instruction poisoned by CO-RE: %s", source),
-			})
+			*ins = ins.WithSource(asm.Comment(fmt.Sprintf("instruction poisoned by CO-RE: %s", source)))
 		} else {
-			*ins = ins.WithSource(&Line{
-				line: "instruction poisoned by CO-RE",
-			})
+			*ins = ins.WithSource(asm.Comment("instruction poisoned by CO-RE"))
 		}
 
 		return nil


### PR DESCRIPTION
When an asm.Comment is added to an instruction, existing source information like btf.Line will be replaced. But in some cases, instructions without line information won't pass the verifier. The expected behavior would be, that the comment gets synthesized into a line info where everything but the line string is zero. This PR implements this.

Fixes https://github.com/cilium/ebpf/issues/1413