### PR TITLE
Extend go test CI from 10 to 15 miniutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
     name: Run tests on previous stable Go
     runs-on: ubuntu-latest-4cores-16gb
     needs: build-and-lint
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
 
@@ -137,7 +137,7 @@ jobs:
     name: Run tests on arm64
     runs-on: actuated-arm64-2cpu-8gb
     needs: build-and-lint
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
 
@@ -170,7 +170,7 @@ jobs:
     name: Run tests on pre-built kernel
     runs-on: ubuntu-latest-4cores-16gb
     needs: build-and-lint
-    timeout-minutes: 10
+    timeout-minutes: 15
     strategy:
       matrix:
         version: ["6.7", "6.1", "5.15", "5.10", "5.4", "4.19", "4.14", "4.9"]


### PR DESCRIPTION
The default builtin timeout in the go test runner is 10 min and the GH runner is also limited to 10 min. In practice the GH runner is quicker to kill tests that exceed this time limit, in which case we abruptly exit without logs on which test caused the timeout.

This change extends the runner timeout to 15 min to give the go runner a chance to kill the bad test and to tell us which test was taking longer so that we can fix the issue.