### PR TITLE
btf: refuse reloTypeIDTarget for kmod types

### DIFF
--- a/btf/btf.go
+++ b/btf/btf.go
@@ -563,7 +563,7 @@ func (s *Spec) TypeByID(id TypeID) (Type, error) {
 
 // TypeID returns the ID for a given Type.
 //
-// Returns an error wrapping ErrNoFound if the type isn't part of the Spec.
+// Returns an error wrapping [ErrNotFound] if the type isn't part of the Spec.
 func (s *Spec) TypeID(typ Type) (TypeID, error) {
 	return s.mutableTypes.typeID(typ)
 }


### PR DESCRIPTION
reloTypeIDTarget is used to substitute the ID of an equivalent type in vmlinux. This is problematic when dealing with kmod types, since their IDs are defined to be sequential with vmlinux. If the last vmlinux type ID is 99, the first type in kmod a and b has ID 100. To disambiguate between these we need a (BTF ID, Type ID) tuple, which we currently don't support.

Poison any relocation which tries to use the target ID of a kmod type. This also gets rid of mergedSpec which didn't take overlapping ID ranges into account.