### PR TITLE
Don't mention inexistent outLen parameter in (*Program).Test godoc

### DIFF
--- a/prog.go
+++ b/prog.go
@@ -659,7 +659,7 @@ type RunOptions struct {
 }
 
 // Test runs the Program in the kernel with the given input and returns the
-// value returned by the eBPF program. outLen may be zero.
+// value returned by the eBPF program.
 //
 // Note: the kernel expects at least 14 bytes input for an ethernet header for
 // XDP and SKB programs.


### PR DESCRIPTION
The outLen parameter to (*Program).Test was removed in commit e45ae4ab8640 ("detect kernel support for BPF_PROG_TEST_RUN and work around unsafe API"). Remove it from the godoc comment as well.