### PR TITLE
Use latest Go version for ARM64 and VM tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '${{ env.prev_go_version }}'
+          go-version: '${{ env.go_version }}'
 
       - run: go install gotest.tools/gotestsum@v1.8.1
 
@@ -182,7 +182,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '${{ env.prev_go_version }}'
+          go-version: '${{ env.go_version }}'
 
       - run: go install gotest.tools/gotestsum@v1.8.1
       - run: sudo pip3 install https://github.com/amluto/virtme/archive/beb85146cd91de37ae455eccb6ab67c393e6e290.zip


### PR DESCRIPTION
The test-on-arm64 and vm-test jobs in CI are using the previous stable Go version (currently 1.21) instead of the latest stable version (currently 1.22). The previous stable Go version is already covered by the test-on-prev-go job, so switch the others to use the latest.