### PR TITLE
doc: rephrase supported kernel versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ This library includes the following packages:
 
 * A version of Go that is [supported by
   upstream](https://golang.org/doc/devel/release.html#policy)
-* Linux >= 4.9. CI is run against kernel.org LTS releases. 4.4 should work but is
-  not tested against.
+* CI is run against kernel.org LTS releases. >= 4.4 should work but EOL'ed versions
+  are not supported.
 
 ## License
 


### PR DESCRIPTION
Change the wording in the readme so that we don't have to keep updating it all the time. This also helps to set expectations with users.

Updates https://github.com/cilium/ebpf/issues/1434