### PR TITLE
program: don't return error when kmod BTF is disabled

### DIFF
--- a/btf/kernel.go
+++ b/btf/kernel.go
@@ -63,6 +63,7 @@ func LoadKernelSpec() (*Spec, error) {
 //
 // Defaults to /sys/kernel/btf/<module>.
 // Returns an error wrapping ErrNotSupported if BTF is not enabled.
+// Returns an error wrapping fs.ErrNotExist if BTF for the specific module doesn't exist.
 func LoadKernelModuleSpec(module string) (*Spec, error) {
 	kernelBTF.RLock()
 	spec := kernelBTF.modules[module]

--- a/linker.go
+++ b/linker.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"math"
 	"slices"
 
@@ -148,10 +149,13 @@ func applyRelocations(insns asm.Instructions, targets []*btf.Spec, kmodName stri
 
 		if kmodName != "" {
 			kmodTarget, err := btf.LoadKernelModuleSpec(kmodName)
-			if err != nil {
+			// Ignore ErrNotExists to cater to kernels which have CONFIG_DEBUG_INFO_BTF_MODULES disabled.
+			if err != nil && !errors.Is(err, fs.ErrNotExist) {
 				return fmt.Errorf("load kernel module spec: %w", err)
 			}
-			targets = append(targets, kmodTarget)
+			if err == nil {
+				targets = append(targets, kmodTarget)
+			}
 		}
 	}
 


### PR DESCRIPTION
In kernels where the flag `CONFIG_DEBUG_INFO_BTF_MODULES` is not set, including kernels 5.10 and below (because the flag was introduced in 5.11), loading a program that attaches to kernel module functions and relied on CORE failed because the module's BTF is not available.

This fix allows the program to run, obviously only as long as it only relies on the kernel's BTF and not on the specific module's BTF.

Fixes: https://github.com/cilium/ebpf/issues/1436. Tested on the same example included in the issue: when using the fixed package, the program attaches successfully.