### PR TITLE
[go.mod] Change `go` directive to `1.21`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cilium/ebpf
 
-go 1.21.0
+go 1.21
 
 require (
 	github.com/go-quicktest/qt v1.101.0


### PR DESCRIPTION
Relates to #1438

Signed-off-by: Pablo Baeyens <pablo.baeyens@datadoghq.com>
