### PR TITLE
gh: don't use code blocks in Bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -14,7 +14,6 @@ body:
       description: |
         A clear and concise description of what the bug is.
         Include what you expected to happen instead.
-      render: markdown
     validations:
         required: true
 
@@ -22,7 +21,6 @@ body:
     attributes:
       label: How to reproduce
       description: "Steps to reproduce the behavior."
-      render: shell
     validations:
         required: true
 


### PR DESCRIPTION
The Bug report template turns the textareas into code blocks. This leads to some weird formatting. Remove the offending "render:" attribute.