### PR TITLE
Add get methods for name of program and map

### DIFF
--- a/map.go
+++ b/map.go
@@ -541,6 +541,11 @@ func (m *Map) String() string {
 	return fmt.Sprintf("%s#%v", m.typ, m.fd)
 }
 
+// Name returns the name of the map.
+func (m *Map) Name() string {
+	return m.name
+}
+
 // Type returns the underlying type of the map.
 func (m *Map) Type() MapType {
 	return m.typ

--- a/prog.go
+++ b/prog.go
@@ -528,6 +528,11 @@ func (p *Program) String() string {
 	return fmt.Sprintf("%s(%v)", p.typ, p.fd)
 }
 
+// Name returns the name of the program.
+func (p *Program) Name() string {
+	return p.name
+}
+
 // Type returns the underlying type of the program.
 func (p *Program) Type() ProgramType {
 	return p.typ


### PR DESCRIPTION
When working with objects loaded from fds, it can be useful to have access to their names. This is already possible via their *Info structs. The objects themself have a name field, though, which are provisioned with the *Info's value. So, the name is already present in the objects, but not exposed yet.

This commit adds methods to Program and Map to access the value of their name field.