### PR TITLE
ci: ignore kprobe_multi test failures on arm64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,8 @@ jobs:
     runs-on: actuated-arm64-2cpu-8gb
     needs: build-and-lint
     timeout-minutes: 15
+    env:
+      EBPF_TEST_IGNORE_KERNEL_VERSION: 'TestKprobeMulti,TestKprobeMultiErrors,TestKprobeMultiCookie,TestKprobeMultiProgramCall,TestHaveBPFLinkKprobeMulti'
     steps:
       - uses: actions/checkout@v4
 
@@ -153,7 +155,7 @@ jobs:
       - run: go install gotest.tools/gotestsum@v1.8.1
 
       - name: Test
-        run: gotestsum --ignore-non-json-output-lines --junitfile junit.xml -- -exec sudo -short -count 1 -json ./...
+        run: gotestsum --ignore-non-json-output-lines --junitfile junit.xml -- -exec 'sudo -E' -short -count 1 -json ./...
 
       - name: Benchmark
         run: go test -exec sudo -short -run '^$' -bench . -benchtime=1x ./...

--- a/internal/testutils/feature.go
+++ b/internal/testutils/feature.go
@@ -24,11 +24,7 @@ func checkFeatureTestError(t *testing.T, err error) {
 
 	var ufe *internal.UnsupportedFeatureError
 	if errors.As(err, &ufe) {
-		if ignoreKernelVersionCheck(t.Name()) {
-			t.Skipf("Ignoring error due to %s: %s", ignoreKernelVersionEnvVar, ufe.Error())
-		} else {
-			checkKernelVersion(t, ufe)
-		}
+		checkKernelVersion(t, ufe)
 	} else {
 		t.Error("Feature test failed:", err)
 	}
@@ -66,8 +62,13 @@ func checkKernelVersion(tb testing.TB, ufe *internal.UnsupportedFeatureError) {
 		return
 	}
 
+	tb.Helper()
+
+	if ignoreKernelVersionCheck(tb.Name()) {
+		tb.Skipf("Ignoring error due to %s: %s", ignoreKernelVersionEnvVar, ufe.Error())
+	}
+
 	if !isKernelLessThan(tb, ufe.MinimumVersion) {
-		tb.Helper()
 		tb.Fatalf("Feature '%s' isn't supported even though kernel is newer than %s",
 			ufe.Name, ufe.MinimumVersion)
 	}


### PR DESCRIPTION
Seems like the new CI arm64 kernels doesn't have the necessary config to support kprobe_multi. Ignore the error until we figure out what to do.

Updates https://github.com/cilium/ebpf/issues/1460