### PR TITLE
perf_event_open cpu should be -1 for valid PID

### DIFF
--- a/link/kprobe.go
+++ b/link/kprobe.go
@@ -274,7 +274,11 @@ func pmuProbe(args tracefs.ProbeArgs) (*perfEvent, error) {
 		}
 	}
 
-	rawFd, err := unix.PerfEventOpen(&attr, args.Pid, 0, -1, unix.PERF_FLAG_FD_CLOEXEC)
+	cpu := 0
+	if args.Pid != perfAllThreads {
+		cpu = -1
+	}
+	rawFd, err := unix.PerfEventOpen(&attr, args.Pid, cpu, -1, unix.PERF_FLAG_FD_CLOEXEC)
 
 	// On some old kernels, kprobe PMU doesn't allow `.` in symbol names and
 	// return -EINVAL. Return ErrNotSupported to allow falling back to tracefs.

--- a/link/perf_event.go
+++ b/link/perf_event.go
@@ -229,7 +229,11 @@ func openTracepointPerfEvent(tid uint64, pid int) (*sys.FD, error) {
 		Wakeup:      1,
 	}
 
-	fd, err := unix.PerfEventOpen(&attr, pid, 0, -1, unix.PERF_FLAG_FD_CLOEXEC)
+	cpu := 0
+	if pid != perfAllThreads {
+		cpu = -1
+	}
+	fd, err := unix.PerfEventOpen(&attr, pid, cpu, -1, unix.PERF_FLAG_FD_CLOEXEC)
 	if err != nil {
 		return nil, fmt.Errorf("opening tracepoint perf event: %w", err)
 	}


### PR DESCRIPTION
This will match libbpf behavior. Relevant snippet from `perf_event_open` [manpage](https://man7.org/linux/man-pages/man2/perf_event_open.2.html#DESCRIPTION)

>        pid > 0 and cpu == -1
>              This measures the specified process/thread on any CPU.