### PR TITLE
debug sporadic vimto hang

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,10 +125,23 @@ jobs:
       - run: sudo chmod 0666 /dev/kvm
 
       - name: Test
-        run: gotestsum --raw-command --ignore-non-json-output-lines --junitfile junit.xml -- vimto -kernel :${CI_MAX_KERNEL_VERSION}-selftests -- go test -short -count 1 -json ./...
+        env:
+          GOTRACEBACK: crash
+        run: |
+          gotestsum --raw-command --ignore-non-json-output-lines --junitfile junit.xml -- vimto -kernel :${CI_MAX_KERNEL_VERSION}-selftests -- go test -timeout 5m -short -count 1 -json ./...
 
       - name: Benchmark
         run: vimto -kernel :${CI_MAX_KERNEL_VERSION}-selftests -- go test -short -run '^$' -bench . -benchtime=1x ./...
+
+      - name: Upload coredumps
+        uses: actions/upload-artifact@v4
+        if: ${{ failure() }}
+        with:
+          name: cores
+          if-no-files-found: ignore
+          path: |
+            **/core-*
+            **/*.test
 
       - name: Upload Test Results
         if: always()


### PR DESCRIPTION
ci: debug sporadic vimto hang

    There is a case where one of the CI tests hangs for 10 minutes an is then 
    killed by the go test harness' timeout. From the dumped goroutines it seems 
    like the runner inside the VM is stuck writing to stdout:

    goroutine 82 [syscall, 9 minutes]: syscall.Syscall(0x4a4b1c?, 0x708c80?,
    0x80000000000?, 0x7ffff80000000000?)
    /opt/hostedtoolcache/go/1.21.9/x64/src/syscall/syscall_linux.go:69 +0x25 
    syscall.write(0xc000014120?, {0xc0002340c0?, 0x4f0996?, 0xc002048680?})
    /opt/hostedtoolcache/go/1.21.9/x64/src/syscall/zsyscall_linux_amd64.go:949
    +0x3b syscall.Write(...)
    /opt/hostedtoolcache/go/1.21.9/x64/src/syscall/syscall_unix.go:209 
    internal/poll.ignoringEINTRIO(...)
    /opt/hostedtoolcache/go/1.21.9/x64/src/internal/poll/fd_unix.go:736 
    internal/poll.(*FD).Write(0xc000014120, {0xc0002340c0, 0x1c, 0xc0})
    /opt/hostedtoolcache/go/1.21.9/x64/src/internal/poll/fd_unix.go:380 +0x35f 
    os.(*File).write(...)
    /opt/hostedtoolcache/go/1.21.9/x64/src/os/file_posix.go:46 
    os.(*File).Write(0xc000040028, {0xc0002340c0?, 0x1c, 0xc0018e4e28:225 +0x97 
    testing.(*matcher).fullName(0xc0023b6150, 0xc0023b6150, {0xc00228ec0b?,
    0x776c00?})
    /opt/hostedtoolcache/go/1.21.9/x64/src/testing/match.go:90 +0x106 
    testing.(*T).Run(0xc00217eb60, {0xc00228ec0b?, 0x7fe098330108?},
    0xc0001d2a80)
    /opt/hostedtoolcache/go/1.21.9/x64/src/testing/testing.go:1639 +0x2db 
    github.com/cilium/ebpf/internal/testutils.Files(0xc00217eb60, {0xc0022ae000,
    0x51c, 0x2e?}, 0xc00220d320)
    /home/runner/work/ebpf/ebpf/internal/testutils/glob.go:25 +0x91 
    github.com/cilium/ebpf.TestLibBPFCompat(0xc00217eb60)
    /home/runner/work/ebpf/ebpf/elf_reader_test.go:954 +0x14e 
    testing.tRunner(0xc00217eb60, 0x792768)
    /opt/hostedtoolcache/go/1.21.9/x64/src/testing/testing.go:1595 +0xff created
    by testing.(*T).Run in goroutine 1
    /opt/hostedtoolcache/go/1.21.9/x64/src/testing/testing.go:1648 +0x3ad

    Note that writing the goroutine dump to stderr does work, so not all I/O is
    broken. Generate and collect a core dump of the Go test the next time this 
    happens.

    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>
