### PR TITLE
docs: add a section on examples

### DIFF
--- a/docs/ebpf/contributing/new-example.md
+++ b/docs/ebpf/contributing/new-example.md
@@ -1,0 +1,23 @@
+# Adding a new example
+
+The library includes some examples to make getting started easier.
+The aim of the examples is to __show how the library works, not how to implement a specific thing in eBPF__.
+This is because the scope of eBPF is simply too large for us to cover.
+
+Please consider the following before proposing a new example:
+
+1. What feature __of the library__ does it showcase?
+2. Is there already an existing example for that feature? If yes, could it be extended without making it harder to understand?
+3. How complicated is the eBPF code required to make it work? How could the amount of eBPF be minimised?
+
+Please contact the maintainers on Slack if you are in doubt about any of
+these points.
+
+## What makes a good example?
+
+* It should be concise. The less code the better.
+* It should show a single thing. The less configurable the better.
+* It should be well documented. Even a novice user must be able to follow
+  along.
+* It should produce meaningful output or have an easily testable effect.
+* It should have as few requirements on software / hardware as possible.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -68,6 +68,7 @@ nav:
     - contributing/index.md
     - contributing/architecture.md
     - contributing/new-feature.md
+    - contributing/new-example.md
   - 'Users': users.md
   - 'Go Reference': https://pkg.go.dev/github.com/cilium/ebpf
   - 'GitHub':

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,4 +1,7 @@
-# eBPF Examples
+# Examples
+
+A collection of programs showing how to use the library.
+Please see our [guide on what makes a good example](https://ebpf-go.dev/contributing/new-example/) if you think something is missing.
 
 * Kprobe - Attach a program to the entry or exit of an arbitrary kernel symbol (function).
   * [kprobe](kprobe/) - Kprobe using bpf2go.
@@ -18,7 +21,6 @@
   * [tcp_close](tcprtt/) - Log RTT of IPv4 TCP connections using eBPF CO-RE helpers.
 * XDP - Attach a program to a network interface to process incoming packets.
   * [xdp](xdp/) - Print packet counts by IPv4 source address.
-* Add your use case(s) here!
 
 ## How to run
 


### PR DESCRIPTION
Every once in a while we have to reject new examples because they don't really show a use case of the library but instead explain some eBPF feature.

Add documentation to explain what examples make sense in the library to avoid future disappointments.