### PR TITLE
elf: turn BTF map_extra into ErrNotSupported

### DIFF
--- a/elf_reader.go
+++ b/elf_reader.go
@@ -972,6 +972,9 @@ func mapSpecFromBTF(es *elfSection, vs *btf.VarSecinfo, def *btf.Struct, spec *b
 				return nil, fmt.Errorf("resolving values contents: %w", err)
 			}
 
+		case "map_extra":
+			return nil, fmt.Errorf("BTF map definition: field %s: %w", member.Name, ErrNotSupported)
+
 		default:
 			return nil, fmt.Errorf("unrecognized field %s in BTF map definition", member.Name)
 		}


### PR DESCRIPTION
Seems like BTF map definitions have gained a map_extra field which we don't know how to handle. Return ErrNotSupported for now so that TestLibBPF can skip the test.