### PR TITLE
Fix ringbuffer ring size reporting

### DIFF
--- a/ringbuf/reader_test.go
+++ b/ringbuf/reader_test.go
@@ -59,7 +59,7 @@ func TestRingbufReader(t *testing.T) {
 			}
 			defer rd.Close()
 
-			if uint32(rd.BufferSize()) != 2*events.MaxEntries() {
+			if uint32(rd.BufferSize()) != events.MaxEntries() {
 				t.Errorf("expected %d BufferSize, got %d", events.MaxEntries(), rd.BufferSize())
 			}
 

--- a/ringbuf/ring.go
+++ b/ringbuf/ring.go
@@ -77,8 +77,9 @@ func (rr *ringReader) isEmpty() bool {
 	return prod == cons
 }
 
-// The data pages in ring buffers are mapped twice in a single contiguous virtual region
-// Therefore the true size is half the size of the mmaped region
+// To be able to wrap around data, data pages in ring buffers are mapped twice in
+// a single contiguous virtual region.
+// Therefore the returned usable size is half the size of the mmaped region.
 func (rr *ringReader) size() int {
 	return cap(rr.ring) / 2
 }

--- a/ringbuf/ring.go
+++ b/ringbuf/ring.go
@@ -77,8 +77,10 @@ func (rr *ringReader) isEmpty() bool {
 	return prod == cons
 }
 
+// The data pages in ring buffers are mapped twice in a single contiguous virtual region
+// Therefore the true size is half the size of the mmaped region
 func (rr *ringReader) size() int {
-	return cap(rr.ring)
+	return cap(rr.ring) / 2
 }
 
 // Read a record from an event ring.


### PR DESCRIPTION
The data pages of a ring buffer are mapped twice in a contiguous virtual region to allow easy wrap around when writing data. The code returns the ring size as the capacity of this mmaped region. However, this is wrong since the kernel [double maps the underlying pages](https://elixir.bootlin.com/linux/latest/source/kernel/bpf/ringbuf.c#L99).

This PR fixes this by reporting the ring size as half the capacity of the underlying mmap region.