### PR TITLE
docs: fix clipped headline on home page

### DIFF
--- a/docs/ebpf/stylesheets/extra.css
+++ b/docs/ebpf/stylesheets/extra.css
@@ -3,7 +3,6 @@
   font-size: 3em;
   font-weight: 900;
   letter-spacing: -0.5px;
-  line-height: 1;
   background: linear-gradient(120deg, #4051B5, 35%, #6AD6E4);
   background-clip: text;
   -webkit-background-clip: text;


### PR DESCRIPTION
The "eBPF Library for Golang" headline is clipped in Firefox on Linux. Remove the offending CSS.