### PR TITLE
allow to pin kprobe and kprobe_multi links

### DIFF
--- a/link/kprobe_multi.go
+++ b/link/kprobe_multi.go
@@ -130,14 +130,6 @@ func (kml *kprobeMultiLink) Update(prog *ebpf.Program) error {
 	return fmt.Errorf("update kprobe_multi: %w", ErrNotSupported)
 }
 
-func (kml *kprobeMultiLink) Pin(string) error {
-	return fmt.Errorf("pin kprobe_multi: %w", ErrNotSupported)
-}
-
-func (kml *kprobeMultiLink) Unpin() error {
-	return fmt.Errorf("unpin kprobe_multi: %w", ErrNotSupported)
-}
-
 func (kml *kprobeMultiLink) Info() (*Info, error) {
 	var info sys.KprobeMultiLinkInfo
 	if err := sys.ObjInfo(kml.fd, &info); err != nil {

--- a/link/link.go
+++ b/link/link.go
@@ -119,7 +119,7 @@ func wrapRawLink(raw *RawLink) (_ Link, err error) {
 	case UprobeMultiType:
 		return &uprobeMultiLink{*raw}, nil
 	case PerfEventType:
-		return nil, fmt.Errorf("recovering perf event fd: %w", ErrNotSupported)
+		return &perfEventLink{*raw, nil}, nil
 	case TCXType:
 		return &tcxLink{*raw}, nil
 	case NetfilterType:


### PR DESCRIPTION
we need to pin kprobe and kprobe_multi links, ATM I'm using this, but I guess there's better way at least for standard kprobes

I'm not sure if the issue described in Pin function comment is also valid  for kprobes created via perf_link,
but the pinning seems to work, and that's what we'd like to use (we don't need to re-open the link)

note the wrapRawLink for perf event kprobe needs to be done properly somehow

cc: @lmb @ti-mo 