### PR TITLE
fix(perf) skip to process nil ring

### DIFF
--- a/perf/reader.go
+++ b/perf/reader.go
@@ -386,6 +386,11 @@ func (pr *Reader) ReadInto(rec *Record) error {
 			// Waking up userspace is expensive, make the most of it by checking
 			// all rings.
 			for _, ring := range pr.rings {
+				// Skip rings that are not currently enabled.
+				if ring == nil {
+					continue
+				}
+
 				ring.loadHead()
 				pr.epollRings = append(pr.epollRings, ring)
 			}


### PR DESCRIPTION
# Code

<details>
  <summary>eBPF code</summary>

``` c
//go:build ignore

#include <common.h>
#include <vmlinux.h>
#include <bpf_helpers.h>
#include <bpf_core_read.h>
#include <bpf_endian.h>

char __license[] SEC("license") = "Dual MIT/GPL";
struct event {
	u32 pid;
	u32 ppid;
	u32 uid;
	char comm[100];
};

struct {
	__uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
} events SEC(".maps");

// Force emitting struct event into the ELF.
const struct event *unused __attribute__((unused));

SEC("kprobe/sys_execve")
int kprobe_execve(struct pt_regs *ctx) {
	struct event e;
	u32 pid, ppid, uid;
	struct task_struct *task;

	pid = bpf_get_current_pid_tgid() >> 32;
	uid = bpf_get_current_uid_gid() & 0xFFFFFFFF;

	task = (struct task_struct *)bpf_get_current_task();
	ppid = BPF_CORE_READ(task, real_parent, tgid);

	e.pid  = pid;
	e.ppid = ppid;
	e.uid  = uid;
	bpf_get_current_comm(&e.comm, sizeof(e.comm));

	bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, &e, sizeof(e));
	return 0;
}
```
</details>

<details>
  <summary>GO code</summary>

``` golang
package main

import (
	"bytes"
	"encoding/binary"
	"fmt"
	"github.com/cilium/ebpf/btf"
	"github.com/cilium/ebpf/link"
	"log"
	"os"
	"os/signal"
	"syscall"

	"github.com/cilium/ebpf"
	"github.com/cilium/ebpf/perf"
	"github.com/cilium/ebpf/rlimit"
)

type bpfEvent struct {
	Pid  uint32
	Ppid uint32
	Uid  uint32
	Comm [100]byte
}

//go:generate go run github.com/cilium/ebpf/cmd/bpf2go bpf exec.c -- -I../headers_fake
func main() {
	// Remove memory limit for eBPF programs
	if err := rlimit.RemoveMemlock(); err != nil {
		fmt.Fprintf(os.Stderr, "Failed to remove memlock limit: %v\n", err)
		os.Exit(1)
	}

	spec, err := btf.LoadSpec("/data/gb/external.btf")
	if err != nil {
		log.Fatalf("loading BTF: %v", err)
	}
	opts := &ebpf.CollectionOptions{
		Programs: ebpf.ProgramOptions{
			KernelTypes: spec,
		},
	}

	objs := bpfObjects{}
	if err := loadBpfObjects(&objs, opts); err != nil {
		fmt.Fprintf(os.Stderr, "Loading objects failed: %v\n", err)
		os.Exit(1)
	}
	defer objs.KprobeExecve.Close()
	defer objs.Events.Close()

	kp, err := link.Kprobe("sys_execve", objs.KprobeExecve, nil)
	if err != nil {
		log.Fatalf("opening kprobe: %s", err)
	}
	defer kp.Close()

	// Set up a perf reader to read events from the eBPF program
	rd, err := perf.NewReader(objs.Events, os.Getpagesize())
	if err != nil {
		fmt.Fprintf(os.Stderr, "Creating perf reader failed: %v\n", err)
		os.Exit(1)
	}
	defer rd.Close()

	// Set up a channel to receive signals
	sig := make(chan os.Signal, 1)
	signal.Notify(sig, os.Interrupt, syscall.SIGTERM)

	fmt.Println("Listening for events..")

	// Loop to read events
	go func() {
		for {
			record, err := rd.Read()
			if err != nil {
				fmt.Fprintf(os.Stderr, "Reading from perf reader failed: %v\n", err)
				os.Exit(1)
			}

			// Parse event data
			var e bpfEvent
			if err := binary.Read(bytes.NewBuffer(record.RawSample), binary.LittleEndian, &e); err != nil {
				fmt.Fprintf(os.Stderr, "Parsing event data failed: %v\n", err)
				os.Exit(1)
			}

			fmt.Printf("PID: %d, PPID: %d, UID: %d, Comm: %s\n", e.Pid, e.Ppid, e.Uid, string(e.Comm[:]))
		}
	}()

	// Wait for a signal to exit
	<-sig
	fmt.Println("Exiting..")
}
```
</details>

header pkg: [headers_fake.tar.gz](https://github.com/user-attachments/files/16103834/headers_fake.tar.gz)


#  Reproducing
## Build
1. add eBPF and Go code file to cilium/ebpf/examples/kprobe-exec
2. add header to cilium/ebpf/examples/headers_fake
3. cd ./cillium/ebpf/examples ;make -C ..
5. cd cilium/ebpf/examples/kprobe-exec; CGO_ENABLED=0 GOOS=linux GOARCH=arm64   go build -gcflags "all=-N -l"
6. upload kprobe-exec binary to aarch64 vm (in my env os version: KY10 SP1.1 aarch64,kernel version: 4.19.90-23.15.v2101)

> tips:
> Go code use external BTF file,your test vm need to enable BTF or use pahole gen external BTF.
if your vm has edabled BTF , should remove GO code :
```go
	spec, err := btf.LoadSpec("/data/gb/external.btf")
	if err != nil {
		log.Fatalf("loading BTF: %v", err)
	}
	opts := &ebpf.CollectionOptions{
		Programs: ebpf.ProgramOptions{
			KernelTypes: spec,
		},
	}
```

## Error
1. NPE error
```bash
# ./kprobe-exec 
Listening for events..
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1bd1f8]

goroutine 25 [running]:
github.com/cilium/ebpf/perf.(*Reader).ReadInto(0x40012b95e0, 0x4002358c98)
        /Users/zhuhuijun/go/src/github.com/cilium/ebpf/perf/reader.go:389 +0x6c8
github.com/cilium/ebpf/perf.(*Reader).Read(0x40012b95e0)
        /Users/zhuhuijun/go/src/github.com/cilium/ebpf/perf/reader.go:337 +0x48
main.main.func1()
        /Users/zhuhuijun/go/src/github.com/cilium/ebpf/examples/kprobe-exec/main.go:75 +0x54
created by main.main in goroutine 1
        /Users/zhuhuijun/go/src/github.com/cilium/ebpf/examples/kprobe-exec/main.go:73 +0xa04
```
2. Causes the error code location
https://github.com/cilium/ebpf/blob/f2b2f6d61aaf1fa8c0eb14c2a58f7e199fbd6086/perf/reader.go#L389

