### PR TITLE
map: fix flaky TestMapIteratorAllocations

### DIFF
--- a/map_test.go
+++ b/map_test.go
@@ -1106,7 +1106,7 @@ func TestMapIteratorAllocations(t *testing.T) {
 	iter := arr.Iterate()
 
 	// AllocsPerRun warms up the function for us.
-	allocs := testing.AllocsPerRun(1, func() {
+	allocs := testing.AllocsPerRun(int(arr.MaxEntries()-1), func() {
 		if !iter.Next(&k, &v) {
 			t.Fatal("Next failed")
 		}


### PR DESCRIPTION
For some reason the allocation check is flaky, with an allocation happening in sysenc.Unmarshal. Pinpointing the exact cause is difficult because we can't tell whether the allocation happened during the warm up or not.

Increase the number of runs for the allocation check, which is probably a sensible thing to do anyways.