### PR TITLE
link: fix nil pointer dereference in AttachXDP

### DIFF
--- a/link/xdp.go
+++ b/link/xdp.go
@@ -51,7 +51,11 @@ func AttachXDP(opts XDPOptions) (Link, error) {
 		Flags:   uint32(opts.Flags),
 	})
 
-	return &xdpLink{*rawLink}, err
+	if err != nil {
+		return nil, fmt.Errorf("failed to attach link: %w", err)
+	}
+
+	return &xdpLink{*rawLink}, nil
 }
 
 type xdpLink struct {

--- a/link/xdp_test.go
+++ b/link/xdp_test.go
@@ -1,10 +1,12 @@
 package link
 
 import (
+	"math"
 	"testing"
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/internal/testutils"
+	"github.com/go-quicktest/qt"
 )
 
 const IfIndexLO = 1
@@ -14,13 +16,17 @@ func TestAttachXDP(t *testing.T) {
 
 	prog := mustLoadProgram(t, ebpf.XDP, 0, "")
 
+	_, err := AttachXDP(XDPOptions{
+		Program:   prog,
+		Interface: math.MaxInt,
+	})
+	qt.Assert(t, qt.IsNotNil(err))
+
 	l, err := AttachXDP(XDPOptions{
 		Program:   prog,
 		Interface: IfIndexLO,
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	qt.Assert(t, qt.IsNil(err))
 
 	testLink(t, l, prog)
 }


### PR DESCRIPTION
With the change in #1435, failures to attach to a XDP link cause a nil pointer dereference. This change ensures any error returned from `AttachRawLink` is handled correctly.