### PR TITLE
bpf2go: enable ebpf code reuse across go packages

### DIFF
--- a/cmd/bpf2go/README.md
+++ b/cmd/bpf2go/README.md
@@ -34,6 +34,20 @@ up-to-date list.
 disable this behaviour using `-no-global-types`. You can add to the set of
 types by specifying `-type foo` for each type you'd like to generate.
 
+## eBPF packages
+
+The tool can pull header files from other Go packages. To enable, create
+`bpf2go.hfiles.go` in the output dir. Add packages you wish to pull headers
+from as imports, e.g.:
+
+```
+// bpf2go.hfiles.go
+package awesome
+import _ "example.org/foo"
+```
+
+Write `#include "example.org/foo/foo.h"` to include `foo.h` from `example.org/foo`.
+
 ## Examples
 
 See [examples/kprobe](../../examples/kprobe/main.go) for a fully worked out example.

--- a/cmd/bpf2go/vfs.go
+++ b/cmd/bpf2go/vfs.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"go/build"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+)
+
+// vfs is LLVM virtual file system parsed from a file
+//
+// In a nutshell, it is a tree of "directory" nodes with leafs being
+// either "file" (a reference to file) or "directory-remap" (a reference
+// to directory).
+//
+// https://github.com/llvm/llvm-project/blob/llvmorg-18.1.0/llvm/include/llvm/Support/VirtualFileSystem.h#L637
+type vfs struct {
+	Version       int       `json:"version"`
+	CaseSensitive bool      `json:"case-sensitive"`
+	Roots         []vfsItem `json:"roots"`
+}
+
+type vfsItem struct {
+	Name             string      `json:"name"`
+	Type             vfsItemType `json:"type"`
+	Contents         []vfsItem   `json:"contents,omitempty"`
+	ExternalContents string      `json:"external-contents,omitempty"`
+}
+
+type vfsItemType string
+
+const (
+	vfsFile      vfsItemType = "file"
+	vfsDirectory vfsItemType = "directory"
+)
+
+func (vi *vfsItem) addDir(path string) (*vfsItem, error) {
+	for _, name := range strings.Split(path, "/") {
+		idx := vi.index(name)
+		if idx == -1 {
+			idx = len(vi.Contents)
+			vi.Contents = append(vi.Contents, vfsItem{Name: name, Type: vfsDirectory})
+		}
+		vi = &vi.Contents[idx]
+		if vi.Type != vfsDirectory {
+			return nil, fmt.Errorf("adding %q: non-directory object already exists", path)
+		}
+	}
+	return vi, nil
+}
+
+func (vi *vfsItem) index(name string) int {
+	return slices.IndexFunc(vi.Contents, func(item vfsItem) bool {
+		return item.Name == name
+	})
+}
+
+func persistVfs(vfs *vfs) (_ string, retErr error) {
+	temp, err := os.CreateTemp("", "")
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		temp.Close()
+		if retErr != nil {
+			os.Remove(temp.Name())
+		}
+	}()
+
+	if err = json.NewEncoder(temp).Encode(vfs); err != nil {
+		return "", err
+	}
+
+	return temp.Name(), nil
+}
+
+// vfsRootDir is the (virtual) directory where we mount go module sources
+// for the C includes to pick them, e.g. "<vfsRootDir>/github.com/cilium/ebpf".
+const vfsRootDir = "/.vfsoverlay.d"
+
+// createVfs produces a vfs from a list of packages. It creates a
+// (virtual) directory tree reflecting package import paths and adds
+// links to header files. E.g. for github.com/foo/bar containing awesome.h:
+//
+//	github.com/
+//	  foo/
+//	    bar/
+//	      awesome.h -> $HOME/go/pkg/mod/github.com/foo/bar@version/awesome.h
+func createVfs(pkgs []*build.Package) (*vfs, error) {
+	roots := [1]vfsItem{{Name: vfsRootDir, Type: vfsDirectory}}
+	for _, pkg := range pkgs {
+		var headers []vfsItem
+		for _, h := range hfiles(pkg) {
+			headers = append(headers, vfsItem{Name: h, Type: vfsFile,
+				ExternalContents: filepath.Join(pkg.Dir, h)})
+		}
+		dir, err := roots[0].addDir(pkg.ImportPath)
+		if err != nil {
+			return nil, err
+		}
+		dir.Contents = headers // NB don't append inplace, same package could be imported twice
+	}
+	return &vfs{CaseSensitive: true, Roots: roots[:]}, nil
+}


### PR DESCRIPTION
Extract imports from "bpf2go.hfiles.go" in the output dir, scan packages for header files, and expose headers to clang. C code consumes headers by providing a go package path in include directive, e.g.

```
bpf2go.hfiles.go:
  package awesome
  import (
    _ "example.org/foo"
  )

frob.c:
  #include "example.org/foo/foo.h"
```

It is handy for sharing code between multiple ebpf blobs within a project. Even better, it enables sharing ebpf code between multiple projects using go modules as delivery vehicle.

By listing build dependencies in a .go file, we ensure that they are properly reflected in go.mod.