### PR TITLE
map: reduce allocations for batch operations

### DIFF
--- a/internal/sysenc/buffer.go
+++ b/internal/sysenc/buffer.go
@@ -68,10 +68,17 @@ func (b Buffer) Pointer() sys.Pointer {
 
 // Unmarshal the buffer into the provided value.
 func (b Buffer) Unmarshal(data any) error {
+	return b.UnmarshalWithLimit(data, b.size)
+}
+
+// UnmarshalWithLimit unmarshals the buffer up to limit into the provided value.
+func (b Buffer) UnmarshalWithLimit(data any, limit int) error {
 	if b.size == syscallPointerOnly {
 		return nil
 	}
-
+	if b.size != limit {
+		return Unmarshal(data, b.unsafeBytes()[:limit])
+	}
 	return Unmarshal(data, b.unsafeBytes())
 }
 

--- a/map.go
+++ b/map.go
@@ -1061,6 +1061,10 @@ func (m *Map) batchLookup(cmd sys.Cmd, cursor *MapBatchCursor, keysOut, valuesOu
 		return n, err
 	}
 
+	if n == 0 {
+		return n, nil
+	}
+
 	err = valueBuf.Unmarshal(valuesOut)
 	if err != nil {
 		return 0, err
@@ -1081,6 +1085,10 @@ func (m *Map) batchLookupPerCPU(cmd sys.Cmd, cursor *MapBatchCursor, keysOut, va
 	n, sysErr := m.batchLookupCmd(cmd, cursor, count, keysOut, valuePtr, opts)
 	if sysErr != nil && !errors.Is(sysErr, unix.ENOENT) {
 		return 0, err
+	}
+
+	if n == 0 {
+		return n, sysErr
 	}
 
 	err = unmarshalBatchPerCPUValue(valuesOut, count, int(m.valueSize), valueBuf)
@@ -1141,6 +1149,10 @@ func (m *Map) batchLookupCmd(cmd sys.Cmd, cursor *MapBatchCursor, count int, key
 	sysErr = wrapMapError(sysErr)
 	if sysErr != nil && !errors.Is(sysErr, unix.ENOENT) {
 		return 0, sysErr
+	}
+
+	if attr.Count == 0 {
+		return int(attr.Count), sysErr
 	}
 
 	if err := keyBuf.Unmarshal(keysOut); err != nil {

--- a/map.go
+++ b/map.go
@@ -1155,7 +1155,7 @@ func (m *Map) batchLookupCmd(cmd sys.Cmd, cursor *MapBatchCursor, count int, key
 		return int(attr.Count), sysErr
 	}
 
-	if err := keyBuf.Unmarshal(keysOut); err != nil {
+	if err := keyBuf.UnmarshalWithLimit(keysOut, int(attr.Count)*int(m.keySize)); err != nil {
 		return 0, err
 	}
 


### PR DESCRIPTION
Reduce allocations for batch operations by
- skipping unmarshaling if returned attr.Count is 0
- allow partial unmarshaling if attr.Count is not expected count

This should help to resolve https://github.com/cilium/ebpf/issues/1080.

```
benchstat old.txt new.txt
name                                        old time/op    new time/op    delta
Iterate/Hash/MapIterator-16                   1.15ms ± 4%    1.10ms ± 9%   -4.27%  (p=0.035 n=10+10)
Iterate/Hash/MapIteratorDelete-16             1.71ms ± 3%    1.71ms ± 3%     ~     (p=0.971 n=10+10)
Iterate/Hash/BatchLookup-16                   2.63µs ± 8%    2.53µs ±10%     ~     (p=0.123 n=10+10)
Iterate/Hash/BatchLookupAndDelete-16          85.5µs ± 2%    86.7µs ± 2%   +1.38%  (p=0.011 n=10+10)
Iterate/Hash/BatchDelete-16                   77.7µs ± 3%    78.0µs ± 2%     ~     (p=0.579 n=10+10)
Iterate/PerCPUHash/MapIterator-16             3.12ms ±13%    3.22ms ± 5%     ~     (p=0.515 n=10+8)
Iterate/PerCPUHash/MapIteratorDelete-16       6.32ms ± 8%    6.14ms ±17%     ~     (p=0.579 n=10+10)
Iterate/PerCPUHash/BatchLookup-16             2.11ms ±19%    0.04ms ±19%  -97.92%  (p=0.000 n=10+10)
Iterate/PerCPUHash/BatchLookupAndDelete-16    3.14ms ± 7%    3.15ms ± 8%     ~     (p=0.796 n=10+10)
Iterate/PerCPUHash/BatchDelete-16              373µs ± 3%     382µs ± 4%   +2.37%  (p=0.028 n=9+10)

name                                        old alloc/op   new alloc/op   delta
Iterate/Hash/MapIterator-16                   24.1kB ± 0%    24.1kB ± 0%     ~     (p=0.101 n=10+10)
Iterate/Hash/MapIteratorDelete-16               107B ± 0%      107B ± 0%     ~     (all equal)
Iterate/Hash/BatchLookup-16                     136B ± 0%      136B ± 0%     ~     (all equal)
Iterate/Hash/BatchLookupAndDelete-16            144B ± 0%      144B ± 0%     ~     (all equal)
Iterate/Hash/BatchDelete-16                    24.0B ± 0%     24.0B ± 0%     ~     (all equal)
Iterate/PerCPUHash/MapIterator-16              152kB ± 0%     152kB ± 0%     ~     (p=0.959 n=10+10)
Iterate/PerCPUHash/MapIteratorDelete-16        281kB ± 0%     281kB ± 0%     ~     (p=0.055 n=10+9)
Iterate/PerCPUHash/BatchLookup-16              155kB ± 0%     131kB ± 0%  -15.45%  (p=0.000 n=10+10)
Iterate/PerCPUHash/BatchLookupAndDelete-16     156kB ± 0%     156kB ± 0%     ~     (p=0.734 n=9+10)
Iterate/PerCPUHash/BatchDelete-16              24.0B ± 0%     24.0B ± 0%     ~     (all equal)

name                                        old allocs/op  new allocs/op  delta
Iterate/Hash/MapIterator-16                    1.00k ± 0%     1.00k ± 0%     ~     (all equal)
Iterate/Hash/MapIteratorDelete-16               4.00 ± 0%      4.00 ± 0%     ~     (all equal)
Iterate/Hash/BatchLookup-16                     5.00 ± 0%      5.00 ± 0%     ~     (all equal)
Iterate/Hash/BatchLookupAndDelete-16            5.00 ± 0%      5.00 ± 0%     ~     (all equal)
Iterate/Hash/BatchDelete-16                     1.00 ± 0%      1.00 ± 0%     ~     (all equal)
Iterate/PerCPUHash/MapIterator-16              2.00k ± 0%     2.00k ± 0%     ~     (all equal)
Iterate/PerCPUHash/MapIteratorDelete-16        3.00k ± 0%     3.00k ± 0%     ~     (all equal)
Iterate/PerCPUHash/BatchLookup-16              1.01k ± 0%     0.01k ± 0%  -99.40%  (p=0.000 n=10+10)
Iterate/PerCPUHash/BatchLookupAndDelete-16     1.01k ± 0%     1.01k ± 0%     ~     (all equal)
Iterate/PerCPUHash/BatchDelete-16               1.00 ± 0%      1.00 ± 0%     ~     (all equal)
```