### PR TITLE
fix a variety of Copy() problems

### DIFF
--- a/btf/btf_test.go
+++ b/btf/btf_test.go
@@ -326,6 +326,8 @@ func TestGuessBTFByteOrder(t *testing.T) {
 }
 
 func TestSpecCopy(t *testing.T) {
+	qt.Check(t, qt.IsNil((*Spec)(nil).Copy()))
+
 	spec := parseELFBTF(t, "../testdata/loader-el.elf")
 	cpy := spec.Copy()
 

--- a/collection.go
+++ b/collection.go
@@ -57,7 +57,7 @@ func (cs *CollectionSpec) Copy() *CollectionSpec {
 		Maps:      make(map[string]*MapSpec, len(cs.Maps)),
 		Programs:  make(map[string]*ProgramSpec, len(cs.Programs)),
 		ByteOrder: cs.ByteOrder,
-		Types:     cs.Types,
+		Types:     cs.Types.Copy(),
 	}
 
 	for name, spec := range cs.Maps {

--- a/collection_test.go
+++ b/collection_test.go
@@ -1,6 +1,7 @@
 package ebpf
 
 import (
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
@@ -57,7 +58,7 @@ func TestCollectionSpecNotModified(t *testing.T) {
 
 func TestCollectionSpecCopy(t *testing.T) {
 	cs := &CollectionSpec{
-		Maps: map[string]*MapSpec{
+		map[string]*MapSpec{
 			"my-map": {
 				Type:       Array,
 				KeySize:    4,
@@ -65,7 +66,7 @@ func TestCollectionSpecCopy(t *testing.T) {
 				MaxEntries: 1,
 			},
 		},
-		Programs: map[string]*ProgramSpec{
+		map[string]*ProgramSpec{
 			"test": {
 				Type: SocketFilter,
 				Instructions: asm.Instructions{
@@ -76,25 +77,12 @@ func TestCollectionSpecCopy(t *testing.T) {
 				License: "MIT",
 			},
 		},
-		Types: &btf.Spec{},
-	}
-	cpy := cs.Copy()
-
-	if cpy == cs {
-		t.Error("Copy returned the same pointer")
+		&btf.Spec{},
+		binary.LittleEndian,
 	}
 
-	if cpy.Maps["my-map"] == cs.Maps["my-map"] {
-		t.Error("Copy returned same Maps")
-	}
-
-	if cpy.Programs["test"] == cs.Programs["test"] {
-		t.Error("Copy returned same Programs")
-	}
-
-	if cpy.Types != cs.Types {
-		t.Error("Copy returned different Types")
-	}
+	qt.Check(t, qt.IsNil((*CollectionSpec)(nil).Copy()))
+	qt.Assert(t, testutils.IsDeepCopy(cs.Copy(), cs))
 }
 
 func TestCollectionSpecLoadCopy(t *testing.T) {

--- a/internal/testutils/checkers.go
+++ b/internal/testutils/checkers.go
@@ -1,0 +1,158 @@
+package testutils
+
+import (
+	"bytes"
+	"fmt"
+	"reflect"
+
+	"github.com/go-quicktest/qt"
+)
+
+// IsDeepCopy checks that got is a deep copy of want.
+//
+// All primitive values must be equal, but pointers must be distinct.
+// This is different from [reflect.DeepEqual] which will accept equal pointer values.
+// That is, reflect.DeepEqual(a, a) is true, while IsDeepCopy(a, a) is false.
+func IsDeepCopy[T any](got, want T) qt.Checker {
+	return &deepCopyChecker[T]{got, want, make(map[pair]struct{})}
+}
+
+type pair struct {
+	got, want reflect.Value
+}
+
+type deepCopyChecker[T any] struct {
+	got, want T
+	visited   map[pair]struct{}
+}
+
+func (dcc *deepCopyChecker[T]) Check(_ func(key string, value any)) error {
+	return dcc.check(reflect.ValueOf(dcc.got), reflect.ValueOf(dcc.want))
+}
+
+func (dcc *deepCopyChecker[T]) check(got, want reflect.Value) error {
+	switch want.Kind() {
+	case reflect.Interface:
+		return dcc.check(got.Elem(), want.Elem())
+
+	case reflect.Pointer:
+		if got.IsNil() && want.IsNil() {
+			return nil
+		}
+
+		if got.IsNil() {
+			return fmt.Errorf("expected non-nil pointer")
+		}
+
+		if want.IsNil() {
+			return fmt.Errorf("expected nil pointer")
+		}
+
+		if got.UnsafePointer() == want.UnsafePointer() {
+			return fmt.Errorf("equal pointer values")
+		}
+
+		switch want.Type() {
+		case reflect.TypeOf((*bytes.Reader)(nil)):
+			// bytes.Reader doesn't allow modifying it's contents, so we
+			// allow a shallow copy.
+			return nil
+		}
+
+		if _, ok := dcc.visited[pair{got, want}]; ok {
+			// Deal with recursive types.
+			return nil
+		}
+
+		dcc.visited[pair{got, want}] = struct{}{}
+		return dcc.check(got.Elem(), want.Elem())
+
+	case reflect.Slice:
+		if got.IsNil() && want.IsNil() {
+			return nil
+		}
+
+		if got.IsNil() {
+			return fmt.Errorf("expected non-nil slice")
+		}
+
+		if want.IsNil() {
+			return fmt.Errorf("expected nil slice")
+		}
+
+		if got.Len() != want.Len() {
+			return fmt.Errorf("expected %d elements, got %d", want.Len(), got.Len())
+		}
+
+		if want.Len() == 0 {
+			return nil
+		}
+
+		if got.UnsafePointer() == want.UnsafePointer() {
+			return fmt.Errorf("equal backing memory")
+		}
+
+		fallthrough
+
+	case reflect.Array:
+		for i := 0; i < want.Len(); i++ {
+			if err := dcc.check(got.Index(i), want.Index(i)); err != nil {
+				return fmt.Errorf("index %d: %w", i, err)
+			}
+		}
+
+		return nil
+
+	case reflect.Struct:
+		for i := 0; i < want.NumField(); i++ {
+			if err := dcc.check(got.Field(i), want.Field(i)); err != nil {
+				return fmt.Errorf("%q: %w", want.Type().Field(i).Name, err)
+			}
+		}
+
+		return nil
+
+	case reflect.Map:
+		if got.Len() != want.Len() {
+			return fmt.Errorf("expected %d items, got %d", want.Len(), got.Len())
+		}
+
+		if got.UnsafePointer() == want.UnsafePointer() {
+			return fmt.Errorf("maps are equal")
+		}
+
+		iter := want.MapRange()
+		for iter.Next() {
+			key := iter.Key()
+			got := got.MapIndex(iter.Key())
+			if !got.IsValid() {
+				return fmt.Errorf("key %v is missing", key)
+			}
+
+			want := iter.Value()
+			if err := dcc.check(got, want); err != nil {
+				return fmt.Errorf("key %v: %w", key, err)
+			}
+		}
+
+		return nil
+
+	case reflect.Chan, reflect.UnsafePointer:
+		return fmt.Errorf("%s is not supported", want.Type())
+
+	default:
+		// Compare by value as usual.
+		if !got.Equal(want) {
+			return fmt.Errorf("%#v is not equal to %#v", got, want)
+		}
+
+		return nil
+	}
+}
+
+func (dcc *deepCopyChecker[T]) Args() []qt.Arg {
+	return []qt.Arg{
+		{Name: "got", Value: dcc.got},
+		{Name: "want", Value: dcc.want},
+	}
+}

--- a/internal/testutils/checkers_test.go
+++ b/internal/testutils/checkers_test.go
@@ -1,0 +1,106 @@
+package testutils
+
+import (
+	"testing"
+
+	"github.com/go-quicktest/qt"
+)
+
+func TestIsDeepCopy(t *testing.T) {
+	type s struct {
+		basic  int
+		array  [1]*int
+		array0 [0]int
+		ptr    *int
+		slice  []*int
+		ifc    any
+		m      map[*int]*int
+		rec    *s
+	}
+
+	key := 1
+	copy := func() *s {
+		v := &s{
+			0,
+			[...]*int{new(int)},
+			[...]int{},
+			new(int),
+			[]*int{new(int)},
+			new(int),
+			map[*int]*int{&key: new(int)},
+			nil,
+		}
+		v.rec = v
+		return v
+	}
+
+	a, b := copy(), copy()
+	qt.Check(t, qt.IsNil(IsDeepCopy(a, b).Check(nil)))
+
+	a.basic++
+	qt.Check(t, qt.ErrorMatches(IsDeepCopy(a, b).Check(nil), `"basic": .*`))
+
+	a = copy()
+	(*a.array[0])++
+	qt.Check(t, qt.ErrorMatches(IsDeepCopy(a, b).Check(nil), `"array": index 0: .*`))
+
+	a = copy()
+	a.array[0] = nil
+	qt.Check(t, qt.ErrorMatches(IsDeepCopy(a, b).Check(nil), `"array": index 0: .*`))
+
+	a = copy()
+	a.array = b.array
+	qt.Check(t, qt.ErrorMatches(IsDeepCopy(a, b).Check(nil), `"array": index 0: .*`))
+
+	a = copy()
+	(*a.ptr)++
+	qt.Check(t, qt.ErrorMatches(IsDeepCopy(a, b).Check(nil), `"ptr": .*`))
+
+	a = copy()
+	a.ptr = b.ptr
+	qt.Check(t, qt.ErrorMatches(IsDeepCopy(a, b).Check(nil), `"ptr": .*`))
+
+	a = copy()
+	(*a.slice[0])++
+	qt.Check(t, qt.ErrorMatches(IsDeepCopy(a, b).Check(nil), `"slice": .*`))
+
+	a = copy()
+	a.slice[0] = nil
+	qt.Check(t, qt.ErrorMatches(IsDeepCopy(a, b).Check(nil), `"slice": .*`))
+
+	a = copy()
+	a.slice = nil
+	qt.Check(t, qt.ErrorMatches(IsDeepCopy(a, b).Check(nil), `"slice": .*`))
+
+	a = copy()
+	a.slice = b.slice
+	qt.Check(t, qt.ErrorMatches(IsDeepCopy(a, b).Check(nil), `"slice": .*`))
+
+	a = copy()
+	*(a.ifc.(*int))++
+	qt.Check(t, qt.ErrorMatches(IsDeepCopy(a, b).Check(nil), `"ifc": .*`))
+
+	a = copy()
+	a.ifc = b.ifc
+	qt.Check(t, qt.ErrorMatches(IsDeepCopy(a, b).Check(nil), `"ifc": .*`))
+
+	a = copy()
+	a.rec = b.rec
+	qt.Check(t, qt.ErrorMatches(IsDeepCopy(a, b).Check(nil), `"rec": .*`))
+
+	a = copy()
+	a.m = b.m
+	qt.Check(t, qt.ErrorMatches(IsDeepCopy(a, b).Check(nil), `"m": .*`))
+
+	a = copy()
+	(*a.m[&key])++
+	qt.Check(t, qt.ErrorMatches(IsDeepCopy(a, b).Check(nil), `"m": .*`))
+
+	a = copy()
+	a.m[new(int)] = new(int)
+	qt.Check(t, qt.ErrorMatches(IsDeepCopy(a, b).Check(nil), `"m": .*`))
+
+	a = copy()
+	delete(a.m, &key)
+	qt.Check(t, qt.ErrorMatches(IsDeepCopy(a, b).Check(nil), `"m": .*`))
+}

--- a/map.go
+++ b/map.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -96,11 +97,26 @@ func (ms *MapSpec) Copy() *MapSpec {
 	}
 
 	cpy := *ms
+	cpy.Contents = slices.Clone(cpy.Contents)
 
-	cpy.Contents = make([]MapKV, len(ms.Contents))
-	copy(cpy.Contents, ms.Contents)
+	if cpy.InnerMap == ms {
+		cpy.InnerMap = &cpy
+	} else {
+		cpy.InnerMap = ms.InnerMap.Copy()
+	}
 
-	cpy.InnerMap = ms.InnerMap.Copy()
+	if cpy.Extra != nil {
+		extra := *cpy.Extra
+		cpy.Extra = &extra
+	}
+
+	if cpy.Key != nil {
+		cpy.Key = btf.Copy(cpy.Key)
+	}
+
+	if cpy.Value != nil {
+		cpy.Value = btf.Copy(cpy.Value)
+	}
 
 	return &cpy
 }

--- a/map_test.go
+++ b/map_test.go
@@ -1,6 +1,7 @@
 package ebpf
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"math"
@@ -90,6 +91,29 @@ func TestMap(t *testing.T) {
 	if k != 1 {
 		t.Error("Want key 1, got", k)
 	}
+}
+
+func TestMapSpecCopy(t *testing.T) {
+	a := &MapSpec{
+		"foo",
+		Hash,
+		4,
+		4,
+		1,
+		1,
+		PinByName,
+		1,
+		[]MapKV{{1, 2}}, // Can't copy Contents, use value types
+		true,
+		nil, // InnerMap
+		bytes.NewReader(nil),
+		&btf.Int{},
+		&btf.Int{},
+	}
+	a.InnerMap = a
+
+	qt.Check(t, qt.IsNil((*MapSpec)(nil).Copy()))
+	qt.Assert(t, testutils.IsDeepCopy(a.Copy(), a))
 }
 
 func TestMapBatch(t *testing.T) {

--- a/prog_test.go
+++ b/prog_test.go
@@ -711,6 +711,27 @@ func TestProgramRejectIncorrectByteOrder(t *testing.T) {
 	}
 }
 
+func TestProgramSpecCopy(t *testing.T) {
+	a := &ProgramSpec{
+		"test",
+		1,
+		1,
+		"attach",
+		nil, // Can't copy Program
+		"section",
+		asm.Instructions{
+			asm.Return(),
+		},
+		1,
+		"license",
+		1,
+		binary.LittleEndian,
+	}
+
+	qt.Check(t, qt.IsNil((*ProgramSpec)(nil).Copy()))
+	qt.Assert(t, testutils.IsDeepCopy(a.Copy(), a))
+}
+
 func TestProgramSpecTag(t *testing.T) {
 	arr := createArray(t)
 


### PR DESCRIPTION
The are multiple Copy() methods in the code base which are used to create deep copies of a struct. Any bugs in them can manifest as data races in concurrent code.

Add a quicktest checker which ensures that two variables are a deep copy of each other: values match, but all locations in memory differ.

Fix a variety of problems with the existing Copy() implementations. They all allow copying a nil struct and copy all elements.

There are exceptions to the deep copy rule:

- MapSpec.Contents is not deep copied because we can't easily make copies of interface values. This is documented already.
- MapSpec.Extra is an immutable bytes.Reader and therefore only needs a shallow copy.
- ProgramSpec.AttachTarget is a Program, which is (currently) safe for concurrent use.

Fixes #1517