### PR TITLE
map: do not allocate on lookup when key doesn't exist

### DIFF
--- a/map.go
+++ b/map.go
@@ -28,6 +28,10 @@ var (
 	ErrIterationAborted = errors.New("iteration aborted")
 	ErrMapIncompatible  = errors.New("map spec is incompatible with existing map")
 	errMapNoBTFValue    = errors.New("map spec does not contain a BTF Value")
+
+	// pre-allocating these errors here since they may get called in hot code paths
+	// and cause unnecessary memory allocations
+	errMapLookupKeyNotExist = fmt.Errorf("lookup: %w", sysErrKeyNotExist)
 )
 
 // MapOptions control loading a map into the kernel.
@@ -695,6 +699,9 @@ func (m *Map) lookup(key interface{}, valueOut sys.Pointer, flags MapLookupFlags
 	}
 
 	if err = sys.MapLookupElem(&attr); err != nil {
+		if errors.Is(err, unix.ENOENT) {
+			return errMapLookupKeyNotExist
+		}
 		return fmt.Errorf("lookup: %w", wrapMapError(err))
 	}
 	return nil

--- a/map_test.go
+++ b/map_test.go
@@ -245,6 +245,17 @@ func TestMapLookupKeyTooSmall(t *testing.T) {
 	qt.Assert(t, qt.IsNotNil(m.Lookup(uint32(0), &small)))
 }
 
+func TestMapLookupKeyNotFoundAllocations(t *testing.T) {
+	m := createArray(t)
+	defer m.Close()
+	var key, out uint32 = 3, 0
+
+	allocs := testing.AllocsPerRun(5, func() {
+		_ = m.Lookup(&key, &out)
+	})
+	qt.Assert(t, qt.Equals(allocs, float64(0)))
+}
+
 func TestBatchAPIMapDelete(t *testing.T) {
 	if err := haveBatchAPI(); err != nil {
 		t.Skipf("batch api not available: %v", err)


### PR DESCRIPTION
Fixes #1516