### PR TITLE
program: deprecate LogSize and VerifierError.Truncated

### DIFF
--- a/internal/errors.go
+++ b/internal/errors.go
@@ -23,7 +23,7 @@ func ErrorWithLog(source string, err error, log []byte) *VerifierError {
 
 	log = bytes.Trim(log, whitespace)
 	if len(log) == 0 {
-		return &VerifierError{source, err, nil}
+		return &VerifierError{source, err, nil, false}
 	}
 
 	logLines := bytes.Split(log, []byte{'\n'})
@@ -34,7 +34,7 @@ func ErrorWithLog(source string, err error, log []byte) *VerifierError {
 		lines = append(lines, string(bytes.TrimRight(line, whitespace)))
 	}
 
-	return &VerifierError{source, err, lines}
+	return &VerifierError{source, err, lines, false}
 }
 
 // VerifierError includes information from the eBPF verifier.
@@ -46,6 +46,8 @@ type VerifierError struct {
 	Cause error
 	// The verifier output split into lines.
 	Log []string
+	// Deprecated: the log is never truncated anymore.
+	Truncated bool
 }
 
 func (le *VerifierError) Unwrap() error {

--- a/prog.go
+++ b/prog.go
@@ -46,6 +46,10 @@ const (
 	outputPad = 256 + 2
 )
 
+// Deprecated: the correct log size is now detected automatically and this
+// constant is unused.
+const DefaultVerifierLogSize = 64 * 1024
+
 // minVerifierLogSize is the default number of bytes allocated for the
 // verifier log.
 const minVerifierLogSize = 64 * 1024
@@ -68,6 +72,10 @@ type ProgramOptions struct {
 	// will always allocate an output buffer, but will result in only a single
 	// attempt at loading the program.
 	LogLevel LogLevel
+
+	// Deprecated: the correct log buffer size is determined automatically
+	// and this field is ignored.
+	LogSize int
 
 	// Disables the verifier log completely, regardless of other options.
 	LogDisabled bool


### PR DESCRIPTION
We removed LogSize and VerifierError.Truncated in a previous commit, but this causes lots of headache when trying to update the dependency in cilium/cilium and cilium/tetragon. We won't be the only ones suffering, so deprecate the field instead of removing it outright.