### PR TITLE
btf: fix panic when copying nil Type

### DIFF
--- a/btf/types.go
+++ b/btf/types.go
@@ -682,6 +682,10 @@ func Copy(typ Type) Type {
 }
 
 func copyType(typ Type, ids map[Type]TypeID, copies map[Type]Type, copiedIDs map[Type]TypeID) Type {
+	if typ == nil {
+		return nil
+	}
+
 	cpy, ok := copies[typ]
 	if ok {
 		// This has been copied previously, no need to continue.

--- a/map.go
+++ b/map.go
@@ -102,6 +102,8 @@ func (ms *MapSpec) Copy() *MapSpec {
 
 	cpy := *ms
 	cpy.Contents = slices.Clone(cpy.Contents)
+	cpy.Key = btf.Copy(cpy.Key)
+	cpy.Value = btf.Copy(cpy.Value)
 
 	if cpy.InnerMap == ms {
 		cpy.InnerMap = &cpy
@@ -112,14 +114,6 @@ func (ms *MapSpec) Copy() *MapSpec {
 	if cpy.Extra != nil {
 		extra := *cpy.Extra
 		cpy.Extra = &extra
-	}
-
-	if cpy.Key != nil {
-		cpy.Key = btf.Copy(cpy.Key)
-	}
-
-	if cpy.Value != nil {
-		cpy.Value = btf.Copy(cpy.Value)
 	}
 
 	return &cpy


### PR DESCRIPTION
Copying a nil Type panics since we unconditionally invoke Type.copy(). Fix this and adjust the tests.