### PR TITLE
map: remove misleading error message when creating without BTF

### DIFF
--- a/map.go
+++ b/map.go
@@ -513,9 +513,6 @@ func handleMapCreateError(attr sys.MapCreateAttr, spec *MapSpec, err error) erro
 			return fmt.Errorf("map create: %w (ring map size %d not a multiple of page size %d)", err, maxEntries, pageSize)
 		}
 	}
-	if attr.BtfFd == 0 {
-		return fmt.Errorf("map create: %w (without BTF k/v)", err)
-	}
 
 	return fmt.Errorf("map create: %w", err)
 }


### PR DESCRIPTION
Time and time again people misunderstand errors like the following:

    map create: cannot allocate memory (without BTF k/v)

Instead of focusing on the ENOMEM they assume that it has something to do with BTF. In reality it just means that creating a map has failed, and we didn't supply any BTF during creation.

Avoid this confusion by removing the "without BTF k/v" part.