### PR TITLE
Drop internal.NativeEndian, use binary.NativeEndian

### DIFF
--- a/btf/btf.go
+++ b/btf/btf.go
@@ -668,7 +668,7 @@ func (s *Spec) TypeByName(name string, typ interface{}) error {
 // Types from base are used to resolve references in the split BTF.
 // The returned Spec only contains types from the split BTF, not from the base.
 func LoadSplitSpecFromReader(r io.ReaderAt, base *Spec) (*Spec, error) {
-	return loadRawSpec(r, internal.NativeEndian, base)
+	return loadRawSpec(r, binary.NativeEndian, base)
 }
 
 // TypesIterator iterates over types of a given spec.

--- a/btf/core_test.go
+++ b/btf/core_test.go
@@ -1,6 +1,7 @@
 package btf
 
 import (
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"os"
@@ -10,7 +11,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/cilium/ebpf/internal"
 	"github.com/cilium/ebpf/internal/testutils"
 
 	"github.com/go-quicktest/qt"
@@ -588,7 +588,7 @@ func TestCOREReloFieldSigned(t *testing.T) {
 			relo := &CORERelocation{
 				typ, coreAccessor{0}, reloFieldSigned, 0,
 			}
-			fixup, err := coreCalculateFixup(relo, &Void{}, internal.NativeEndian, dummyTypeID)
+			fixup, err := coreCalculateFixup(relo, &Void{}, binary.NativeEndian, dummyTypeID)
 			qt.Assert(t, qt.IsTrue(fixup.poison))
 			qt.Assert(t, qt.IsNil(err))
 		})
@@ -598,7 +598,7 @@ func TestCOREReloFieldSigned(t *testing.T) {
 		relo := &CORERelocation{
 			&Array{}, coreAccessor{0}, reloFieldSigned, 0,
 		}
-		_, err := coreCalculateFixup(relo, &Array{}, internal.NativeEndian, dummyTypeID)
+		_, err := coreCalculateFixup(relo, &Array{}, binary.NativeEndian, dummyTypeID)
 		qt.Assert(t, qt.ErrorIs(err, errNoSignedness))
 	})
 }
@@ -615,7 +615,7 @@ func TestCOREReloFieldShiftU64(t *testing.T) {
 		{typ, coreAccessor{0, 0}, reloFieldLShiftU64, 1},
 	} {
 		t.Run(relo.kind.String(), func(t *testing.T) {
-			_, err := coreCalculateFixup(relo, typ, internal.NativeEndian, dummyTypeID)
+			_, err := coreCalculateFixup(relo, typ, binary.NativeEndian, dummyTypeID)
 			qt.Assert(t, qt.ErrorIs(err, errUnsizedType))
 		})
 	}
@@ -639,7 +639,7 @@ func TestCORERelosKmodTypeID(t *testing.T) {
 	fixups, err := coreCalculateFixups(
 		relos,
 		[]Type{a, b},
-		internal.NativeEndian,
+		binary.NativeEndian,
 		typeID,
 	)
 	qt.Assert(t, qt.IsNil(err))
@@ -649,7 +649,7 @@ func TestCORERelosKmodTypeID(t *testing.T) {
 	fixups, err = coreCalculateFixups(
 		relos,
 		[]Type{b},
-		internal.NativeEndian,
+		binary.NativeEndian,
 		typeID,
 	)
 	qt.Assert(t, qt.IsNil(err))

--- a/btf/ext_info.go
+++ b/btf/ext_info.go
@@ -418,8 +418,8 @@ func (fi *funcInfo) marshal(w *bytes.Buffer, b *Builder) error {
 		TypeID:  id,
 	}
 	buf := make([]byte, FuncInfoSize)
-	internal.NativeEndian.PutUint32(buf, bfi.InsnOff)
-	internal.NativeEndian.PutUint32(buf[4:], uint32(bfi.TypeID))
+	binary.NativeEndian.PutUint32(buf, bfi.InsnOff)
+	binary.NativeEndian.PutUint32(buf[4:], uint32(bfi.TypeID))
 	_, err = w.Write(buf)
 	return err
 }
@@ -627,10 +627,10 @@ func (li *lineInfo) marshal(w *bytes.Buffer, b *Builder) error {
 	}
 
 	buf := make([]byte, LineInfoSize)
-	internal.NativeEndian.PutUint32(buf, bli.InsnOff)
-	internal.NativeEndian.PutUint32(buf[4:], bli.FileNameOff)
-	internal.NativeEndian.PutUint32(buf[8:], bli.LineOff)
-	internal.NativeEndian.PutUint32(buf[12:], bli.LineCol)
+	binary.NativeEndian.PutUint32(buf, bli.InsnOff)
+	binary.NativeEndian.PutUint32(buf[4:], bli.FileNameOff)
+	binary.NativeEndian.PutUint32(buf[8:], bli.LineOff)
+	binary.NativeEndian.PutUint32(buf[12:], bli.LineCol)
 	_, err = w.Write(buf)
 	return err
 }

--- a/btf/ext_info_test.go
+++ b/btf/ext_info_test.go
@@ -2,10 +2,9 @@ package btf
 
 import (
 	"bytes"
+	"encoding/binary"
 	"strings"
 	"testing"
-
-	"github.com/cilium/ebpf/internal"
 )
 
 func TestParseExtInfoBigRecordSize(t *testing.T) {
@@ -15,11 +14,11 @@ func TestParseExtInfoBigRecordSize(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := parseFuncInfos(rd, internal.NativeEndian, table); err == nil {
+	if _, err := parseFuncInfos(rd, binary.NativeEndian, table); err == nil {
 		t.Error("Parsing func info with large record size doesn't return an error")
 	}
 
-	if _, err := parseLineInfos(rd, internal.NativeEndian, table); err == nil {
+	if _, err := parseLineInfos(rd, binary.NativeEndian, table); err == nil {
 		t.Error("Parsing line info with large record size doesn't return an error")
 	}
 }

--- a/btf/fuzz_test.go
+++ b/btf/fuzz_test.go
@@ -6,13 +6,11 @@ import (
 	"fmt"
 	"io"
 	"testing"
-
-	"github.com/cilium/ebpf/internal"
 )
 
 func FuzzSpec(f *testing.F) {
 	var buf bytes.Buffer
-	err := binary.Write(&buf, internal.NativeEndian, &btfHeader{
+	err := binary.Write(&buf, binary.NativeEndian, &btfHeader{
 		Magic:   btfMagic,
 		Version: 1,
 		HdrLen:  uint32(binary.Size(btfHeader{})),
@@ -26,7 +24,7 @@ func FuzzSpec(f *testing.F) {
 			t.Skip("data is too short")
 		}
 
-		spec, err := loadRawSpec(bytes.NewReader(data), internal.NativeEndian, nil)
+		spec, err := loadRawSpec(bytes.NewReader(data), binary.NativeEndian, nil)
 		if err != nil {
 			if spec != nil {
 				t.Fatal("spec is not nil")
@@ -47,7 +45,7 @@ func FuzzSpec(f *testing.F) {
 
 func FuzzExtInfo(f *testing.F) {
 	var buf bytes.Buffer
-	err := binary.Write(&buf, internal.NativeEndian, &btfExtHeader{
+	err := binary.Write(&buf, binary.NativeEndian, &btfExtHeader{
 		Magic:   btfMagic,
 		Version: 1,
 		HdrLen:  uint32(binary.Size(btfExtHeader{})),
@@ -70,7 +68,7 @@ func FuzzExtInfo(f *testing.F) {
 		emptySpec := specFromTypes(t, nil)
 		emptySpec.strings = table
 
-		info, err := loadExtInfos(bytes.NewReader(data), internal.NativeEndian, emptySpec)
+		info, err := loadExtInfos(bytes.NewReader(data), binary.NativeEndian, emptySpec)
 		if err != nil {
 			if info != nil {
 				t.Fatal("info is not nil")

--- a/btf/handle.go
+++ b/btf/handle.go
@@ -2,6 +2,7 @@ package btf
 
 import (
 	"bytes"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"math"
@@ -143,7 +144,7 @@ func (h *Handle) Spec(base *Spec) (*Spec, error) {
 		return nil, fmt.Errorf("missing base types")
 	}
 
-	return loadRawSpec(bytes.NewReader(btfBuffer), internal.NativeEndian, base)
+	return loadRawSpec(bytes.NewReader(btfBuffer), binary.NativeEndian, base)
 }
 
 // Close destroys the handle.

--- a/btf/kernel.go
+++ b/btf/kernel.go
@@ -1,6 +1,7 @@
 package btf
 
 import (
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"os"
@@ -99,7 +100,7 @@ func loadKernelSpec() (_ *Spec, fallback bool, _ error) {
 	if err == nil {
 		defer fh.Close()
 
-		spec, err := loadRawSpec(fh, internal.NativeEndian, nil)
+		spec, err := loadRawSpec(fh, binary.NativeEndian, nil)
 		return spec, false, err
 	}
 
@@ -125,7 +126,7 @@ func loadKernelModuleSpec(module string, base *Spec) (*Spec, error) {
 	}
 	defer fh.Close()
 
-	return loadRawSpec(fh, internal.NativeEndian, base)
+	return loadRawSpec(fh, binary.NativeEndian, base)
 }
 
 // findVMLinux scans multiple well-known paths for vmlinux kernel images.

--- a/btf/marshal.go
+++ b/btf/marshal.go
@@ -27,7 +27,7 @@ type MarshalOptions struct {
 // KernelMarshalOptions will generate BTF suitable for the current kernel.
 func KernelMarshalOptions() *MarshalOptions {
 	return &MarshalOptions{
-		Order:              internal.NativeEndian,
+		Order:              binary.NativeEndian,
 		StripFuncLinkage:   haveFuncLinkage() != nil,
 		ReplaceEnum64:      haveEnum64() != nil,
 		PreventNoTypeFound: true, // All current kernels require this.
@@ -154,7 +154,7 @@ func (b *Builder) Marshal(buf []byte, opts *MarshalOptions) ([]byte, error) {
 	}
 
 	if opts == nil {
-		opts = &MarshalOptions{Order: internal.NativeEndian}
+		opts = &MarshalOptions{Order: binary.NativeEndian}
 	}
 
 	// Reserve space for the BTF header.

--- a/btf/marshal_test.go
+++ b/btf/marshal_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/go-quicktest/qt"
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/cilium/ebpf/internal"
 	"github.com/cilium/ebpf/internal/testutils"
 )
 
@@ -31,11 +30,11 @@ func TestBuilderMarshal(t *testing.T) {
 	qt.Assert(t, qt.IsNil(err))
 
 	cpy := *b
-	buf, err := b.Marshal(nil, &MarshalOptions{Order: internal.NativeEndian})
+	buf, err := b.Marshal(nil, &MarshalOptions{Order: binary.NativeEndian})
 	qt.Assert(t, qt.IsNil(err))
 	qt.Assert(t, qt.CmpEquals(b, &cpy, cmp.AllowUnexported(*b)), qt.Commentf("Marshaling should not change Builder state"))
 
-	have, err := loadRawSpec(bytes.NewReader(buf), internal.NativeEndian, nil)
+	have, err := loadRawSpec(bytes.NewReader(buf), binary.NativeEndian, nil)
 	qt.Assert(t, qt.IsNil(err), qt.Commentf("Couldn't parse BTF"))
 	qt.Assert(t, qt.DeepEquals(have.imm.types, want))
 }
@@ -124,12 +123,12 @@ func TestMarshalEnum64(t *testing.T) {
 	b, err := NewBuilder([]Type{enum})
 	qt.Assert(t, qt.IsNil(err))
 	buf, err := b.Marshal(nil, &MarshalOptions{
-		Order:         internal.NativeEndian,
+		Order:         binary.NativeEndian,
 		ReplaceEnum64: true,
 	})
 	qt.Assert(t, qt.IsNil(err))
 
-	spec, err := loadRawSpec(bytes.NewReader(buf), internal.NativeEndian, nil)
+	spec, err := loadRawSpec(bytes.NewReader(buf), binary.NativeEndian, nil)
 	qt.Assert(t, qt.IsNil(err))
 
 	var have *Union
@@ -191,7 +190,7 @@ func specFromTypes(tb testing.TB, types []Type) *Spec {
 	tb.Helper()
 
 	btf := marshalNativeEndian(tb, types)
-	spec, err := loadRawSpec(bytes.NewReader(btf), internal.NativeEndian, nil)
+	spec, err := loadRawSpec(bytes.NewReader(btf), binary.NativeEndian, nil)
 	qt.Assert(tb, qt.IsNil(err))
 
 	return spec

--- a/collection.go
+++ b/collection.go
@@ -623,7 +623,7 @@ func resolveKconfig(m *MapSpec) error {
 			if err != nil {
 				return fmt.Errorf("getting kernel version: %w", err)
 			}
-			internal.NativeEndian.PutUint32(data[vsi.Offset:], kv.Kernel())
+			binary.NativeEndian.PutUint32(data[vsi.Offset:], kv.Kernel())
 
 		case "LINUX_HAS_SYSCALL_WRAPPER":
 			integer, ok := v.Type.(*btf.Int)

--- a/elf_reader_test.go
+++ b/elf_reader_test.go
@@ -188,7 +188,7 @@ func TestLoadCollectionSpec(t *testing.T) {
 			t.Errorf("MapSpec mismatch (-want +got):\n%s", diff)
 		}
 
-		if have.ByteOrder != internal.NativeEndian {
+		if have.ByteOrder != binary.NativeEndian {
 			return
 		}
 
@@ -379,7 +379,7 @@ func TestLoadInitializedBTFMap(t *testing.T) {
 		}
 
 		t.Run("NewCollection", func(t *testing.T) {
-			if coll.ByteOrder != internal.NativeEndian {
+			if coll.ByteOrder != binary.NativeEndian {
 				t.Skipf("Skipping %s collection", coll.ByteOrder)
 			}
 

--- a/info.go
+++ b/info.go
@@ -3,6 +3,7 @@ package ebpf
 import (
 	"bufio"
 	"bytes"
+	"encoding/binary"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -334,7 +335,7 @@ func (pi *ProgramInfo) Instructions() (asm.Instructions, error) {
 
 	r := bytes.NewReader(pi.insns)
 	var insns asm.Instructions
-	if err := insns.Unmarshal(r, internal.NativeEndian); err != nil {
+	if err := insns.Unmarshal(r, binary.NativeEndian); err != nil {
 		return nil, fmt.Errorf("unmarshaling instructions: %w", err)
 	}
 
@@ -359,7 +360,7 @@ func (pi *ProgramInfo) Instructions() (asm.Instructions, error) {
 
 			lineInfos, err := btf.LoadLineInfos(
 				bytes.NewReader(pi.lineInfos),
-				internal.NativeEndian,
+				binary.NativeEndian,
 				pi.numLineInfos,
 				spec,
 			)
@@ -369,7 +370,7 @@ func (pi *ProgramInfo) Instructions() (asm.Instructions, error) {
 
 			funcInfos, err := btf.LoadFuncInfos(
 				bytes.NewReader(pi.funcInfos),
-				internal.NativeEndian,
+				binary.NativeEndian,
 				pi.numFuncInfos,
 				spec,
 			)

--- a/internal/auxv_test.go
+++ b/internal/auxv_test.go
@@ -66,7 +66,7 @@ func newAuxFileReader(path string, order binary.ByteOrder, uintptrIs32bits bool)
 
 func newDefaultAuxvFileReader() (auxvPairReader, error) {
 	const uintptrIs32bits = unsafe.Sizeof((uintptr)(0)) == 4
-	return newAuxFileReader("/proc/self/auxv", NativeEndian, uintptrIs32bits)
+	return newAuxFileReader("/proc/self/auxv", binary.NativeEndian, uintptrIs32bits)
 }
 
 func TestAuxvBothSourcesEqual(t *testing.T) {

--- a/internal/endian_be.go
+++ b/internal/endian_be.go
@@ -1,9 +1,0 @@
-//go:build armbe || arm64be || mips || mips64 || mips64p32 || ppc64 || s390 || s390x || sparc || sparc64
-
-package internal
-
-import "encoding/binary"
-
-// NativeEndian is set to either binary.BigEndian or binary.LittleEndian,
-// depending on the host's endianness.
-var NativeEndian = binary.BigEndian

--- a/internal/endian_le.go
+++ b/internal/endian_le.go
@@ -1,9 +1,0 @@
-//go:build 386 || amd64 || amd64p32 || arm || arm64 || loong64 || mipsle || mips64le || mips64p32le || ppc64le || riscv64
-
-package internal
-
-import "encoding/binary"
-
-// NativeEndian is set to either binary.BigEndian or binary.LittleEndian,
-// depending on the host's endianness.
-var NativeEndian = binary.LittleEndian

--- a/internal/epoll/poller.go
+++ b/internal/epoll/poller.go
@@ -1,6 +1,7 @@
 package epoll
 
 import (
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"math"
@@ -10,7 +11,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/cilium/ebpf/internal"
 	"github.com/cilium/ebpf/internal/unix"
 )
 
@@ -266,7 +266,7 @@ func (efd *eventFd) close() error {
 
 func (efd *eventFd) add(n uint64) error {
 	var buf [8]byte
-	internal.NativeEndian.PutUint64(buf[:], n)
+	binary.NativeEndian.PutUint64(buf[:], n)
 	_, err := efd.file.Write(buf[:])
 	return err
 }
@@ -274,5 +274,5 @@ func (efd *eventFd) add(n uint64) error {
 func (efd *eventFd) read() (uint64, error) {
 	var buf [8]byte
 	_, err := efd.file.Read(buf[:])
-	return internal.NativeEndian.Uint64(buf[:]), err
+	return binary.NativeEndian.Uint64(buf[:]), err
 }

--- a/internal/kconfig/kconfig.go
+++ b/internal/kconfig/kconfig.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"compress/gzip"
+	"encoding/binary"
 	"fmt"
 	"io"
 	"math"
@@ -181,7 +182,7 @@ func putValueTri(data []byte, typ btf.Type, value string) error {
 			return fmt.Errorf("value %q is not support for libbpf_tristate", value)
 		}
 
-		internal.NativeEndian.PutUint64(data, uint64(tri))
+		binary.NativeEndian.PutUint64(data, uint64(tri))
 	default:
 		return fmt.Errorf("cannot add number value, expected btf.Int or btf.Enum, got: %T", v)
 	}
@@ -277,14 +278,14 @@ func PutInteger(data []byte, integer *btf.Int, n uint64) error {
 		if integer.Encoding == btf.Signed && (int64(n) > math.MaxInt16 || int64(n) < math.MinInt16) {
 			return fmt.Errorf("can't represent %d as a signed integer of size %d", int64(n), integer.Size)
 		}
-		internal.NativeEndian.PutUint16(data, uint16(n))
+		binary.NativeEndian.PutUint16(data, uint16(n))
 	case 4:
 		if integer.Encoding == btf.Signed && (int64(n) > math.MaxInt32 || int64(n) < math.MinInt32) {
 			return fmt.Errorf("can't represent %d as a signed integer of size %d", int64(n), integer.Size)
 		}
-		internal.NativeEndian.PutUint32(data, uint32(n))
+		binary.NativeEndian.PutUint32(data, uint32(n))
 	case 8:
-		internal.NativeEndian.PutUint64(data, uint64(n))
+		binary.NativeEndian.PutUint64(data, uint64(n))
 	default:
 		return fmt.Errorf("size (%d) is not valid, expected: 1, 2, 4 or 8", integer.Size)
 	}

--- a/internal/kconfig/kconfig_test.go
+++ b/internal/kconfig/kconfig_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/cilium/ebpf/btf"
-	"github.com/cilium/ebpf/internal"
 
 	"github.com/go-quicktest/qt"
 )
@@ -402,7 +401,7 @@ func TestPutValue(t *testing.T) {
 		}
 
 		var buf bytes.Buffer
-		err := binary.Write(&buf, internal.NativeEndian, c.expected)
+		err := binary.Write(&buf, binary.NativeEndian, c.expected)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/sysenc/marshal.go
+++ b/internal/sysenc/marshal.go
@@ -37,17 +37,17 @@ func Marshal(data any, size int) (Buffer, error) {
 	case []byte:
 		buf = value
 	case int16:
-		buf = internal.NativeEndian.AppendUint16(make([]byte, 0, 2), uint16(value))
+		buf = binary.NativeEndian.AppendUint16(make([]byte, 0, 2), uint16(value))
 	case uint16:
-		buf = internal.NativeEndian.AppendUint16(make([]byte, 0, 2), value)
+		buf = binary.NativeEndian.AppendUint16(make([]byte, 0, 2), value)
 	case int32:
-		buf = internal.NativeEndian.AppendUint32(make([]byte, 0, 4), uint32(value))
+		buf = binary.NativeEndian.AppendUint32(make([]byte, 0, 4), uint32(value))
 	case uint32:
-		buf = internal.NativeEndian.AppendUint32(make([]byte, 0, 4), value)
+		buf = binary.NativeEndian.AppendUint32(make([]byte, 0, 4), value)
 	case int64:
-		buf = internal.NativeEndian.AppendUint64(make([]byte, 0, 8), uint64(value))
+		buf = binary.NativeEndian.AppendUint64(make([]byte, 0, 8), uint64(value))
 	case uint64:
-		buf = internal.NativeEndian.AppendUint64(make([]byte, 0, 8), value)
+		buf = binary.NativeEndian.AppendUint64(make([]byte, 0, 8), value)
 	default:
 		if buf := unsafeBackingMemory(data); len(buf) == size {
 			return newBuffer(buf), nil
@@ -56,7 +56,7 @@ func Marshal(data any, size int) (Buffer, error) {
 		wr := internal.NewBuffer(make([]byte, 0, size))
 		defer internal.PutBuffer(wr)
 
-		err = binary.Write(wr, internal.NativeEndian, value)
+		err = binary.Write(wr, binary.NativeEndian, value)
 		buf = wr.Bytes()
 	}
 	if err != nil {
@@ -105,7 +105,7 @@ func Unmarshal(data interface{}, buf []byte) error {
 
 		rd.Reset(buf)
 
-		if err := binary.Read(rd, internal.NativeEndian, value); err != nil {
+		if err := binary.Read(rd, binary.NativeEndian, value); err != nil {
 			return err
 		}
 

--- a/internal/sysenc/marshal_test.go
+++ b/internal/sysenc/marshal_test.go
@@ -10,8 +10,6 @@ import (
 
 	"github.com/go-quicktest/qt"
 	"github.com/google/go-cmp/cmp/cmpopts"
-
-	"github.com/cilium/ebpf/internal"
 )
 
 type testcase struct {
@@ -61,7 +59,7 @@ func TestMarshal(t *testing.T) {
 		value := test.new()
 		t.Run(fmt.Sprintf("%T", value), func(t *testing.T) {
 			var want bytes.Buffer
-			if err := binary.Write(&want, internal.NativeEndian, value); err != nil {
+			if err := binary.Write(&want, binary.NativeEndian, value); err != nil {
 				t.Fatal(err)
 			}
 
@@ -148,7 +146,7 @@ func TestUnsafeBackingMemory(t *testing.T) {
 		t.Helper()
 
 		var buf bytes.Buffer
-		qt.Assert(t, qt.IsNil(binary.Write(&buf, internal.NativeEndian, data)))
+		qt.Assert(t, qt.IsNil(binary.Write(&buf, binary.NativeEndian, data)))
 		return buf.Bytes()
 	}
 
@@ -295,7 +293,7 @@ func randomiseValue(tb testing.TB, value any) []byte {
 		buf[i] = byte(i)
 	}
 
-	err := binary.Read(bytes.NewReader(buf), internal.NativeEndian, value)
+	err := binary.Read(bytes.NewReader(buf), binary.NativeEndian, value)
 	qt.Assert(tb, qt.IsNil(err))
 
 	return buf

--- a/linker.go
+++ b/linker.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/cilium/ebpf/asm"
 	"github.com/cilium/ebpf/btf"
-	"github.com/cilium/ebpf/internal"
 )
 
 // handles stores handle objects to avoid gc cleanup
@@ -137,7 +136,7 @@ func applyRelocations(insns asm.Instructions, targets []*btf.Spec, kmodName stri
 	}
 
 	if bo == nil {
-		bo = internal.NativeEndian
+		bo = binary.NativeEndian
 	}
 
 	if len(targets) == 0 {

--- a/map.go
+++ b/map.go
@@ -2,6 +2,7 @@ package ebpf
 
 import (
 	"bytes"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
@@ -1535,7 +1536,7 @@ func marshalMap(m *Map, length int) ([]byte, error) {
 	}
 
 	buf := make([]byte, 4)
-	internal.NativeEndian.PutUint32(buf, m.fd.Uint())
+	binary.NativeEndian.PutUint32(buf, m.fd.Uint())
 	return buf, nil
 }
 

--- a/map_test.go
+++ b/map_test.go
@@ -2,6 +2,7 @@ package ebpf
 
 import (
 	"bytes"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"math"
@@ -82,7 +83,7 @@ func TestMap(t *testing.T) {
 
 	var slice []byte
 	qt.Assert(t, qt.IsNil(m.Lookup(uint32(0), &slice)))
-	qt.Assert(t, qt.DeepEquals(slice, internal.NativeEndian.AppendUint32(nil, 42)))
+	qt.Assert(t, qt.DeepEquals(slice, binary.NativeEndian.AppendUint32(nil, 42)))
 
 	var k uint32
 	if err := m.NextKey(uint32(0), &k); err != nil {
@@ -1881,21 +1882,21 @@ type benchValue struct {
 type customBenchValue benchValue
 
 func (cbv *customBenchValue) UnmarshalBinary(buf []byte) error {
-	cbv.ID = internal.NativeEndian.Uint32(buf)
-	cbv.Val16 = internal.NativeEndian.Uint16(buf[4:])
-	cbv.Val16_2 = internal.NativeEndian.Uint16(buf[6:])
+	cbv.ID = binary.NativeEndian.Uint32(buf)
+	cbv.Val16 = binary.NativeEndian.Uint16(buf[4:])
+	cbv.Val16_2 = binary.NativeEndian.Uint16(buf[6:])
 	copy(cbv.Name[:], buf[8:])
-	cbv.LID = internal.NativeEndian.Uint64(buf[16:])
+	cbv.LID = binary.NativeEndian.Uint64(buf[16:])
 	return nil
 }
 
 func (cbv *customBenchValue) MarshalBinary() ([]byte, error) {
 	buf := make([]byte, 24)
-	internal.NativeEndian.PutUint32(buf, cbv.ID)
-	internal.NativeEndian.PutUint16(buf[4:], cbv.Val16)
-	internal.NativeEndian.PutUint16(buf[6:], cbv.Val16_2)
+	binary.NativeEndian.PutUint32(buf, cbv.ID)
+	binary.NativeEndian.PutUint16(buf[4:], cbv.Val16)
+	binary.NativeEndian.PutUint16(buf[6:], cbv.Val16_2)
 	copy(buf[8:], cbv.Name[:])
-	internal.NativeEndian.PutUint64(buf[16:], cbv.LID)
+	binary.NativeEndian.PutUint64(buf[16:], cbv.LID)
 	return buf, nil
 }
 
@@ -1905,7 +1906,7 @@ type benchKey struct {
 
 func (bk *benchKey) MarshalBinary() ([]byte, error) {
 	buf := make([]byte, 8)
-	internal.NativeEndian.PutUint64(buf, bk.id)
+	binary.NativeEndian.PutUint64(buf, bk.id)
 	return buf, nil
 }
 

--- a/marshalers_test.go
+++ b/marshalers_test.go
@@ -1,6 +1,7 @@
 package ebpf
 
 import (
+	"encoding/binary"
 	"testing"
 
 	"github.com/cilium/ebpf/internal"
@@ -39,7 +40,7 @@ func TestMarshalBatchPerCPUValue(t *testing.T) {
 	expected := make([]byte, sliceLen*internal.Align(elemLength, 8))
 	b := expected
 	for _, elem := range slice {
-		internal.NativeEndian.PutUint32(b, elem)
+		binary.NativeEndian.PutUint32(b, elem)
 		b = b[8:]
 	}
 	buf, err := marshalBatchPerCPUValue(slice, batchLen, elemLength)
@@ -70,7 +71,7 @@ func TestUnmarshalBatchPerCPUValue(t *testing.T) {
 	buf := make([]byte, batchLen*possibleCPU*internal.Align(elemLength, 8))
 	b := buf
 	for _, elem := range expected {
-		internal.NativeEndian.PutUint32(b, elem)
+		binary.NativeEndian.PutUint32(b, elem)
 		b = b[8:]
 	}
 	err := unmarshalBatchPerCPUValue(output, batchLen, elemLength, buf)
@@ -106,7 +107,7 @@ func TestUnmarshalPerCPUValue(t *testing.T) {
 	buf := make([]byte, possibleCPUs*internal.Align(elemLength, 8))
 	b := buf
 	for _, elem := range expected {
-		internal.NativeEndian.PutUint32(b, elem)
+		binary.NativeEndian.PutUint32(b, elem)
 		b = b[8:]
 	}
 	slice := make([]uint32, possibleCPUs)

--- a/perf/reader.go
+++ b/perf/reader.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/cilium/ebpf"
-	"github.com/cilium/ebpf/internal"
 	"github.com/cilium/ebpf/internal/epoll"
 	"github.com/cilium/ebpf/internal/sys"
 	"github.com/cilium/ebpf/internal/unix"
@@ -66,9 +65,9 @@ func readRecord(rd io.Reader, rec *Record, buf []byte, overwritable bool) error 
 	}
 
 	header := perfEventHeader{
-		internal.NativeEndian.Uint32(buf[0:4]),
-		internal.NativeEndian.Uint16(buf[4:6]),
-		internal.NativeEndian.Uint16(buf[6:8]),
+		binary.NativeEndian.Uint32(buf[0:4]),
+		binary.NativeEndian.Uint16(buf[4:6]),
+		binary.NativeEndian.Uint16(buf[6:8]),
 	}
 
 	switch header.Type {
@@ -95,7 +94,7 @@ func readLostRecords(rd io.Reader) (uint64, error) {
 		Lost uint64
 	}
 
-	err := binary.Read(rd, internal.NativeEndian, &lostHeader)
+	err := binary.Read(rd, binary.NativeEndian, &lostHeader)
 	if err != nil {
 		return 0, fmt.Errorf("can't read lost records header: %v", err)
 	}
@@ -117,7 +116,7 @@ func readRawSample(rd io.Reader, buf, sampleBuf []byte) ([]byte, error) {
 	}
 
 	sample := perfEventSample{
-		internal.NativeEndian.Uint32(buf),
+		binary.NativeEndian.Uint32(buf),
 	}
 
 	var data []byte

--- a/perf/reader_test.go
+++ b/perf/reader_test.go
@@ -462,7 +462,7 @@ func TestCreatePerfEvent(t *testing.T) {
 func TestReadRecord(t *testing.T) {
 	var buf bytes.Buffer
 
-	err := binary.Write(&buf, internal.NativeEndian, &perfEventHeader{})
+	err := binary.Write(&buf, binary.NativeEndian, &perfEventHeader{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/prog.go
+++ b/prog.go
@@ -159,7 +159,7 @@ func (ps *ProgramSpec) Copy() *ProgramSpec {
 //
 // Use asm.Instructions.Tag if you need to calculate for non-native endianness.
 func (ps *ProgramSpec) Tag() (string, error) {
-	return ps.Instructions.Tag(internal.NativeEndian)
+	return ps.Instructions.Tag(binary.NativeEndian)
 }
 
 // KernelModule returns the kernel module, if any, the AttachTo function is contained in.
@@ -251,8 +251,8 @@ func newProgramWithOptions(spec *ProgramSpec, opts ProgramOptions) (*Program, er
 		return nil, errors.New("can't load program of unspecified type")
 	}
 
-	if spec.ByteOrder != nil && spec.ByteOrder != internal.NativeEndian {
-		return nil, fmt.Errorf("can't load %s program on %s", spec.ByteOrder, internal.NativeEndian)
+	if spec.ByteOrder != nil && spec.ByteOrder != binary.NativeEndian {
+		return nil, fmt.Errorf("can't load %s program on %s", spec.ByteOrder, binary.NativeEndian)
 	}
 
 	// Kernels before 5.0 (6c4fc209fcf9 "bpf: remove useless version check for prog load")
@@ -360,7 +360,7 @@ func newProgramWithOptions(spec *ProgramSpec, opts ProgramOptions) (*Program, er
 	}
 
 	buf := bytes.NewBuffer(make([]byte, 0, insns.Size()))
-	err = insns.Marshal(buf, internal.NativeEndian)
+	err = insns.Marshal(buf, binary.NativeEndian)
 	if err != nil {
 		return nil, err
 	}
@@ -788,7 +788,7 @@ func (p *Program) run(opts *RunOptions) (uint32, time.Duration, error) {
 	var ctxBytes []byte
 	if opts.Context != nil {
 		ctx := new(bytes.Buffer)
-		if err := binary.Write(ctx, internal.NativeEndian, opts.Context); err != nil {
+		if err := binary.Write(ctx, binary.NativeEndian, opts.Context); err != nil {
 			return 0, 0, fmt.Errorf("cannot serialize context: %v", err)
 		}
 		ctxBytes = ctx.Bytes()
@@ -862,7 +862,7 @@ retry:
 
 	if len(ctxOut) != 0 {
 		b := bytes.NewReader(ctxOut)
-		if err := binary.Read(b, internal.NativeEndian, opts.ContextOut); err != nil {
+		if err := binary.Read(b, binary.NativeEndian, opts.ContextOut); err != nil {
 			return 0, 0, fmt.Errorf("failed to decode ContextOut: %v", err)
 		}
 	}
@@ -888,7 +888,7 @@ func marshalProgram(p *Program, length int) ([]byte, error) {
 	}
 
 	buf := make([]byte, 4)
-	internal.NativeEndian.PutUint32(buf, p.fd.Uint())
+	binary.NativeEndian.PutUint32(buf, p.fd.Uint())
 	return buf, nil
 }
 

--- a/prog_test.go
+++ b/prog_test.go
@@ -701,7 +701,7 @@ func TestProgramRejectIncorrectByteOrder(t *testing.T) {
 	spec := socketFilterSpec.Copy()
 
 	spec.ByteOrder = binary.BigEndian
-	if spec.ByteOrder == internal.NativeEndian {
+	if spec.ByteOrder == binary.NativeEndian {
 		spec.ByteOrder = binary.LittleEndian
 	}
 
@@ -939,7 +939,7 @@ func TestProgramInstructions(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tagXlated, err := insns.Tag(internal.NativeEndian)
+	tagXlated, err := insns.Tag(binary.NativeEndian)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/syscalls.go
+++ b/syscalls.go
@@ -2,6 +2,7 @@ package ebpf
 
 import (
 	"bytes"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"math"
@@ -47,7 +48,7 @@ func invalidBPFObjNameChar(char rune) bool {
 
 func progLoad(insns asm.Instructions, typ ProgramType, license string) (*sys.FD, error) {
 	buf := bytes.NewBuffer(make([]byte, 0, insns.Size()))
-	if err := insns.Marshal(buf, internal.NativeEndian); err != nil {
+	if err := insns.Marshal(buf, binary.NativeEndian); err != nil {
 		return nil, err
 	}
 	bytecode := buf.Bytes()
@@ -311,7 +312,7 @@ var haveProgramExtInfos = internal.NewFeatureTest("program ext_infos", "5.0", fu
 	}
 
 	buf := bytes.NewBuffer(make([]byte, 0, insns.Size()))
-	if err := insns.Marshal(buf, internal.NativeEndian); err != nil {
+	if err := insns.Marshal(buf, binary.NativeEndian); err != nil {
 		return err
 	}
 	bytecode := buf.Bytes()


### PR DESCRIPTION
Since go 1.21 we can use binary.NativeEndian directly. The main benefit is there's no need to maintain own definition of it.

This change is mostly automated using:

	gofmt -w -r 'internal.NativeEndian -> binary.NativeEndian' .
	goimports .