### PR TITLE
program: remove LogSize and VerifierError.Truncated

### DIFF
--- a/internal/errors.go
+++ b/internal/errors.go
@@ -23,7 +23,7 @@ func ErrorWithLog(source string, err error, log []byte) *VerifierError {
 
 	log = bytes.Trim(log, whitespace)
 	if len(log) == 0 {
-		return &VerifierError{source, err, nil, false}
+		return &VerifierError{source, err, nil}
 	}
 
 	logLines := bytes.Split(log, []byte{'\n'})
@@ -34,7 +34,7 @@ func ErrorWithLog(source string, err error, log []byte) *VerifierError {
 		lines = append(lines, string(bytes.TrimRight(line, whitespace)))
 	}
 
-	return &VerifierError{source, err, lines, false}
+	return &VerifierError{source, err, lines}
 }
 
 // VerifierError includes information from the eBPF verifier.
@@ -46,8 +46,6 @@ type VerifierError struct {
 	Cause error
 	// The verifier output split into lines.
 	Log []string
-	// Deprecated: the log is never truncated anymore.
-	Truncated bool
 }
 
 func (le *VerifierError) Unwrap() error {

--- a/prog.go
+++ b/prog.go
@@ -46,10 +46,6 @@ const (
 	outputPad = 256 + 2
 )
 
-// Deprecated: the correct log size is now detected automatically and this
-// constant is unused.
-const DefaultVerifierLogSize = 64 * 1024
-
 // minVerifierLogSize is the default number of bytes allocated for the
 // verifier log.
 const minVerifierLogSize = 64 * 1024
@@ -72,10 +68,6 @@ type ProgramOptions struct {
 	// will always allocate an output buffer, but will result in only a single
 	// attempt at loading the program.
 	LogLevel LogLevel
-
-	// Deprecated: the correct log buffer size is determined automatically
-	// and this field is ignored.
-	LogSize int
 
 	// Disables the verifier log completely, regardless of other options.
 	LogDisabled bool


### PR DESCRIPTION
This reverts commit 218b9f968308e6bfdf1cc4324ee683de66c3ea68.

Remove the deprecated API related to log buffer sizing. We've just cut a release where the fields are deprecated, which gives people time to update.