### PR TITLE
docs: make timo code owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -9,3 +9,5 @@ ringbuf/ @florianl
 btf/ @dylandreimerink
 
 cmd/bpf2go/ @mejedi
+
+docs/ @ti-mo


### PR DESCRIPTION
Add Timo as the codeowner of the docs/ folder, which mostly gets automated PRs from dependabot.