### PR TITLE
ci/goimports: group cilium/ebpf imports after 3rd party imports

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -11,3 +11,9 @@ linters:
     - typecheck
     - unused
     - gofmt
+linters-settings:
+  goimports:
+    # A comma-separated list of prefixes, which, if set, checks import paths
+    # with the given prefixes are grouped after 3rd-party packages.
+    # Default: ""
+    local-prefixes: github.com/cilium/ebpf

--- a/btf/types_test.go
+++ b/btf/types_test.go
@@ -8,9 +8,10 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/cilium/ebpf/internal/testutils"
 	"github.com/go-quicktest/qt"
 	"github.com/google/go-cmp/cmp"
+
+	"github.com/cilium/ebpf/internal/testutils"
 )
 
 func TestSizeof(t *testing.T) {

--- a/cmd/bpf2go/main_test.go
+++ b/cmd/bpf2go/main_test.go
@@ -10,10 +10,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/go-quicktest/qt"
+
 	"github.com/cilium/ebpf/cmd/bpf2go/gen"
 	"github.com/cilium/ebpf/cmd/bpf2go/internal"
 	"github.com/cilium/ebpf/internal/testutils"
-	"github.com/go-quicktest/qt"
 )
 
 const minimalSocketFilter = `__attribute__((section("socket"), used)) int main() { return 0; }`

--- a/internal/epoll/poller_test.go
+++ b/internal/epoll/poller_test.go
@@ -7,8 +7,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cilium/ebpf/internal/unix"
 	"github.com/go-quicktest/qt"
+
+	"github.com/cilium/ebpf/internal/unix"
 )
 
 func TestPoller(t *testing.T) {

--- a/link/uprobe_multi_test.go
+++ b/link/uprobe_multi_test.go
@@ -7,9 +7,10 @@ import (
 	"os/exec"
 	"testing"
 
+	"github.com/go-quicktest/qt"
+
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/internal/testutils"
-	"github.com/go-quicktest/qt"
 )
 
 func TestUprobeMulti(t *testing.T) {

--- a/link/xdp_test.go
+++ b/link/xdp_test.go
@@ -4,9 +4,10 @@ import (
 	"math"
 	"testing"
 
+	"github.com/go-quicktest/qt"
+
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/internal/testutils"
-	"github.com/go-quicktest/qt"
 )
 
 const IfIndexLO = 1


### PR DESCRIPTION
This PR ensures that we uniformly format imports in the future (mostly relevant for tests).