### PR TITLE
elf: support multiple .data sections

### DIFF
--- a/elf_reader.go
+++ b/elf_reader.go
@@ -100,7 +100,7 @@ func LoadCollectionSpecFromReader(rd io.ReaderAt) (*CollectionSpec, error) {
 			sections[idx] = newElfSection(sec, mapSection)
 		case sec.Name == ".maps":
 			sections[idx] = newElfSection(sec, btfMapSection)
-		case sec.Name == ".bss" || sec.Name == ".data" || strings.HasPrefix(sec.Name, ".rodata"):
+		case sec.Name == ".bss" || strings.HasPrefix(sec.Name, ".data") || strings.HasPrefix(sec.Name, ".rodata"):
 			sections[idx] = newElfSection(sec, dataSection)
 		case sec.Type == elf.SHT_REL:
 			// Store relocations under the section index of the target


### PR DESCRIPTION
libbpf supports multiple .rodata/.data sections since commit 5bf62459b185 ("libbpf: Support multiple .rodata.* and .data.* BPF maps").

So does our library.