### PR TITLE
internal: clean up use of golang.org/x/exp

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/go-quicktest/qt v1.101.0
 	github.com/google/go-cmp v0.6.0
 	github.com/jsimonetti/rtnetlink/v2 v2.0.1
-	golang.org/x/exp v0.0.0-20230224173230-c95f2b4c22f2
 	golang.org/x/sys v0.20.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,6 @@ github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsK
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=
 github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
-golang.org/x/exp v0.0.0-20230224173230-c95f2b4c22f2 h1:Jvc7gsqn21cJHCmAWx0LiimpP18LZmUxkT5Mp7EZ1mI=
-golang.org/x/exp v0.0.0-20230224173230-c95f2b4c22f2/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/net v0.23.0 h1:7EYJ93RZ9vYSZAIb2x3lnuvqO5zneoD6IvWjuhfxjTs=
 golang.org/x/net v0.23.0/go.mod h1:JKghWKKOSdJwpW2GEx0Ja7fmaKnMsbu+MWVZTokSYmg=
 golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=

--- a/internal/math.go
+++ b/internal/math.go
@@ -1,13 +1,16 @@
 package internal
 
-import "golang.org/x/exp/constraints"
-
 // Align returns 'n' updated to 'alignment' boundary.
-func Align[I constraints.Integer](n, alignment I) I {
+func Align[I Integer](n, alignment I) I {
 	return (n + alignment - 1) / alignment * alignment
 }
 
 // IsPow returns true if n is a power of two.
-func IsPow[I constraints.Integer](n I) bool {
+func IsPow[I Integer](n I) bool {
 	return n != 0 && (n&(n-1)) == 0
+}
+
+// Integer represents all possible integer types
+type Integer interface {
+	~int | ~int8 | ~int16 | ~int32 | ~int64 | ~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uintptr
 }

--- a/internal/math_test.go
+++ b/internal/math_test.go
@@ -2,7 +2,10 @@ package internal
 
 import (
 	"fmt"
+	"go/importer"
+	"strings"
 	"testing"
+	"unicode"
 )
 
 func TestPow(t *testing.T) {
@@ -25,5 +28,59 @@ func TestPow(t *testing.T) {
 				t.Errorf("unexpected result for n %d; want: %v, got: %v", tt.n, want, got)
 			}
 		})
+	}
+}
+
+var (
+	// integerConstraintTests holds compile test cases exercising the Integer constraint for each of the keyed int types.
+	// testcases for new predeclared integer types should be added in init() functions in build-constrained files for appropriate go versions.
+	integerConstraintTests = map[string]func(){
+		"int":     func() { Align(int(1), int(1)) },
+		"int16":   func() { Align(int16(1), int16(1)) },
+		"int32":   func() { Align(int32(1), int32(1)) },
+		"int64":   func() { Align(int64(1), int64(1)) },
+		"int8":    func() { Align(int8(1), int8(1)) },
+		"uint":    func() { Align(uint(1), uint(1)) },
+		"uint16":  func() { Align(uint16(1), uint16(1)) },
+		"uint32":  func() { Align(uint32(1), uint32(1)) },
+		"uint64":  func() { Align(uint64(1), uint64(1)) },
+		"uint8":   func() { Align(uint8(1), uint8(1)) },
+		"uintptr": func() { Align(uintptr(1), uintptr(1)) },
+	}
+
+	// integerConstraintFalsePositives holds symbols in the reflect package containing 'int' which are not actually integer types.
+	integerConstraintFalsePositives = map[string]struct{}{
+		"interface":     struct{}{},
+		"unsafepointer": struct{}{},
+		"pointer":       struct{}{},
+		"pointerto":     struct{}{},
+	}
+)
+
+func TestIntegerConstraint(t *testing.T) {
+	pkg, err := importer.Default().Import("reflect")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, name := range pkg.Scope().Names() {
+		if !unicode.IsUpper(rune(name[0])) {
+			continue
+		}
+		lowerName := strings.ToLower(name)
+		if !strings.Contains(lowerName, "int") {
+			continue
+		}
+		if _, falsePositive := integerConstraintFalsePositives[lowerName]; falsePositive {
+			continue
+		}
+		integerConstraintTest, ok := integerConstraintTests[lowerName]
+		if !ok {
+			t.Errorf("Unexpected symbol reflect.%s containing 'int' as a substring.", name)
+			t.Errorf("If this is a false positive 'int' substring match, add it to the falsePositives map above.")
+			t.Errorf("If this is a new predeclared integer type, add a test case for it to integerConstraintTests in an init() block in a file for appropriate go versions.")
+			continue
+		}
+		integerConstraintTest()
 	}
 }


### PR DESCRIPTION
Removes last remaining use of golang.org/x/exp and adds test for new integer types

Fixes https://github.com/cilium/ebpf/issues/1095