### PR TITLE
Support wasm architecture

### DIFF
--- a/btf/btf.go
+++ b/btf/btf.go
@@ -632,8 +632,16 @@ func (s *Spec) TypeByName(name string, typ interface{}) error {
 		wanted = typPtr.Elem().Type()
 	}
 
-	if !wanted.AssignableTo(typeInterface) {
-		return fmt.Errorf("%T does not satisfy Type interface", typ)
+	switch wanted {
+	case reflect.TypeOf((**Datasec)(nil)).Elem():
+		// Those types are already assignable to Type. No need to call
+		// AssignableTo. Avoid it when possible to workaround
+		// limitation in tinygo:
+		// https://github.com/tinygo-org/tinygo/issues/4277
+	default:
+		if !wanted.AssignableTo(typeInterface) {
+			return fmt.Errorf("%T does not satisfy Type interface", typ)
+		}
 	}
 
 	types, err := s.AnyTypesByName(name)

--- a/internal/endian_le.go
+++ b/internal/endian_le.go
@@ -1,4 +1,4 @@
-//go:build 386 || amd64 || amd64p32 || arm || arm64 || loong64 || mipsle || mips64le || mips64p32le || ppc64le || riscv64
+//go:build 386 || amd64 || amd64p32 || arm || arm64 || loong64 || mipsle || mips64le || mips64p32le || ppc64le || riscv64 || wasm
 
 package internal
 

--- a/internal/io.go
+++ b/internal/io.go
@@ -28,7 +28,7 @@ func NewBufferedSectionReader(ra io.ReaderAt, off, n int64) *bufio.Reader {
 	// of 4096. Allow arches with larger pages to allocate more, but don't
 	// allocate a fixed 4k buffer if we only need to read a small segment.
 	buf := n
-	if ps := int64(os.Getpagesize()); n > ps {
+	if ps := int64(Getpagesize()); n > ps {
 		buf = ps
 	}
 

--- a/internal/page_others.go
+++ b/internal/page_others.go
@@ -1,0 +1,9 @@
+//go:build !wasm
+
+package internal
+
+import "os"
+
+func Getpagesize() int {
+	return os.Getpagesize()
+}

--- a/internal/page_wasm.go
+++ b/internal/page_wasm.go
@@ -1,0 +1,8 @@
+//go:build wasm
+
+package internal
+
+func Getpagesize() int {
+	// A WebAssembly page has a constant size of 65,536 bytes, i.e., 64KiB
+	return 64 * 1024
+}

--- a/map.go
+++ b/map.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"math/rand"
-	"os"
 	"path/filepath"
 	"reflect"
 	"slices"
@@ -507,7 +506,7 @@ func handleMapCreateError(attr sys.MapCreateAttr, spec *MapSpec, err error) erro
 	// BPF_MAP_TYPE_RINGBUF's max_entries must be a power-of-2 multiple of kernel's page size.
 	if errors.Is(err, unix.EINVAL) &&
 		(attr.MapType == sys.BPF_MAP_TYPE_RINGBUF || attr.MapType == sys.BPF_MAP_TYPE_USER_RINGBUF) {
-		pageSize := uint32(os.Getpagesize())
+		pageSize := uint32(internal.Getpagesize())
 		maxEntries := attr.MaxEntries
 		if maxEntries%pageSize != 0 || !internal.IsPow(maxEntries) {
 			return fmt.Errorf("map create: %w (ring map size %d not a multiple of page size %d)", err, maxEntries, pageSize)
@@ -950,7 +949,7 @@ func (m *Map) nextKey(key interface{}, nextKeyOut sys.Pointer) error {
 }
 
 var mmapProtectedPage = sync.OnceValues(func() ([]byte, error) {
-	return unix.Mmap(-1, 0, os.Getpagesize(), unix.PROT_NONE, unix.MAP_ANON|unix.MAP_SHARED)
+	return unix.Mmap(-1, 0, internal.Getpagesize(), unix.PROT_NONE, unix.MAP_ANON|unix.MAP_SHARED)
 })
 
 // guessNonExistentKey attempts to perform a map lookup that returns ENOENT.

--- a/syscalls.go
+++ b/syscalls.go
@@ -27,7 +27,14 @@ var (
 // invalidBPFObjNameChar returns true if char may not appear in
 // a BPF object name.
 func invalidBPFObjNameChar(char rune) bool {
-	dotAllowed := objNameAllowsDot() == nil
+	var dotAllowed bool
+	if runtime.GOOS == "js" {
+		// In Javascript environments, BPF objects are not going to be
+		// loaded to a kernel, so we can use dots without testing.
+		dotAllowed = true
+	} else {
+		dotAllowed = objNameAllowsDot() == nil
+	}
 
 	switch {
 	case char >= 'A' && char <= 'Z':


### PR DESCRIPTION
cilium/ebpf currently does not compile to wasm with tinygo. This patch makes it compile.

I am working on a website where users can submit ebpf binaries (either in ELF format or as an Inspektor Gadget export) and the website will parse the ebpf binary client-side with wasm. The wasm code is written in Go, using cilium/ebpf and is compiled with tinygo.

My wasm code uses ebpf.LoadCollectionSpecFromReader() to display information about the ebpf binary. But it will not call ebpf.NewCollection() because the wasm/javascript environment in the browser cannot interact with the Linux kernel.

---

The website PoC looks like this:
- https://github.com/alban/bpfanalyser
- https://alban.github.io/bpfanalyser/

![image](https://github.com/user-attachments/assets/7b52f1bf-75cd-469e-ad85-5c538f7fc893)

Since cilium/ebpf is running in the browser, I can use Chrome DevTools to profile the performance:

![Screenshot-Chrome-DevTools-cilium-ebpf](https://github.com/user-attachments/assets/4a51da00-eefc-41c7-bc7d-0b1dde75f753)
