### PR TITLE
internal: remove dependency on x/exp/constraints

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/go-quicktest/qt v1.101.0
 	github.com/google/go-cmp v0.6.0
 	github.com/jsimonetti/rtnetlink/v2 v2.0.1
-	golang.org/x/exp v0.0.0-20230224173230-c95f2b4c22f2
 	golang.org/x/sys v0.20.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,6 @@ github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsK
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=
 github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
-golang.org/x/exp v0.0.0-20230224173230-c95f2b4c22f2 h1:Jvc7gsqn21cJHCmAWx0LiimpP18LZmUxkT5Mp7EZ1mI=
-golang.org/x/exp v0.0.0-20230224173230-c95f2b4c22f2/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/net v0.23.0 h1:7EYJ93RZ9vYSZAIb2x3lnuvqO5zneoD6IvWjuhfxjTs=
 golang.org/x/net v0.23.0/go.mod h1:JKghWKKOSdJwpW2GEx0Ja7fmaKnMsbu+MWVZTokSYmg=
 golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=

--- a/internal/math.go
+++ b/internal/math.go
@@ -1,13 +1,22 @@
 package internal
 
-import "golang.org/x/exp/constraints"
-
 // Align returns 'n' updated to 'alignment' boundary.
-func Align[I constraints.Integer](n, alignment I) I {
+func Align[I Integer](n, alignment I) I {
 	return (n + alignment - 1) / alignment * alignment
 }
 
 // IsPow returns true if n is a power of two.
-func IsPow[I constraints.Integer](n I) bool {
+func IsPow[I Integer](n I) bool {
 	return n != 0 && (n&(n-1)) == 0
 }
+
+// Integer represents all possible integer types.
+// Remove when x/exp/constraints is moved to the standard library.
+type Integer interface {
+	~int | ~int8 | ~int16 | ~int32 | ~int64 | ~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uintptr
+}
+
+// List of integer types known by the Go compiler. Used by TestIntegerConstraint
+// to warn if a new integer type is introduced. Remove when x/exp/constraints
+// is moved to the standard library.
+var integers = []string{"int", "int8", "int16", "int32", "int64", "uint", "uint8", "uint16", "uint32", "uint64", "uintptr"}

--- a/internal/math_test.go
+++ b/internal/math_test.go
@@ -2,6 +2,10 @@ package internal
 
 import (
 	"fmt"
+	"go/importer"
+	"regexp"
+	"slices"
+	"strings"
 	"testing"
 )
 
@@ -25,5 +29,25 @@ func TestPow(t *testing.T) {
 				t.Errorf("unexpected result for n %d; want: %v, got: %v", tt.n, want, got)
 			}
 		})
+	}
+}
+
+func TestIntegerConstraint(t *testing.T) {
+	rgx := regexp.MustCompile(`^(u)?int([0-9]*|ptr)?$`)
+
+	pkg, err := importer.Default().Import("reflect")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, name := range pkg.Scope().Names() {
+		name = strings.ToLower(name)
+		if !rgx.MatchString(name) {
+			continue
+		}
+
+		if !slices.Contains(integers, name) {
+			t.Errorf("Go type %s is not in the list of known integer types", name)
+		}
 	}
 }


### PR DESCRIPTION
Temporarily copy the definition of the Integer constraint until the constraints package is moved out of x/exp into the stdlib.

Add a test that makes sure Integer contains all of Go's integer types.

Supersedes https://github.com/cilium/ebpf/pull/1551.