### PR TITLE
map: remove MapSpec.Freeze field

### DIFF
--- a/elf_reader.go
+++ b/elf_reader.go
@@ -200,6 +200,10 @@ func loadVersion(sec *elf.Section, bo binary.ByteOrder) (uint32, error) {
 	return version, nil
 }
 
+func isConstantDataSection(name string) bool {
+	return strings.HasPrefix(name, ".rodata")
+}
+
 type elfSectionKind int
 
 const (
@@ -1137,9 +1141,8 @@ func (ec *elfCode) loadDataSections() error {
 			}
 		}
 
-		if strings.HasPrefix(sec.Name, ".rodata") {
+		if isConstantDataSection(sec.Name) {
 			mapSpec.Flags = sys.BPF_F_RDONLY_PROG
-			mapSpec.Freeze = true
 		}
 
 		ec.maps[sec.Name] = mapSpec
@@ -1175,7 +1178,6 @@ func (ec *elfCode) loadKconfigSection() error {
 		ValueSize:  ds.Size,
 		MaxEntries: 1,
 		Flags:      sys.BPF_F_RDONLY_PROG,
-		Freeze:     true,
 		Key:        &btf.Int{Size: 4},
 		Value:      ds,
 	}

--- a/elf_reader_test.go
+++ b/elf_reader_test.go
@@ -491,7 +491,7 @@ func TestStringSection(t *testing.T) {
 		t.Fatal("Unable to find map '.rodata.str1.1' in loaded collection")
 	}
 
-	if !strMap.Freeze {
+	if !strMap.readOnly() {
 		t.Fatal("Read only data maps should be frozen")
 	}
 

--- a/map_test.go
+++ b/map_test.go
@@ -104,8 +104,7 @@ func TestMapSpecCopy(t *testing.T) {
 		PinByName,
 		1,
 		[]MapKV{{1, 2}}, // Can't copy Contents, use value types
-		true,
-		nil, // InnerMap
+		nil,             // InnerMap
 		bytes.NewReader(nil),
 		&btf.Int{},
 		&btf.Int{},


### PR DESCRIPTION
This has been an ambiguous flag since its inception. Internally, we would allow maps to be created with BPF_F_RDONLY_PROG, but not freeze them afterwards. Conversely, we would allow MapSpecs with Freeze set to 'true', but without the rdonly map flag set.

The latter case has caused subtle bugs in the past, since BPF_MAP_FREEZE only blocks further modifications from user space, but doesn't actually mark the map as readonly for the verifier. This will prevent code pruning and other optimizations from taking place.

This commit removes the Freeze field in favor of the map flag and adds a helper to keep existing call sites simple. Sourcegraph code search yields no references to this field in open-source code.