### PR TITLE
map tests queues and refactor

### DIFF
--- a/map_test.go
+++ b/map_test.go
@@ -838,6 +838,14 @@ func TestMapQueue(t *testing.T) {
 	}
 
 	var v uint32
+	if err := m.Lookup(nil, &v); err != nil {
+		t.Fatal("Lookup (Peek) on Queue:", err)
+	}
+	if v != 42 {
+		t.Error("Want value 42, got", v)
+	}
+	v = 0
+
 	if err := m.LookupAndDelete(nil, &v); err != nil {
 		t.Fatal("Can't lookup and delete element:", err)
 	}
@@ -855,6 +863,10 @@ func TestMapQueue(t *testing.T) {
 
 	if err := m.LookupAndDelete(nil, &v); !errors.Is(err, ErrKeyNotExist) {
 		t.Fatal("Lookup and delete on empty Queue:", err)
+	}
+
+	if err := m.Lookup(nil, &v); !errors.Is(err, ErrKeyNotExist) {
+		t.Fatal("Lookup (Peek) on empty Queue:", err)
 	}
 }
 

--- a/map_test.go
+++ b/map_test.go
@@ -1123,6 +1123,28 @@ func TestMapIterate(t *testing.T) {
 	qt.Assert(t, qt.DeepEquals(keys, data))
 }
 
+func TestIterateWrongMap(t *testing.T) {
+	testutils.SkipOnOldKernel(t, "4.20", "map type queue")
+
+	m, err := NewMap(&MapSpec{
+		Type:       Queue,
+		ValueSize:  4,
+		MaxEntries: 2,
+		Contents: []MapKV{
+			{nil, uint32(0)},
+			{nil, uint32(1)},
+		},
+	})
+	qt.Assert(t, qt.IsNil(err))
+	defer m.Close()
+
+	var value uint32
+	entries := m.Iterate()
+
+	qt.Assert(t, qt.IsFalse(entries.Next(nil, &value)))
+	qt.Assert(t, qt.IsNotNil(entries.Err()))
+}
+
 func TestMapIteratorAllocations(t *testing.T) {
 	arr, err := NewMap(&MapSpec{
 		Type:       Array,


### PR DESCRIPTION
This PR introduces a new test for `MapIterator` as well as small refactoring to some other tests.
With this, the aim is primarily to ensure that `MapIterator` fails when called on keyless maps such as queues/stacks: this is because the current implementation relies on a key (nextKey) lookup from the map, which is then used to retrieve its respective value.
Commit messages should contain each the explanation, feel free to reach me for further q&a :smiley: 