### PR TITLE
feat(gen): Make Identifier function configurable

### DIFF
--- a/cmd/bpf2go/gen/output_test.go
+++ b/cmd/bpf2go/gen/output_test.go
@@ -3,6 +3,7 @@ package gen
 import (
 	"bytes"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/go-quicktest/qt"
@@ -81,3 +82,18 @@ func TestPackageImport(t *testing.T) {
 var typesEqualComparer = cmp.Comparer(func(a, b btf.Type) bool {
 	return a == b
 })
+
+func TestCustomIdentifier(t *testing.T) {
+	var buf bytes.Buffer
+	args := GenerateArgs{
+		Package:    "foo",
+		Stem:       "bar",
+		ObjectFile: "frob.o",
+		Output:     &buf,
+		Programs:   []string{"do_thing"},
+		Identifier: strings.ToUpper,
+	}
+	err := Generate(args)
+	qt.Assert(t, qt.IsNil(err))
+	qt.Assert(t, qt.StringContains(buf.String(), "DO_THING"))
+}


### PR DESCRIPTION
The standard Identifier function used by the generator results in very unidiomatic go identifier names when used with my ebpf object. With this change, the Identifier function becomes configurable, allowing me to pass in something that produces better outputs in my context. If no function is passed in, we keep using the default, this makes the change entirely backwards compatible.
Furthermore, a test has been added to ensure the configuration is correctly passed through.