### PR TITLE
elf_reader: don't use BPF_F_RDONLY_PROG flag to trigger map freezing

### DIFF
--- a/elf_reader.go
+++ b/elf_reader.go
@@ -210,6 +210,10 @@ func isConstantDataSection(name string) bool {
 	return strings.HasPrefix(name, ".rodata")
 }
 
+func isKconfigSection(name string) bool {
+	return name == ".kconfig"
+}
+
 type elfSectionKind int
 
 const (
@@ -1119,6 +1123,10 @@ func (ec *elfCode) loadDataSections() error {
 			MaxEntries: 1,
 		}
 
+		if isConstantDataSection(sec.Name) {
+			mapSpec.Flags = sys.BPF_F_RDONLY_PROG
+		}
+
 		switch sec.Type {
 		// Only open the section if we know there's actual data to be read.
 		case elf.SHT_PROGBITS:
@@ -1213,10 +1221,6 @@ func (ec *elfCode) loadDataSections() error {
 					ev.t = v.Type
 				}
 			}
-		}
-
-		if isConstantDataSection(sec.Name) {
-			mapSpec.Flags = sys.BPF_F_RDONLY_PROG
 		}
 
 		ec.maps[sec.Name] = mapSpec

--- a/map.go
+++ b/map.go
@@ -1405,7 +1405,7 @@ func (m *Map) finalize(spec *MapSpec) error {
 		}
 	}
 
-	if spec.readOnly() {
+	if isConstantDataSection(spec.Name) || isKconfigSection(spec.Name) {
 		if err := m.Freeze(); err != nil {
 			return fmt.Errorf("freezing map: %w", err)
 		}


### PR DESCRIPTION
In https://github.com/cilium/ebpf/pull/1558#pullrequestreview-2302565861, it was pointed out that BPF_F_RDONLY_PROG only implies a map being read-only from bpf space, not user space. Using the flag to trigger freezing a map from user space doesn't make much sense.

Change this to a name-based trigger, more closely resembling the libbpf behaviour.