### PR TITLE
link: uprobe multi: add context to EINVAL, don't overflow pid_t in tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,7 +192,8 @@ jobs:
     strategy:
       matrix:
         tag:
-          - "mainline"
+          # Re-enable when https://github.com/lmb/vimto/issues/19 is fixed.
+          # - "mainline"
           - "stable"
           - "6.6"
           - "6.1"

--- a/internal/tracefs/kprobe.go
+++ b/internal/tracefs/kprobe.go
@@ -214,7 +214,10 @@ func NewEvent(args ProbeArgs) (*Event, error) {
 	if err == nil {
 		return nil, fmt.Errorf("trace event %s/%s: %w", args.Group, eventName, os.ErrExist)
 	}
-	if err != nil && !errors.Is(err, os.ErrNotExist) {
+	if errors.Is(err, unix.EINVAL) {
+		return nil, fmt.Errorf("trace event %s/%s: %w (unknown symbol?)", args.Group, eventName, err)
+	}
+	if !errors.Is(err, os.ErrNotExist) {
 		return nil, fmt.Errorf("checking trace event %s/%s: %w", args.Group, eventName, err)
 	}
 

--- a/link/kprobe.go
+++ b/link/kprobe.go
@@ -60,6 +60,9 @@ func (ko *KprobeOptions) cookie() uint64 {
 // platform's syscall prefix (e.g. __x64_) to support attaching to syscalls
 // in a portable fashion.
 //
+// On kernels 6.11 and later, setting a kprobe on a nonexistent symbol using
+// tracefs incorrectly returns [unix.EINVAL] instead of [os.ErrNotExist].
+//
 // The returned Link may implement [PerfEvent].
 func Kprobe(symbol string, prog *ebpf.Program, opts *KprobeOptions) (Link, error) {
 	k, err := kprobe(symbol, prog, opts, false)
@@ -91,7 +94,7 @@ func Kprobe(symbol string, prog *ebpf.Program, opts *KprobeOptions) (Link, error
 // in a portable fashion.
 //
 // On kernels 5.10 and earlier, setting a kretprobe on a nonexistent symbol
-// incorrectly returns unix.EINVAL instead of os.ErrNotExist.
+// incorrectly returns [unix.EINVAL] instead of [os.ErrNotExist].
 //
 // The returned Link may implement [PerfEvent].
 func Kretprobe(symbol string, prog *ebpf.Program, opts *KprobeOptions) (Link, error) {

--- a/link/kprobe_test.go
+++ b/link/kprobe_test.go
@@ -224,15 +224,15 @@ func TestKprobeTraceFS(t *testing.T) {
 
 	// Write a k(ret)probe event for a non-existing symbol.
 	_, err = tracefs.NewEvent(args)
-	qt.Assert(t, qt.ErrorIs(err, os.ErrNotExist), qt.Commentf("got error: %s", err))
+	// A kernel bug was introduced in 9d8616034f16 that causes EINVAL to be returned
+	// instead of ENOENT when trying to attach kprobes to non-existing symbols.
+	qt.Assert(t, qt.IsTrue(errors.Is(err, os.ErrNotExist) || errors.Is(err, unix.EINVAL)), qt.Commentf("got error: %s", err))
 
 	// A kernel bug was fixed in 97c753e62e6c where EINVAL was returned instead
 	// of ENOENT, but only for kretprobes.
 	args.Ret = true
 	_, err = tracefs.NewEvent(args)
-	if !(errors.Is(err, os.ErrNotExist) || errors.Is(err, unix.EINVAL)) {
-		t.Fatal(err)
-	}
+	qt.Assert(t, qt.IsTrue(errors.Is(err, os.ErrNotExist) || errors.Is(err, unix.EINVAL)), qt.Commentf("got error: %s", err))
 }
 
 func BenchmarkKprobeCreateTraceFS(b *testing.B) {

--- a/link/uprobe_multi.go
+++ b/link/uprobe_multi.go
@@ -99,8 +99,11 @@ func (ex *Executable) uprobeMulti(symbols []string, prog *ebpf.Program, opts *Up
 	if errors.Is(err, unix.ESRCH) {
 		return nil, fmt.Errorf("%w (specified pid not found?)", os.ErrNotExist)
 	}
+	// Since Linux commit 46ba0e49b642 ("bpf: fix multi-uprobe PID filtering
+	// logic"), if the provided pid overflows MaxInt32 (turning it negative), the
+	// kernel will return EINVAL instead of ESRCH.
 	if errors.Is(err, unix.EINVAL) {
-		return nil, fmt.Errorf("%w (missing symbol or prog's AttachType not AttachTraceUprobeMulti?)", err)
+		return nil, fmt.Errorf("%w (invalid pid, missing symbol or prog's AttachType not AttachTraceUprobeMulti?)", err)
 	}
 
 	if err != nil {

--- a/link/uprobe_multi_test.go
+++ b/link/uprobe_multi_test.go
@@ -97,12 +97,13 @@ func TestUprobeMultiInput(t *testing.T) {
 
 	// PID not found
 	_, err = bashEx.UprobeMulti(bashSyms, prog, &UprobeMultiOptions{
-		PID: math.MaxUint32,
+		// pid_t is int32, overflowing it will return EINVAL.
+		PID: math.MaxInt32,
 	})
 	qt.Assert(t, qt.ErrorIs(err, os.ErrNotExist))
 
 	_, err = bashEx.UretprobeMulti(bashSyms, prog, &UprobeMultiOptions{
-		PID: math.MaxUint32,
+		PID: math.MaxInt32,
 	})
 	qt.Assert(t, qt.ErrorIs(err, os.ErrNotExist))
 }


### PR DESCRIPTION
As documented in the code, Linux commit torvalds/linux@46ba0e49b642 added an extra check on the pid field, which it interprets as a signed pid_t value, returning EINVAL if it's negative.

Take care not to overflow the value in tests so we can keep receiving ESRCH.