### PR TITLE
map,prog,link: verify object type in LoadPinned*()

### DIFF
--- a/internal/cmd/gentypes/main.go
+++ b/internal/cmd/gentypes/main.go
@@ -140,6 +140,7 @@ import (
 		cType  string
 	}{
 		{"Cmd", "bpf_cmd"},
+		{"ObjType", "bpf_type"},
 		{"MapType", "bpf_map_type"},
 		{"ProgType", "bpf_prog_type"},
 		{"AttachType", "bpf_attach_type"},

--- a/internal/sys/fd_test.go
+++ b/internal/sys/fd_test.go
@@ -1,6 +1,7 @@
 package sys
 
 import (
+	"errors"
 	"os"
 	"syscall"
 	"testing"
@@ -30,7 +31,7 @@ func reserveFdZero() {
 		panic(err)
 	}
 	if fd != 0 {
-		panic(err)
+		panic(errors.New("zero fd already taken"))
 	}
 }
 

--- a/internal/sys/types.go
+++ b/internal/sys/types.go
@@ -566,6 +566,15 @@ const (
 	BPF_MAP_TYPE_CGRP_STORAGE                     MapType = 32
 )
 
+type ObjType uint32
+
+const (
+	BPF_TYPE_UNSPEC ObjType = 0
+	BPF_TYPE_PROG   ObjType = 1
+	BPF_TYPE_MAP    ObjType = 2
+	BPF_TYPE_LINK   ObjType = 3
+)
+
 type PerfEventType uint32
 
 const (

--- a/map_test.go
+++ b/map_test.go
@@ -1894,6 +1894,38 @@ func TestPerfEventArrayCompatible(t *testing.T) {
 	qt.Assert(t, qt.IsNotNil(ms.Compatible(m)))
 }
 
+func TestLoadWrongPin(t *testing.T) {
+	p := mustSocketFilter(t)
+	m := newHash(t)
+	tmp := testutils.TempBPFFS(t)
+
+	ppath := filepath.Join(tmp, "prog")
+	mpath := filepath.Join(tmp, "map")
+
+	qt.Assert(t, qt.IsNil(m.Pin(mpath)))
+	qt.Assert(t, qt.IsNil(p.Pin(ppath)))
+
+	t.Run("Program", func(t *testing.T) {
+		lp, err := LoadPinnedProgram(ppath, nil)
+		testutils.SkipIfNotSupported(t, err)
+		qt.Assert(t, qt.IsNil(err))
+		qt.Assert(t, qt.IsNil(lp.Close()))
+
+		_, err = LoadPinnedProgram(mpath, nil)
+		qt.Assert(t, qt.IsNotNil(err))
+	})
+
+	t.Run("Map", func(t *testing.T) {
+		lm, err := LoadPinnedMap(mpath, nil)
+		testutils.SkipIfNotSupported(t, err)
+		qt.Assert(t, qt.IsNil(err))
+		qt.Assert(t, qt.IsNil(lm.Close()))
+
+		_, err = LoadPinnedMap(ppath, nil)
+		qt.Assert(t, qt.IsNotNil(err))
+	})
+}
+
 type benchValue struct {
 	ID      uint32
 	Val16   uint16


### PR DESCRIPTION
Fixes https://github.com/cilium/ebpf/issues/1566.

Before this patch, ebpf.LoadPinnedMap and ebpf.LoadPinnedProg both succeed when used with the wrong object type. Meaning that you can open a prog using epbf.LoadPinnedMap or vice-versa and you'll get garbage data in the object's info.

To my knowledge, there are two ways of knowing from an opened FD which object type it is:
* checking for specific fields in /proc/self/fdinfo/<fd>;
* running readlink(2) on /proc/self/fd/<fd> and check for anon_inode:bpf-prog or anon_inode:bpf-map.

This is a breaking change for users relying on LoadPinned<object> to open any object: I've been using that behavior to scan BPF filesystem.

Note to the reviewer: I've been writing this fairly quickly, I'm sure I'm breaking all your conventions style-wise and I was very hesitant to return an error on failing to run `readlink`. Please feel free to comment on anything, I just wanted to start with something.