### PR TITLE
GHA: re-enable mainline kernel in testing matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
 
   test-on-prev-go:
     name: Run tests on previous stable Go
-    runs-on: ubuntu-latest-4cores-16gb
+    runs-on: ubuntu-latest
     needs: build-and-lint
     timeout-minutes: 15
     env:
@@ -186,7 +186,7 @@ jobs:
 
   vm-test:
     name: Run tests
-    runs-on: ubuntu-latest-4cores-16gb
+    runs-on: ubuntu-latest
     needs: build-and-lint
     timeout-minutes: 15
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,8 +192,7 @@ jobs:
     strategy:
       matrix:
         tag:
-          # Re-enable when https://github.com/lmb/vimto/issues/19 is fixed.
-          # - "mainline"
+          - "mainline"
           - "stable"
           - "6.6"
           - "6.1"


### PR DESCRIPTION
Switch to ubuntu-latest runners, these now support nested virt. Also added a test for disabling verifier logs.