### PR TITLE
kallsyms: optimise parsing

### DIFF
--- a/internal/kallsyms/kallsyms.go
+++ b/internal/kallsyms/kallsyms.go
@@ -60,7 +60,12 @@ func loadKernelModuleMapping(f io.Reader) (map[string]string, error) {
 	mods := make(map[string]string)
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
-		fields := bytes.Fields(scanner.Bytes())
+		line := scanner.Bytes()
+		// bytes.Fields is expensive, so filter for '[' first
+		if !bytes.ContainsRune(line, '[') {
+			continue
+		}
+		fields := bytes.Fields(line)
 		if len(fields) < 4 {
 			continue
 		}

--- a/internal/kallsyms/kallsyms_test.go
+++ b/internal/kallsyms/kallsyms_test.go
@@ -2,6 +2,7 @@ package kallsyms
 
 import (
 	"bytes"
+	"runtime"
 	"testing"
 
 	"github.com/go-quicktest/qt"
@@ -61,4 +62,16 @@ func TestLoadSymbolAddresses(t *testing.T) {
 	}
 	err := loadSymbolAddresses(b, ksyms)
 	qt.Assert(t, qt.ErrorIs(err, errKsymIsAmbiguous))
+}
+
+func BenchmarkKernelModuleMemory(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		FlushKernelModuleCache()
+		runtime.GC()
+
+		b.StartTimer()
+		KernelModule("foo")
+	}
 }


### PR DESCRIPTION
In tests with pprof in Inspektor Gadget, I see allocations getting reduced from 34MB to 12MB.

I also added a standalone benchmark.

tl;dr: 12% faster, 42% less allocations in bytes, 48% less allocations

```
$ go test -run=BenchmarkKernelModuleMemory -bench=. ./internal/kallsyms/... -count 10 | tee main.bench
$ go test -run=BenchmarkKernelModuleMemory -bench=. ./internal/kallsyms/... -count 10 | tee patched.bench
$ benchstat main.bench patched.bench
goos: linux
goarch: amd64
pkg: github.com/cilium/ebpf/internal/kallsyms
cpu: Intel(R) Core(TM) i7-6500U CPU @ 2.50GHz
                     │ main.bench  │            patched.bench            │
                     │   sec/op    │   sec/op     vs base                │
KernelModuleMemory-4   299.9m ± 3%   262.1m ± 6%  -12.59% (p=0.000 n=10)

                     │  main.bench  │            patched.bench             │
                     │     B/op     │     B/op      vs base                │
KernelModuleMemory-4   37.70Mi ± 0%   21.67Mi ± 0%  -42.53% (p=0.000 n=10)

                     │ main.bench  │            patched.bench            │
                     │  allocs/op  │  allocs/op   vs base                │
KernelModuleMemory-4   432.1k ± 0%   221.9k ± 0%  -48.64% (p=0.000 n=10)
```

xref https://github.com/inspektor-gadget/inspektor-gadget/pull/3571#issuecomment-2410532116

cc @burak-ok