### PR TITLE
prog: don't search for kmod when not needed

### DIFF
--- a/prog.go
+++ b/prog.go
@@ -276,9 +276,15 @@ func newProgramWithOptions(spec *ProgramSpec, opts ProgramOptions) (*Program, er
 	insns := make(asm.Instructions, len(spec.Instructions))
 	copy(insns, spec.Instructions)
 
-	kmodName, err := spec.KernelModule()
-	if err != nil {
-		return nil, fmt.Errorf("kernel module search: %w", err)
+	var kmodName string
+	var err error
+
+	// applyRelocations() only uses kmodName if len(targets) == 0
+	if opts.KernelTypes == nil || len(opts.KernelModuleTypes) != 0 {
+		kmodName, err = spec.KernelModule()
+		if err != nil {
+			return nil, fmt.Errorf("kernel module search: %w", err)
+		}
 	}
 
 	var targets []*btf.Spec


### PR DESCRIPTION
When using btfgen (to provide BTF information for kernels without BTF support), spec.LoadAndAssign() is called with opts.KernelTypes but without opts.KernelModuleTypes.

In this scenario, newProgramWithOptions() never makes use of kmod. Therefore we don't need to read /proc/kallsyms to find out the kmod implementing the symbol.

This patch removes the call to spec.KernelModule() in that case. This saves us about 10MB of memory allocation.

Related optimization: #1584

cc @burak-ok