### PR TITLE
 kallsyms: introduce 'reader', an efficient /proc/kallsyms line parser

### DIFF
--- a/elf_reader.go
+++ b/elf_reader.go
@@ -1313,7 +1313,7 @@ func (ec *elfCode) loadKsymsSection() error {
 		}
 	}
 
-	if err := kallsyms.LoadSymbolAddresses(ec.ksyms); err != nil {
+	if err := kallsyms.AssignAddresses(ec.ksyms); err != nil {
 		return fmt.Errorf("error while loading ksym addresses: %w", err)
 	}
 

--- a/elf_reader_test.go
+++ b/elf_reader_test.go
@@ -798,7 +798,7 @@ func TestKsym(t *testing.T) {
 		"tty_fops":        0,
 	}
 
-	qt.Assert(t, qt.IsNil(kallsyms.LoadSymbolAddresses(ksyms)))
+	qt.Assert(t, qt.IsNil(kallsyms.AssignAddresses(ksyms)))
 
 	var value uint64
 	qt.Assert(t, qt.IsNil(obj.ArrayMap.Lookup(uint32(0), &value)))

--- a/internal/kallsyms/reader.go
+++ b/internal/kallsyms/reader.go
@@ -1,0 +1,118 @@
+package kallsyms
+
+import (
+	"bufio"
+	"io"
+	"unicode"
+	"unicode/utf8"
+)
+
+// reader is a line and word-oriented reader built for reading /proc/kallsyms.
+// It takes an io.Reader and iterates its contents line by line, then word by
+// word.
+//
+// It's designed to allow partial reading of lines without paying the cost of
+// allocating objects that will never be accessed, resulting in less work for
+// the garbage collector.
+type reader struct {
+	s    *bufio.Scanner
+	line []byte
+	word []byte
+
+	err error
+}
+
+func newReader(r io.Reader) *reader {
+	return &reader{
+		s: bufio.NewScanner(r),
+	}
+}
+
+// Bytes returns the current word as a byte slice.
+func (r *reader) Bytes() []byte {
+	return r.word
+}
+
+// Text returns the output of Bytes as a string.
+func (r *reader) Text() string {
+	return string(r.Bytes())
+}
+
+// Line advances the reader to the next line in the input. Calling Line resets
+// the current word, making [reader.Bytes] and [reader.Text] return empty
+// values. Follow this up with a call to [reader.Word].
+//
+// Like [bufio.Scanner], [reader.Err] needs to be checked after Line returns
+// false to determine if an error occurred during reading.
+//
+// Returns true if Line can be called again. Returns false if all lines in the
+// input have been read.
+func (r *reader) Line() bool {
+	for r.s.Scan() {
+		line := r.s.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+
+		r.line = line
+		r.word = nil
+
+		return true
+	}
+	if err := r.s.Err(); err != nil {
+		r.err = err
+	}
+
+	return false
+}
+
+// Word advances the reader to the next word in the current line.
+//
+// Returns true if a word is found and Word should be called again. Returns
+// false when all words on the line have been read.
+func (r *reader) Word() bool {
+	if len(r.line) == 0 {
+		return false
+	}
+
+	// Find next word start, skipping leading spaces.
+	start := 0
+	for width := 0; start < len(r.line); start += width {
+		var c rune
+		c, width = utf8.DecodeRune(r.line[start:])
+		if !unicode.IsSpace(c) {
+			break
+		}
+	}
+
+	// Whitespace scanning reached the end of the line due to trailing whitespace,
+	// meaning there are no more words to read
+	if start == len(r.line) {
+		return false
+	}
+
+	// Find next word end.
+	for width, i := 0, start; i < len(r.line); i += width {
+		var c rune
+		c, width = utf8.DecodeRune(r.line[i:])
+		if unicode.IsSpace(c) {
+			r.word = r.line[start:i]
+			r.line = r.line[i:]
+			return true
+		}
+	}
+
+	// The line contains data, but no end-of-word boundary was found. This is the
+	// last, unterminated word in the line.
+	if len(r.line) > start {
+		r.word = r.line[start:]
+		r.line = nil
+		return true
+	}
+
+	return false
+}
+
+func (r *reader) Err() error {
+	return r.err
+}

--- a/internal/kallsyms/reader_test.go
+++ b/internal/kallsyms/reader_test.go
@@ -1,0 +1,42 @@
+package kallsyms
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/go-quicktest/qt"
+)
+
+func TestReader(t *testing.T) {
+	b := []byte(`
+one  two 		three
+  four  
+
+  λέξη	`)
+
+	r := newReader(bytes.NewReader(b))
+
+	qt.Assert(t, qt.IsTrue(r.Line()))
+	qt.Assert(t, qt.IsTrue(r.Word()))
+	qt.Assert(t, qt.Equals(r.Text(), "one"))
+
+	qt.Assert(t, qt.IsTrue(r.Word()))
+	qt.Assert(t, qt.Equals(r.Text(), "two"))
+
+	qt.Assert(t, qt.IsTrue(r.Word()))
+	qt.Assert(t, qt.Equals(r.Text(), "three"))
+	qt.Assert(t, qt.IsFalse(r.Word()))
+
+	qt.Assert(t, qt.IsTrue(r.Line()))
+	qt.Assert(t, qt.IsTrue(r.Word()))
+	qt.Assert(t, qt.Equals(r.Text(), "four"))
+	qt.Assert(t, qt.IsFalse(r.Word()))
+
+	qt.Assert(t, qt.IsTrue(r.Line()))
+	qt.Assert(t, qt.IsTrue(r.Word()))
+	qt.Assert(t, qt.Equals(r.Text(), "λέξη"))
+	qt.Assert(t, qt.IsFalse(r.Word()))
+
+	qt.Assert(t, qt.IsFalse(r.Line()))
+	qt.Assert(t, qt.IsNil(r.Err()))
+}

--- a/prog.go
+++ b/prog.go
@@ -173,7 +173,7 @@ func (ps *ProgramSpec) KernelModule() (string, error) {
 		}
 		fallthrough
 	case Kprobe:
-		return kallsyms.KernelModule(ps.AttachTo)
+		return kallsyms.SymbolModule(ps.AttachTo)
 	}
 }
 


### PR DESCRIPTION
This commit introduces kallsyms.reader, meant to address the performance
concerns caused by fmt.Sscanf and bytes.Fields. Both of these options
allocate heavily and aren't flexible in terms of avoiding unnecessary
work like skipping the remainder of a line if we're not interested in
the remainder of its contents.

This approach borrows the implementation for reader.Word() from
bufio.ScanWords, paying attention to handling utf-8 characters correctly.
Kernel modules (out-of-tree, at least) can contain international symbols
in exported global kernel variables, which show up in /proc/kallsyms. We
need to err on the side of caution since this is technically user input
that's beyond our control.

This commit renames kallsyms.LoadSymbolAddresses to AssignAddresses and
kallsyms.KernelModule to SymbolModule respectively. Both implementations
have been changed to use kallsyms.reader.

```
                   │   old.txt   │              new.txt               │
                   │   sec/op    │   sec/op     vs base               │
SymbolKmods-16       246.6m ± 1%   281.5m ± 2%  +14.16% (p=0.002 n=6)
AssignAddresses-16   734.9m ± 1%   299.4m ± 1%  -59.26% (p=0.002 n=6)
geomean              425.7m        290.3m       -31.80%

                   │    old.txt    │               new.txt               │
                   │     B/op      │     B/op      vs base               │
SymbolKmods-16        39.81Mi ± 0%   15.81Mi ± 0%  -60.27% (p=0.002 n=6)
AssignAddresses-16   60.622Mi ± 0%   9.881Mi ± 0%  -83.70% (p=0.002 n=6)
geomean               49.12Mi        12.50Mi       -74.55%

                   │   old.txt    │              new.txt               │
                   │  allocs/op   │  allocs/op   vs base               │
SymbolKmods-16        477.4k ± 0%   266.5k ± 0%  -44.18% (p=0.002 n=6)
AssignAddresses-16   2653.0k ± 0%   462.7k ± 0%  -82.56% (p=0.002 n=6)
geomean               1.125M        351.2k       -68.80%
```

The SymbolKmods-16 wall clock time took a small hit because bytes.Fields
has an ASCII fast-path. Still worth it in the bigger picture since the
allocation pressure dropped by a significant amount to compensate, and
future work will change how the caching layer works for both AssignAddresses
and SymbolModule.

cc @alban @patrickpichler 