### PR TITLE
btf: LoadSpecFromReader: add filter param to optimize memory

### DIFF
--- a/btf/ext_info.go
+++ b/btf/ext_info.go
@@ -717,6 +717,10 @@ func (cr *CORERelocation) String() string {
 	return fmt.Sprintf("CORERelocation(%s, %s[%s], local_id=%d)", cr.kind, cr.typ, cr.accessor, cr.id)
 }
 
+func (cr *CORERelocation) TypeName() string {
+	return cr.typ.TypeName()
+}
+
 func CORERelocationMetadata(ins *asm.Instruction) *CORERelocation {
 	relo, _ := ins.Metadata.Get(coreRelocationMeta{}).(*CORERelocation)
 	return relo

--- a/btf/handle.go
+++ b/btf/handle.go
@@ -143,7 +143,7 @@ func (h *Handle) Spec(base *Spec) (*Spec, error) {
 		return nil, fmt.Errorf("missing base types")
 	}
 
-	return loadRawSpec(bytes.NewReader(btfBuffer), internal.NativeEndian, base)
+	return loadRawSpec(bytes.NewReader(btfBuffer), internal.NativeEndian, base, nil)
 }
 
 // Close destroys the handle.

--- a/btf/types.go
+++ b/btf/types.go
@@ -750,6 +750,10 @@ func copyType(typ Type, ids map[Type]TypeID, copies map[Type]Type, copiedIDs map
 
 type typeDeque = internal.Deque[*Type]
 
+type TypeFilter struct {
+	Names map[string]bool
+}
+
 // readAndInflateTypes reads the raw btf type info and turns it into a graph
 // of Types connected via pointers.
 //
@@ -759,13 +763,19 @@ type typeDeque = internal.Deque[*Type]
 // Returns a slice of types indexed by TypeID. Since BTF ignores compilation
 // units, multiple types may share the same name. A Type may form a cyclic graph
 // by pointing at itself.
-func readAndInflateTypes(r io.Reader, bo binary.ByteOrder, typeLen uint32, rawStrings *stringTable, base *Spec) ([]Type, error) {
+func readAndInflateTypes(r io.Reader, reset func(int64), bo binary.ByteOrder, typeLen uint32, rawStrings *stringTable, base *Spec, filter *TypeFilter) ([]Type, error) {
 	// because of the interleaving between types and struct members it is difficult to
 	// precompute the numbers of raw types this will parse
 	// this "guess" is a good first estimation
 	sizeOfbtfType := uintptr(btfTypeLen)
 	tyMaxCount := uintptr(typeLen) / sizeOfbtfType / 2
 	types := make([]Type, 0, tyMaxCount)
+
+	offsets := make([]int, 0, tyMaxCount)
+	keep := make([]bool, 0, tyMaxCount)
+	newIdx := make([]int, 0, tyMaxCount)
+
+	remainingIdxToProcess := []int{}
 
 	// Void is defined to always be type ID 0, and is thus omitted from BTF.
 	types = append(types, (*Void)(nil))
@@ -796,15 +806,23 @@ func readAndInflateTypes(r io.Reader, bo binary.ByteOrder, typeLen uint32, rawSt
 			}
 		}
 
-		idx := int(id - firstTypeID)
-		if idx < len(types) {
-			// We've already inflated this type, fix it up immediately.
-			*typ = types[idx]
-			return
-		}
-
 		fixups = append(fixups, fixupDef{id, typ})
 	}
+
+	appendItem := func(rawID TypeID) {
+		if rawID <= firstTypeID {
+			return
+		}
+		newTypeIdx := int(rawID - firstTypeID - 1)
+
+		if keep[newTypeIdx] {
+			return // already marked
+		}
+		newIdx[newTypeIdx] = len(types) + len(remainingIdxToProcess)
+		remainingIdxToProcess = append(remainingIdxToProcess, newTypeIdx)
+		keep[newTypeIdx] = true
+	}
+
 
 	type bitfieldFixupDef struct {
 		id TypeID
@@ -831,6 +849,7 @@ func readAndInflateTypes(r io.Reader, bo binary.ByteOrder, typeLen uint32, rawSt
 			})
 
 			m := &members[i]
+			appendItem(raw[i].Type)
 			fixup(raw[i].Type, &m.Type)
 
 			if kindFlag {
@@ -885,10 +904,13 @@ func readAndInflateTypes(r io.Reader, bo binary.ByteOrder, typeLen uint32, rawSt
 	)
 
 	var declTags []*declTag
+
+	// First pass: only initialising offsets and mark initial names
+	curOffset := 0
+	idx := 0
 	for {
 		var (
 			id  = firstTypeID + TypeID(len(types))
-			typ Type
 		)
 
 		if _, err := io.ReadFull(r, buf[:btfTypeLen]); err == io.EOF {
@@ -905,9 +927,96 @@ func readAndInflateTypes(r io.Reader, bo binary.ByteOrder, typeLen uint32, rawSt
 			return nil, fmt.Errorf("no more type IDs")
 		}
 
+		if _, err := unmarshalBtfType(&header, buf[:btfTypeLen], bo); err != nil {
+			return nil, fmt.Errorf("can't unmarshal type info for id %v: %v", id, err)
+		}
+
 		name, err := rawStrings.Lookup(header.NameOff)
 		if err != nil {
 			return nil, fmt.Errorf("get name for type id %d: %w", id, err)
+		}
+
+		offsets = append(offsets, curOffset)
+		if filter == nil || filter.Names[name] {
+			keep = append(keep, true)
+			newIdx = append(newIdx, idx)
+			remainingIdxToProcess = append(remainingIdxToProcess, idx)
+		} else {
+			keep = append(keep, false)
+			newIdx = append(newIdx, -1)
+		}
+		idx++
+
+		curOffset += btfTypeLen
+
+		addendumSize := 0
+		switch header.Kind() {
+		case kindInt:
+			addendumSize = btfIntLen
+		case kindPointer:
+		case kindArray:
+			addendumSize = btfArrayLen
+
+		case kindStruct:
+			fallthrough
+		case kindUnion:
+			addendumSize = header.Vlen()*btfMemberLen
+
+		case kindEnum:
+			addendumSize = header.Vlen()*btfEnumLen
+
+		case kindForward:
+		case kindTypedef:
+		case kindVolatile:
+		case kindConst:
+		case kindRestrict:
+		case kindFunc:
+		case kindFuncProto:
+			addendumSize = header.Vlen()*btfParamLen
+		case kindVar:
+			addendumSize = btfVariableLen
+		case kindDatasec:
+			addendumSize = header.Vlen()*btfVarSecinfoLen
+		case kindFloat:
+		case kindDeclTag:
+			addendumSize = btfDeclTagLen
+
+		case kindTypeTag:
+		case kindEnum64:
+			addendumSize = header.Vlen()*btfEnum64Len
+
+		default:
+			return nil, fmt.Errorf("type id %d: unknown kind: %v", id, header.Kind())
+		}
+
+		curOffset += addendumSize
+		buf = slices.Grow(buf[:0], addendumSize)[:addendumSize]
+		if _, err := io.ReadFull(r, buf); err != nil {
+			return nil, fmt.Errorf("can't read btfMembers, id: %d: %w", id, err)
+		}
+	}
+
+	// Second pass: initializing types that pass the filter
+	for (len(remainingIdxToProcess) > 0) {
+		var pos int
+		pos, remainingIdxToProcess = remainingIdxToProcess[0], remainingIdxToProcess[1:]
+
+		id := firstTypeID + TypeID(pos)
+		reset(int64(offsets[pos]))
+
+		var typ Type
+
+		if _, err := io.ReadFull(r, buf[:btfTypeLen]); err != nil {
+			return nil, fmt.Errorf("can't read type info at position %v: %v", pos, err)
+		}
+
+		if _, err := unmarshalBtfType(&header, buf[:btfTypeLen], bo); err != nil {
+			return nil, fmt.Errorf("can't unmarshal type info at position %v: %v", pos, err)
+		}
+
+		name, err := rawStrings.Lookup(header.NameOff)
+		if err != nil {
+			return nil, fmt.Errorf("get name for type at position %d: %w (%+v)", pos, err, header)
 		}
 
 		switch header.Kind() {
@@ -915,10 +1024,10 @@ func readAndInflateTypes(r io.Reader, bo binary.ByteOrder, typeLen uint32, rawSt
 			size := header.Size()
 			buf = buf[:btfIntLen]
 			if _, err := io.ReadFull(r, buf); err != nil {
-				return nil, fmt.Errorf("can't read btfInt, id: %d: %w", id, err)
+				return nil, fmt.Errorf("can't read btfInt, pos: %d: %w", pos, err)
 			}
 			if _, err := unmarshalBtfInt(&bInt, buf, bo); err != nil {
-				return nil, fmt.Errorf("can't unmarshal btfInt, id: %d: %w", id, err)
+				return nil, fmt.Errorf("can't unmarshal btfInt, pos: %d: %w", pos, err)
 			}
 			if bInt.Offset() > 0 || bInt.Bits().Bytes() != size {
 				legacyBitfields[id] = [2]Bits{bInt.Offset(), bInt.Bits()}
@@ -927,20 +1036,23 @@ func readAndInflateTypes(r io.Reader, bo binary.ByteOrder, typeLen uint32, rawSt
 
 		case kindPointer:
 			ptr := &Pointer{nil}
+			appendItem(header.Type())
 			fixup(header.Type(), &ptr.Target)
 			typ = ptr
 
 		case kindArray:
 			buf = buf[:btfArrayLen]
 			if _, err := io.ReadFull(r, buf); err != nil {
-				return nil, fmt.Errorf("can't read btfArray, id: %d: %w", id, err)
+				return nil, fmt.Errorf("can't read btfArray, pos: %d: %w", pos, err)
 			}
 			if _, err := unmarshalBtfArray(&bArr, buf, bo); err != nil {
-				return nil, fmt.Errorf("can't unmarshal btfArray, id: %d: %w", id, err)
+				return nil, fmt.Errorf("can't unmarshal btfArray, pos: %d: %w", pos, err)
 			}
 
 			arr := &Array{nil, nil, bArr.Nelems}
+			appendItem(bArr.IndexType)
 			fixup(bArr.IndexType, &arr.Index)
+			appendItem(bArr.Type)
 			fixup(bArr.Type, &arr.Type)
 			typ = arr
 
@@ -949,15 +1061,15 @@ func readAndInflateTypes(r io.Reader, bo binary.ByteOrder, typeLen uint32, rawSt
 			bMembers = slices.Grow(bMembers[:0], vlen)[:vlen]
 			buf = slices.Grow(buf[:0], vlen*btfMemberLen)[:vlen*btfMemberLen]
 			if _, err := io.ReadFull(r, buf); err != nil {
-				return nil, fmt.Errorf("can't read btfMembers, id: %d: %w", id, err)
+				return nil, fmt.Errorf("can't read btfMembers, pos: %d: %w", pos, err)
 			}
 			if _, err := unmarshalBtfMembers(bMembers, buf, bo); err != nil {
-				return nil, fmt.Errorf("can't unmarshal btfMembers, id: %d: %w", id, err)
+				return nil, fmt.Errorf("can't unmarshal btfMembers, pos: %d: %w", pos, err)
 			}
 
 			members, err := convertMembers(bMembers, header.Bitfield())
 			if err != nil {
-				return nil, fmt.Errorf("struct %s (id %d): %w", name, id, err)
+				return nil, fmt.Errorf("struct %s (pos %d): %w", name, pos, err)
 			}
 			typ = &Struct{name, header.Size(), members, nil}
 
@@ -966,15 +1078,15 @@ func readAndInflateTypes(r io.Reader, bo binary.ByteOrder, typeLen uint32, rawSt
 			bMembers = slices.Grow(bMembers[:0], vlen)[:vlen]
 			buf = slices.Grow(buf[:0], vlen*btfMemberLen)[:vlen*btfMemberLen]
 			if _, err := io.ReadFull(r, buf); err != nil {
-				return nil, fmt.Errorf("can't read btfMembers, id: %d: %w", id, err)
+				return nil, fmt.Errorf("can't read btfMembers, pos: %d: %w", pos, err)
 			}
 			if _, err := unmarshalBtfMembers(bMembers, buf, bo); err != nil {
-				return nil, fmt.Errorf("can't unmarshal btfMembers, id: %d: %w", id, err)
+				return nil, fmt.Errorf("can't unmarshal btfMembers, pos: %d: %w", pos, err)
 			}
 
 			members, err := convertMembers(bMembers, header.Bitfield())
 			if err != nil {
-				return nil, fmt.Errorf("union %s (id %d): %w", name, id, err)
+				return nil, fmt.Errorf("union %s (pos %d): %w", name, pos, err)
 			}
 			typ = &Union{name, header.Size(), members, nil}
 
@@ -983,10 +1095,10 @@ func readAndInflateTypes(r io.Reader, bo binary.ByteOrder, typeLen uint32, rawSt
 			bEnums = slices.Grow(bEnums[:0], vlen)[:vlen]
 			buf = slices.Grow(buf[:0], vlen*btfEnumLen)[:vlen*btfEnumLen]
 			if _, err := io.ReadFull(r, buf); err != nil {
-				return nil, fmt.Errorf("can't read btfEnums, id: %d: %w", id, err)
+				return nil, fmt.Errorf("can't read btfEnums, pos: %d: %w", pos, err)
 			}
 			if _, err := unmarshalBtfEnums(bEnums, buf, bo); err != nil {
-				return nil, fmt.Errorf("can't unmarshal btfEnums, id: %d: %w", id, err)
+				return nil, fmt.Errorf("can't unmarshal btfEnums, pos: %d: %w", pos, err)
 			}
 
 			vals := make([]EnumValue, 0, vlen)
@@ -1010,26 +1122,31 @@ func readAndInflateTypes(r io.Reader, bo binary.ByteOrder, typeLen uint32, rawSt
 
 		case kindTypedef:
 			typedef := &Typedef{name, nil, nil}
+			appendItem(header.Type())
 			fixup(header.Type(), &typedef.Type)
 			typ = typedef
 
 		case kindVolatile:
 			volatile := &Volatile{nil}
+			appendItem(header.Type())
 			fixup(header.Type(), &volatile.Type)
 			typ = volatile
 
 		case kindConst:
 			cnst := &Const{nil}
+			appendItem(header.Type())
 			fixup(header.Type(), &cnst.Type)
 			typ = cnst
 
 		case kindRestrict:
 			restrict := &Restrict{nil}
+			appendItem(header.Type())
 			fixup(header.Type(), &restrict.Type)
 			typ = restrict
 
 		case kindFunc:
 			fn := &Func{name, nil, header.Linkage(), nil, nil}
+			appendItem(header.Type())
 			fixup(header.Type(), &fn.Type)
 			typ = fn
 
@@ -1038,10 +1155,10 @@ func readAndInflateTypes(r io.Reader, bo binary.ByteOrder, typeLen uint32, rawSt
 			bParams = slices.Grow(bParams[:0], vlen)[:vlen]
 			buf = slices.Grow(buf[:0], vlen*btfParamLen)[:vlen*btfParamLen]
 			if _, err := io.ReadFull(r, buf); err != nil {
-				return nil, fmt.Errorf("can't read btfParams, id: %d: %w", id, err)
+				return nil, fmt.Errorf("can't read btfParams, pos: %d: %w", pos, err)
 			}
 			if _, err := unmarshalBtfParams(bParams, buf, bo); err != nil {
-				return nil, fmt.Errorf("can't unmarshal btfParams, id: %d: %w", id, err)
+				return nil, fmt.Errorf("can't unmarshal btfParams, pos: %d: %w", pos, err)
 			}
 
 			params := make([]FuncParam, 0, vlen)
@@ -1055,23 +1172,26 @@ func readAndInflateTypes(r io.Reader, bo binary.ByteOrder, typeLen uint32, rawSt
 				})
 			}
 			for i := range params {
+				appendItem(bParams[i].Type)
 				fixup(bParams[i].Type, &params[i].Type)
 			}
 
 			fp := &FuncProto{nil, params}
+			appendItem(header.Type())
 			fixup(header.Type(), &fp.Return)
 			typ = fp
 
 		case kindVar:
 			buf = buf[:btfVariableLen]
 			if _, err := io.ReadFull(r, buf); err != nil {
-				return nil, fmt.Errorf("can't read btfVariable, id: %d: %w", id, err)
+				return nil, fmt.Errorf("can't read btfVariable, pos: %d: %w", pos, err)
 			}
 			if _, err := unmarshalBtfVariable(&bVariable, buf, bo); err != nil {
-				return nil, fmt.Errorf("can't read btfVariable, id: %d: %w", id, err)
+				return nil, fmt.Errorf("can't read btfVariable, pos: %d: %w", pos, err)
 			}
 
 			v := &Var{name, nil, VarLinkage(bVariable.Linkage), nil}
+			appendItem(header.Type())
 			fixup(header.Type(), &v.Type)
 			typ = v
 
@@ -1080,10 +1200,10 @@ func readAndInflateTypes(r io.Reader, bo binary.ByteOrder, typeLen uint32, rawSt
 			bSecInfos = slices.Grow(bSecInfos[:0], vlen)[:vlen]
 			buf = slices.Grow(buf[:0], vlen*btfVarSecinfoLen)[:vlen*btfVarSecinfoLen]
 			if _, err := io.ReadFull(r, buf); err != nil {
-				return nil, fmt.Errorf("can't read btfVarSecInfos, id: %d: %w", id, err)
+				return nil, fmt.Errorf("can't read btfVarSecInfos, pos: %d: %w", pos, err)
 			}
 			if _, err := unmarshalBtfVarSecInfos(bSecInfos, buf, bo); err != nil {
-				return nil, fmt.Errorf("can't unmarshal btfVarSecInfos, id: %d: %w", id, err)
+				return nil, fmt.Errorf("can't unmarshal btfVarSecInfos, pos: %d: %w", pos, err)
 			}
 
 			vars := make([]VarSecinfo, 0, vlen)
@@ -1094,6 +1214,7 @@ func readAndInflateTypes(r io.Reader, bo binary.ByteOrder, typeLen uint32, rawSt
 				})
 			}
 			for i := range vars {
+				appendItem(bSecInfos[i].Type)
 				fixup(bSecInfos[i].Type, &vars[i].Type)
 			}
 			typ = &Datasec{name, header.Size(), vars}
@@ -1104,18 +1225,19 @@ func readAndInflateTypes(r io.Reader, bo binary.ByteOrder, typeLen uint32, rawSt
 		case kindDeclTag:
 			buf = buf[:btfDeclTagLen]
 			if _, err := io.ReadFull(r, buf); err != nil {
-				return nil, fmt.Errorf("can't read btfDeclTag, id: %d: %w", id, err)
+				return nil, fmt.Errorf("can't read btfDeclTag, pos: %d: %w", pos, err)
 			}
 			if _, err := unmarshalBtfDeclTag(&bDeclTag, buf, bo); err != nil {
-				return nil, fmt.Errorf("can't read btfDeclTag, id: %d: %w", id, err)
+				return nil, fmt.Errorf("can't read btfDeclTag, pos: %d: %w", pos, err)
 			}
 
 			btfIndex := bDeclTag.ComponentIdx
 			if uint64(btfIndex) > math.MaxInt {
-				return nil, fmt.Errorf("type id %d: index exceeds int", id)
+				return nil, fmt.Errorf("type pos %d: index exceeds int", pos)
 			}
 
 			dt := &declTag{nil, name, int(int32(btfIndex))}
+			appendItem(header.Type())
 			fixup(header.Type(), &dt.Type)
 			typ = dt
 
@@ -1123,6 +1245,7 @@ func readAndInflateTypes(r io.Reader, bo binary.ByteOrder, typeLen uint32, rawSt
 
 		case kindTypeTag:
 			tt := &TypeTag{nil, name}
+			appendItem(header.Type())
 			fixup(header.Type(), &tt.Type)
 			typ = tt
 
@@ -1131,10 +1254,10 @@ func readAndInflateTypes(r io.Reader, bo binary.ByteOrder, typeLen uint32, rawSt
 			bEnums64 = slices.Grow(bEnums64[:0], vlen)[:vlen]
 			buf = slices.Grow(buf[:0], vlen*btfEnum64Len)[:vlen*btfEnum64Len]
 			if _, err := io.ReadFull(r, buf); err != nil {
-				return nil, fmt.Errorf("can't read btfEnum64s, id: %d: %w", id, err)
+				return nil, fmt.Errorf("can't read btfEnum64s, pos: %d: %w", pos, err)
 			}
 			if _, err := unmarshalBtfEnums64(bEnums64, buf, bo); err != nil {
-				return nil, fmt.Errorf("can't unmarshal btfEnum64s, id: %d: %w", id, err)
+				return nil, fmt.Errorf("can't unmarshal btfEnum64s, pos: %d: %w", pos, err)
 			}
 
 			vals := make([]EnumValue, 0, vlen)
@@ -1149,7 +1272,7 @@ func readAndInflateTypes(r io.Reader, bo binary.ByteOrder, typeLen uint32, rawSt
 			typ = &Enum{name, header.Size(), header.Signed(), vals}
 
 		default:
-			return nil, fmt.Errorf("type id %d: unknown kind: %v", id, header.Kind())
+			return nil, fmt.Errorf("type pos %d: unknown kind: %v", pos, header.Kind())
 		}
 
 		types = append(types, typ)
@@ -1161,6 +1284,17 @@ func readAndInflateTypes(r io.Reader, bo binary.ByteOrder, typeLen uint32, rawSt
 		}
 
 		idx := int(fixup.id - firstTypeID)
+
+		// if idx is 0, that's the Void type. No need to adjust
+		if idx > 0 {
+			idx = newIdx[idx-1]
+
+			if idx == -1 {
+				return nil, fmt.Errorf("reference to skipped type id: %d", fixup.id)
+			} else {
+				idx++
+			}
+		}
 		if idx >= len(types) {
 			return nil, fmt.Errorf("reference to invalid type id: %d", fixup.id)
 		}


### PR DESCRIPTION
This is a proof-of-concept. The code is not ready for merging but it shows it is possible to significantly reduce the memory consumption (by 27MB).

---

In the new LoadSpecFromReader, I added a filter parameter to only parse required kernel btf types.

```go
type TypeFilter struct {
       Names map[string]bool
}

func LoadSpecFromReader(rd io.ReaderAt, filter *TypeFilter) (*Spec, error)
```

Users of the cilium/ebpf package can get the list of relocations they programs require and give it to LoadKernelSpecWithFilter:
```go
var filter *btf.TypeFilter
if len(programs) > 0 {
        filter = &btf.TypeFilter{
                Names: map[string]bool{},
        }
        for _, p := range programs {
                iter := p.Instructions.Iterate()
                for iter.Next() {
                        if relo := btf.CORERelocationMetadata(iter.Ins); relo != nil {
                                fmt.Printf("relo %s\n", relo.String())
                                filter.Names[relo.TypeName()] = true
                        }
                }
        }
}
s, err := btf.LoadKernelSpecWithFilter(filter)
...
opts := ebpf.CollectionOptions{
	Programs: ebpf.ProgramOptions{
		KernelTypes: s,
	},
}
...
if err := spec.LoadAndAssign(objs, &opts); err != nil {
```

---

In my tests in Inspektor Gadget (with this [branch](https://github.com/alban/inspektor-gadget/commits/alban_btf_mem/)), pprof flamegraph inuse_space shows a reduction of memory usage from 40MB to 12MB: btf.LoadKernelSpec() is completely removed from the flamegraph. It used to take 27MB.

Before:

![image](https://github.com/user-attachments/assets/82744a09-40b7-4286-becc-c9956a0be0ba)

After:

![image](https://github.com/user-attachments/assets/c77c5741-abd0-4404-aa1b-a2c1538dcfda)

---

It works with parsing the BTF file in two passes:
1. read sequentially the BTF file to get offsets of each BTF type and mark those we want to keep
2. parse the types we want to keep at the offsets found in the previous steps and follow the type dependency graph.

@burak-ok @mauriciovasquezbernal @flyth