### PR TITLE
internal: add a way to write portable feature tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,7 @@ jobs:
     needs: build-and-lint
     timeout-minutes: 15
     env:
-      EBPF_TEST_IGNORE_KERNEL_VERSION: 'TestKprobeMulti,TestKprobeMultiErrors,TestKprobeMultiCookie,TestKprobeMultiProgramCall,TestHaveBPFLinkKprobeMulti'
+      EBPF_TEST_IGNORE_VERSION: 'TestKprobeMulti,TestKprobeMultiErrors,TestKprobeMultiCookie,TestKprobeMultiProgramCall,TestHaveBPFLinkKprobeMulti'
     steps:
       - uses: actions/checkout@v4
 

--- a/internal/testutils/feature.go
+++ b/internal/testutils/feature.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	ignoreKernelVersionEnvVar = "EBPF_TEST_IGNORE_KERNEL_VERSION"
+	ignoreVersionEnvVar = "EBPF_TEST_IGNORE_VERSION"
 )
 
 func CheckFeatureTest(t *testing.T, fn func() error) {
@@ -25,7 +25,7 @@ func checkFeatureTestError(t *testing.T, err error) {
 
 	var ufe *internal.UnsupportedFeatureError
 	if errors.As(err, &ufe) {
-		checkKernelVersion(t, ufe)
+		checkVersion(t, ufe)
 	} else {
 		t.Error("Feature test failed:", err)
 	}
@@ -50,7 +50,7 @@ func SkipIfNotSupported(tb testing.TB, err error) {
 
 	var ufe *internal.UnsupportedFeatureError
 	if errors.As(err, &ufe) {
-		checkKernelVersion(tb, ufe)
+		checkVersion(tb, ufe)
 		tb.Skip(ufe.Error())
 	}
 	if errors.Is(err, internal.ErrNotSupported) {
@@ -58,15 +58,28 @@ func SkipIfNotSupported(tb testing.TB, err error) {
 	}
 }
 
-func checkKernelVersion(tb testing.TB, ufe *internal.UnsupportedFeatureError) {
+func SkipIfNotSupportedOnOS(tb testing.TB, err error) {
+	tb.Helper()
+
+	if err == internal.ErrNotSupportedOnOS {
+		tb.Fatal("Unwrapped ErrNotSupportedOnOS")
+	}
+
+	if errors.Is(err, internal.ErrNotSupportedOnOS) {
+		tb.Skip(err.Error())
+	}
+}
+
+func checkVersion(tb testing.TB, ufe *internal.UnsupportedFeatureError) {
 	if ufe.MinimumVersion.Unspecified() {
 		return
 	}
 
 	tb.Helper()
 
-	if ignoreKernelVersionCheck(tb.Name()) {
-		tb.Skipf("Ignoring error due to %s: %s", ignoreKernelVersionEnvVar, ufe.Error())
+	if ignoreVersionCheck(tb.Name()) {
+		tb.Logf("Ignoring error due to %s: %s", ignoreVersionEnvVar, ufe.Error())
+		return
 	}
 
 	if !isKernelLessThan(tb, ufe.MinimumVersion) {
@@ -121,12 +134,15 @@ func kernelVersion(tb testing.TB) internal.Version {
 	return v
 }
 
-// ignoreKernelVersionCheck checks if test name should be ignored for kernel version check by checking against environment var EBPF_TEST_IGNORE_KERNEL_VERSION.
-// EBPF_TEST_IGNORE_KERNEL_VERSION is a comma (,) separated list of test names for which kernel version check should be ignored.
+// ignoreVersionCheck checks whether to omit the version check for a test.
 //
-// eg: EBPF_TEST_IGNORE_KERNEL_VERSION=TestABC,TestXYZ
-func ignoreKernelVersionCheck(tName string) bool {
-	tNames := os.Getenv(ignoreKernelVersionEnvVar)
+// It reads a comma separated list of test names from an environment variable.
+//
+// For example:
+//
+//	EBPF_TEST_IGNORE_VERSION=TestABC,TestXYZ go test ...
+func ignoreVersionCheck(tName string) bool {
+	tNames := os.Getenv(ignoreVersionEnvVar)
 	if tNames == "" {
 		return false
 	}

--- a/internal/testutils/feature_test.go
+++ b/internal/testutils/feature_test.go
@@ -44,9 +44,9 @@ func TestIgnoreKernelVersionCheckWhenEnvVarIsSet(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Setenv(ignoreKernelVersionEnvVar, tt.toIgnoreNamesEnvValue)
+			t.Setenv(ignoreVersionEnvVar, tt.toIgnoreNamesEnvValue)
 
-			if got := ignoreKernelVersionCheck(tt.testName); got != tt.ignoreKernelVersionCheck {
+			if got := ignoreVersionCheck(tt.testName); got != tt.ignoreKernelVersionCheck {
 				t.Errorf("ignoreKernelVersionCheck() = %v, want %v", got, tt.ignoreKernelVersionCheck)
 			}
 		})


### PR DESCRIPTION
Feature tests are used to enable new features in a backwards compatible manner. They exercise very specific code paths in the kernel. It makes sense to assume that the existing feature tests will not work as intended when porting to a new platform. Change the existing NewFeatureTest constructor to return a new sentinel error when invoked on non-Linux OS.

Add a new constructor NewPortableFeatureTest which allows indicating on which platforms and versions a feature test is reliable.