### PR TITLE
internal: move PlatformPrefix to internal/linux

### DIFF
--- a/internal/linux/platform.go
+++ b/internal/linux/platform.go
@@ -1,4 +1,4 @@
-package internal
+package linux
 
 import (
 	"runtime"

--- a/link/kprobe.go
+++ b/link/kprobe.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/internal"
+	"github.com/cilium/ebpf/internal/linux"
 	"github.com/cilium/ebpf/internal/sys"
 	"github.com/cilium/ebpf/internal/tracefs"
 	"github.com/cilium/ebpf/internal/unix"
@@ -172,7 +173,7 @@ func kprobe(symbol string, prog *ebpf.Program, opts *KprobeOptions, ret bool) (*
 	// Use kprobe PMU if the kernel has it available.
 	tp, err := pmuProbe(args)
 	if errors.Is(err, os.ErrNotExist) || errors.Is(err, unix.EINVAL) {
-		if prefix := internal.PlatformPrefix(); prefix != "" {
+		if prefix := linux.PlatformPrefix(); prefix != "" {
 			args.Symbol = prefix + symbol
 			tp, err = pmuProbe(args)
 		}
@@ -188,7 +189,7 @@ func kprobe(symbol string, prog *ebpf.Program, opts *KprobeOptions, ret bool) (*
 	args.Symbol = symbol
 	tp, err = tracefsProbe(args)
 	if errors.Is(err, os.ErrNotExist) || errors.Is(err, unix.EINVAL) {
-		if prefix := internal.PlatformPrefix(); prefix != "" {
+		if prefix := linux.PlatformPrefix(); prefix != "" {
 			args.Symbol = prefix + symbol
 			tp, err = tracefsProbe(args)
 		}

--- a/syscalls.go
+++ b/syscalls.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cilium/ebpf/asm"
 	"github.com/cilium/ebpf/internal"
+	"github.com/cilium/ebpf/internal/linux"
 	"github.com/cilium/ebpf/internal/sys"
 	"github.com/cilium/ebpf/internal/tracefs"
 	"github.com/cilium/ebpf/internal/unix"
@@ -276,7 +277,7 @@ var haveBPFToBPFCalls = internal.NewFeatureTest("bpf2bpf calls", func() error {
 }, "4.16")
 
 var haveSyscallWrapper = internal.NewFeatureTest("syscall wrapper", func() error {
-	prefix := internal.PlatformPrefix()
+	prefix := linux.PlatformPrefix()
 	if prefix == "" {
 		return fmt.Errorf("unable to find the platform prefix for (%s)", runtime.GOARCH)
 	}


### PR DESCRIPTION
The platform prefix is tied to the Linux kernel, move it to the appropriate package.