### PR TITLE
features: add HaveV4ISA probe for checking ISA v4 support in the kernel

### DIFF
--- a/features/misc.go
+++ b/features/misc.go
@@ -1,9 +1,12 @@
 package features
 
 import (
+	"errors"
+
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/asm"
 	"github.com/cilium/ebpf/internal"
+	"github.com/cilium/ebpf/internal/sys"
 )
 
 // HaveLargeInstructions probes the running kernel if more than 4096 instructions
@@ -62,7 +65,7 @@ func HaveV2ISA() error {
 }
 
 var haveV2ISA = internal.NewFeatureTest("v2 ISA", func() error {
-	return probeProgram(&ebpf.ProgramSpec{
+	err := probeProgram(&ebpf.ProgramSpec{
 		Type: ebpf.SocketFilter,
 		Instructions: asm.Instructions{
 			asm.Mov.Imm(asm.R0, 0),
@@ -71,6 +74,11 @@ var haveV2ISA = internal.NewFeatureTest("v2 ISA", func() error {
 			asm.Return().WithSymbol("exit"),
 		},
 	})
+	// This sometimes bubbles up from the JIT on aarch64.
+	if errors.Is(err, sys.ENOTSUPP) {
+		return ebpf.ErrNotSupported
+	}
+	return err
 }, "4.14")
 
 // HaveV3ISA probes the running kernel if instructions of the v3 ISA are supported.
@@ -83,7 +91,7 @@ func HaveV3ISA() error {
 }
 
 var haveV3ISA = internal.NewFeatureTest("v3 ISA", func() error {
-	return probeProgram(&ebpf.ProgramSpec{
+	err := probeProgram(&ebpf.ProgramSpec{
 		Type: ebpf.SocketFilter,
 		Instructions: asm.Instructions{
 			asm.Mov.Imm(asm.R0, 0),
@@ -92,6 +100,11 @@ var haveV3ISA = internal.NewFeatureTest("v3 ISA", func() error {
 			asm.Return().WithSymbol("exit"),
 		},
 	})
+	// This sometimes bubbles up from the JIT on aarch64.
+	if errors.Is(err, sys.ENOTSUPP) {
+		return ebpf.ErrNotSupported
+	}
+	return err
 }, "5.1")
 
 // HaveV4ISA probes the running kernel if instructions of the v4 ISA are supported.

--- a/features/misc_test.go
+++ b/features/misc_test.go
@@ -21,3 +21,7 @@ func TestHaveV2ISA(t *testing.T) {
 func TestHaveV3ISA(t *testing.T) {
 	testutils.CheckFeatureTest(t, HaveV3ISA)
 }
+
+func TestHaveV4ISA(t *testing.T) {
+	testutils.CheckFeatureTest(t, HaveV4ISA)
+}


### PR DESCRIPTION
This PR introduces the `haveV4ISA` probe and `HaveV4ISA` API to check in the running kernel if instructions of the v4 ISA are supported. The upstream commit used as reference is 1f9a1ea821ff ("bpf: Support new sign-extension load insns"). The probes tests the new long jump given by `BPF_JMP32 | BPF_JA`.

I'm attempting to submit an identical patch to bpftool, so that `bpftool feature probe` will output also ISAv4 support.