### PR TITLE
prog, map: add nil checks for value marshaller

### DIFF
--- a/map.go
+++ b/map.go
@@ -1589,6 +1589,10 @@ func unmarshalMap(buf sysenc.Buffer) (*Map, error) {
 
 // marshalMap marshals the fd of a map into a buffer in host endianness.
 func marshalMap(m *Map, length int) ([]byte, error) {
+	if m == nil {
+		return nil, errors.New("can't marshal a nil Map")
+	}
+
 	if length != 4 {
 		return nil, fmt.Errorf("can't marshal map to %d bytes", length)
 	}

--- a/map_test.go
+++ b/map_test.go
@@ -905,6 +905,10 @@ func TestMapInMap(t *testing.T) {
 				t.Fatal("Can't put inner map:", err)
 			}
 
+			if err := outer.Put(uint32(0), (*Map)(nil)); err == nil {
+				t.Fatal("Put accepted a nil Map")
+			}
+
 			var inner2 *Map
 			if err := outer.Lookup(uint32(0), &inner2); err != nil {
 				t.Fatal("Can't lookup 0:", err)

--- a/prog.go
+++ b/prog.go
@@ -893,6 +893,10 @@ func unmarshalProgram(buf sysenc.Buffer) (*Program, error) {
 }
 
 func marshalProgram(p *Program, length int) ([]byte, error) {
+	if p == nil {
+		return nil, errors.New("can't marshal a nil Program")
+	}
+
 	if length != 4 {
 		return nil, fmt.Errorf("can't marshal program to %d bytes", length)
 	}

--- a/prog_test.go
+++ b/prog_test.go
@@ -596,6 +596,10 @@ func TestProgramMarshaling(t *testing.T) {
 	arr := createProgramArray(t)
 	defer arr.Close()
 
+	if err := arr.Put(idx, (*Program)(nil)); err == nil {
+		t.Fatal("Put accepted a nil Program")
+	}
+
 	prog := mustSocketFilter(t)
 
 	if err := arr.Put(idx, prog); err != nil {


### PR DESCRIPTION
In case of programs or maps as map value types, the value marshalling results in a panic in case of a nil pointer. For other types this is not a problem since sysenc.Marshal does a nil check.

This commit adds a nil check to the internal helper for marshalling programs and maps.