### PR TITLE
variable: copy VariableSpec.Type during initial assignment and during copy

### DIFF
--- a/elf_reader.go
+++ b/elf_reader.go
@@ -1233,7 +1233,9 @@ func (ec *elfCode) loadDataSections() error {
 						return fmt.Errorf("data section %s: variable %s size in datasec (%d) doesn't match ELF symbol size (%d)", sec.Name, name, v.Size, ev.size)
 					}
 
-					ev.t = vt
+					// Decouple the Var in the VariableSpec from the underlying DataSec in
+					// the MapSpec to avoid modifications from affecting map loads later on.
+					ev.t = btf.Copy(vt).(*btf.Var)
 				}
 			}
 		}

--- a/variable.go
+++ b/variable.go
@@ -112,7 +112,9 @@ func (s *VariableSpec) copy(cpy *CollectionSpec) *VariableSpec {
 		name:   s.name,
 		offset: s.offset,
 		size:   s.size,
-		t:      s.t,
+	}
+	if s.t != nil {
+		out.t = btf.Copy(s.t).(*btf.Var)
 	}
 
 	// Attempt to find a MapSpec with the same name in the copied CollectionSpec.

--- a/variable_test.go
+++ b/variable_test.go
@@ -62,6 +62,14 @@ func TestVariableSpecCopy(t *testing.T) {
 	// Verify that the original underlying MapSpec was not modified.
 	zero := make([]byte, 4)
 	qt.Assert(t, qt.DeepEquals(spec.Maps[".rodata"].Contents[0].Value.([]byte), zero))
+
+	// Check that modifications to the VariableSpec's Type don't affect the
+	// underlying MapSpec's type information on either the original or the copy.
+	cpy.Variables["var_rodata"].Type().Name = "modified"
+	spec.Variables["var_rodata"].Type().Name = "modified"
+
+	qt.Assert(t, qt.Equals(cpy.Maps[".rodata"].Value.(*btf.Datasec).Vars[0].Type.(*btf.Var).Name, "var_rodata"))
+	qt.Assert(t, qt.Equals(spec.Maps[".rodata"].Value.(*btf.Datasec).Vars[0].Type.(*btf.Var).Name, "var_rodata"))
 }
 
 func mustReturn(tb testing.TB, prog *Program, value uint32) {


### PR DESCRIPTION
Before this patch, VariableSpec shared its Type with the underlying datasec, including any prior copies. This commit copies when the type is assigned from the Datasec to the VariableSpec, as well as when the VariableSpec is copied during CollectionSpec.Copy().