### PR TITLE
Optimize `epoll.Wait` by using sentinel errors

### DIFF
--- a/internal/epoll/poller.go
+++ b/internal/epoll/poller.go
@@ -14,7 +14,11 @@ import (
 	"github.com/cilium/ebpf/internal/unix"
 )
 
-var ErrFlushed = errors.New("data was flushed")
+var (
+	ErrFlushed                   = errors.New("data was flushed")
+	errEpollWaitDeadlineExceeded = fmt.Errorf("epoll wait: %w", os.ErrDeadlineExceeded)
+	errEpollWaitClosed           = fmt.Errorf("epoll wait: %w", os.ErrClosed)
+)
 
 // Poller waits for readiness notifications from multiple file descriptors.
 //
@@ -44,7 +48,7 @@ func New() (_ *Poller, err error) {
 
 	epollFd, err := unix.EpollCreate1(unix.EPOLL_CLOEXEC)
 	if err != nil {
-		return nil, fmt.Errorf("create epoll fd: %v", err)
+		return nil, fmt.Errorf("create epoll fd: %w", err)
 	}
 	defer closeFDOnError(epollFd)
 
@@ -158,7 +162,7 @@ func (p *Poller) Wait(events []unix.EpollEvent, deadline time.Time) (int, error)
 	defer p.epollMu.Unlock()
 
 	if p.epollFd == -1 {
-		return 0, fmt.Errorf("epoll wait: %w", os.ErrClosed)
+		return 0, errEpollWaitClosed
 	}
 
 	for {
@@ -184,7 +188,7 @@ func (p *Poller) Wait(events []unix.EpollEvent, deadline time.Time) (int, error)
 		}
 
 		if n == 0 {
-			return 0, fmt.Errorf("epoll wait: %w", os.ErrDeadlineExceeded)
+			return 0, errEpollWaitDeadlineExceeded
 		}
 
 		for i := 0; i < n; {
@@ -193,7 +197,7 @@ func (p *Poller) Wait(events []unix.EpollEvent, deadline time.Time) (int, error)
 				// Since we don't read p.closeEvent the event is never cleared and
 				// we'll keep getting this wakeup until Close() acquires the
 				// lock and sets p.epollFd = -1.
-				return 0, fmt.Errorf("epoll wait: %w", os.ErrClosed)
+				return 0, errEpollWaitClosed
 			}
 			if int(event.Fd) == p.flushEvent.raw {
 				// read event to prevent it from continuing to wake


### PR DESCRIPTION
Batched perfmap readers with 10ms deadlines showed `fmt.Errorf` consuming ~4% of CPU. This PR reduces CPU usage by replacing repeated formatting with package-level error variables.

<img width="1178" alt="Screenshot 2024-12-05 at 10 16 24" src="https://github.com/user-attachments/assets/d8f35aad-4c09-4e03-9fb2-bb89c61df43e">

