### PR TITLE
elf: reintroduce unreferenced datasec pruning

### DIFF
--- a/elf_reader.go
+++ b/elf_reader.go
@@ -1125,6 +1125,17 @@ func (ec *elfCode) loadDataSections() error {
 			continue
 		}
 
+		// If a section has no references, it will be freed as soon as the
+		// Collection closes, so creating and populating it is wasteful. If it has
+		// no symbols, it is likely an ephemeral section used during compilation
+		// that wasn't sanitized by the bpf linker. (like .rodata.str1.1)
+		//
+		// No symbols means no VariableSpecs can be generated from it, making it
+		// pointless to emit a data section for.
+		if sec.references == 0 && len(sec.symbols) == 0 {
+			continue
+		}
+
 		if sec.Size > math.MaxUint32 {
 			return fmt.Errorf("data section %s: contents exceed maximum size", sec.Name)
 		}


### PR DESCRIPTION
In commit 82c5aca ("elf: include data sections without references in CollectionSpec"), the sec.references check at the start of *elfCode.loadDataSections was removed to enable generating VariableSpecs for sections without references due to them being potentially compiled out.

After merging this patch, we received an early user complaint about a .rodata.str1.1 map suddenly popping up and being loaded on a non-supported kernel, whereas the same ELF worked fine before.

This patch reintroduces the behaviour with an extra condition: the datasec must have both no references and no symbols, meaning it can't be meaningfully represented in a CollectionSpec, since it would be freed immediately after closing the resulting Collection. String sections typically don't have any associated symbols nor a BTF datasec since they're just opaque storage, so we can't generate VariableSpecs from them either.

In conclusion, these are safe to drop.