### PR TITLE
map: automatically set CPUMap MaxEntries based on possible CPUs

### DIFF
--- a/map.go
+++ b/map.go
@@ -158,6 +158,17 @@ func (spec *MapSpec) fixupMagicFields() (*MapSpec, error) {
 			// behaviour in the past.
 			spec.MaxEntries = n
 		}
+
+	case CPUMap:
+		n, err := PossibleCPU()
+		if err != nil {
+			return nil, fmt.Errorf("fixup cpu map: %w", err)
+		}
+
+		if n := uint32(n); spec.MaxEntries == 0 || spec.MaxEntries > n {
+			// Perform clamping similar to PerfEventArray.
+			spec.MaxEntries = n
+		}
 	}
 
 	return spec, nil

--- a/map_test.go
+++ b/map_test.go
@@ -981,6 +981,15 @@ func TestPerfEventArray(t *testing.T) {
 	}
 }
 
+func TestCPUMap(t *testing.T) {
+	testutils.SkipOnOldKernel(t, "4.15", "cpu map")
+
+	m, err := NewMap(&MapSpec{Type: CPUMap, KeySize: 4, ValueSize: 4})
+	qt.Assert(t, qt.IsNil(err))
+	qt.Assert(t, qt.Equals(m.MaxEntries(), uint32(MustPossibleCPU())))
+	m.Close()
+}
+
 func createMapInMap(t *testing.T, typ MapType) *Map {
 	t.Helper()
 


### PR DESCRIPTION
This commit modifies the `MapSpec.fixupMagicFields` method to support the following for the CPU map:

  * Validation of KeySize and ValueSize
  * Setting KeySize, ValueSize and MaxEntries when set to zero
  * Clamping MaxEntries to the number of possible CPUs

This enables to write more portable code when utilizing the CPU map, since kernel-specific and node-specific arguments no longer have to be supplied at compile-time.