### PR TITLE
prog: fix shadowing log size variable in verifier log retry loop

### DIFF
--- a/prog.go
+++ b/prog.go
@@ -451,7 +451,7 @@ func newProgramWithOptions(spec *ProgramSpec, opts ProgramOptions) (*Program, er
 		// Make an educated guess how large the buffer should be by multiplying.
 		// Ensure the size doesn't overflow.
 		const factor = 2
-		logSize := internal.Between(logSize, minVerifierLogSize, maxVerifierLogSize/factor)
+		logSize = internal.Between(logSize, minVerifierLogSize, maxVerifierLogSize/factor)
 		logSize *= factor
 
 		if attr.LogTrueSize != 0 {


### PR DESCRIPTION
When ProgramOptions.LogSize was removed in 0.16, the tests weren't updated to exercise the retry loop, since a minimum log size was chosen that was larger than what the test program could generate.

With the addition of LogSizeStart, this notoriously fragile code broke when logSize was again tracked as a separate variable, while being accidentally shadowed within the scope of the for loop. This resulted in an endless loop on kernels without the LogTrueSize field.

Remove the shadowing and fix the tests.