### PR TITLE
bpf2go: ergonomic enums

### DIFF
--- a/cmd/bpf2go/gen/output.go
+++ b/cmd/bpf2go/gen/output.go
@@ -173,6 +173,17 @@ func Generate(args GenerateArgs) error {
 	gf := &btf.GoFormatter{
 		Names:      nameByType,
 		Identifier: args.Identifier,
+		ShortEnumIdentifier: func(_, element string) string {
+			elementName := args.Stem + args.Identifier(element)
+			if _, nameTaken := typeByName[elementName]; nameTaken {
+				return ""
+			}
+			if _, nameReserved := reservedNames[elementName]; nameReserved {
+				return ""
+			}
+			reservedNames[elementName] = struct{}{}
+			return elementName
+		},
 	}
 
 	ctx := struct {
@@ -201,7 +212,7 @@ func Generate(args GenerateArgs) error {
 
 	var buf bytes.Buffer
 	if err := commonTemplate.Execute(&buf, &ctx); err != nil {
-		return fmt.Errorf("can't generate types: %s", err)
+		return fmt.Errorf("can't generate types: %v", err)
 	}
 
 	return internal.WriteFormatted(buf.Bytes(), args.Output)

--- a/cmd/bpf2go/gen/output.tpl
+++ b/cmd/bpf2go/gen/output.tpl
@@ -13,8 +13,8 @@ import (
 )
 
 {{- if .Types }}
-{{- range $type := .Types }}
-{{ $.TypeDeclaration (index $.TypeNames $type) $type }}
+{{- range $name, $type := .Types }}
+{{ $.TypeDeclaration $name $type }}
 
 {{ end }}
 {{- end }}

--- a/cmd/bpf2go/gen/output_test.go
+++ b/cmd/bpf2go/gen/output_test.go
@@ -8,61 +8,8 @@ import (
 
 	"github.com/go-quicktest/qt"
 
-	"github.com/cilium/ebpf/btf"
 	"github.com/cilium/ebpf/cmd/bpf2go/internal"
 )
-
-func TestOrderTypes(t *testing.T) {
-	a := &btf.Int{}
-	b := &btf.Int{}
-	c := &btf.Int{}
-
-	for _, test := range []struct {
-		name string
-		in   map[btf.Type]string
-		out  []btf.Type
-	}{
-		{
-			"order",
-			map[btf.Type]string{
-				a: "foo",
-				b: "bar",
-				c: "baz",
-			},
-			[]btf.Type{b, c, a},
-		},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			result, err := sortTypes(test.in)
-			qt.Assert(t, qt.IsNil(err))
-			qt.Assert(t, qt.Equals(len(result), len(test.out)))
-			for i, o := range test.out {
-				if result[i] != o {
-					t.Fatalf("Index %d: expected %p got %p", i, o, result[i])
-				}
-			}
-		})
-	}
-
-	for _, test := range []struct {
-		name string
-		in   map[btf.Type]string
-	}{
-		{
-			"duplicate names",
-			map[btf.Type]string{
-				a: "foo",
-				b: "foo",
-			},
-		},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			result, err := sortTypes(test.in)
-			qt.Assert(t, qt.IsNotNil(err))
-			qt.Assert(t, qt.IsNil(result))
-		})
-	}
-}
 
 func TestPackageImport(t *testing.T) {
 	var buf bytes.Buffer

--- a/cmd/bpf2go/test/test_bpfeb.go
+++ b/cmd/bpf2go/test/test_bpfeb.go
@@ -30,7 +30,9 @@ type testBaz struct{ A uint64 }
 type testE uint32
 
 const (
+	testHOOPY  testE = 0
 	testEHOOPY testE = 0
+	testFROOD  testE = 1
 	testEFROOD testE = 1
 )
 

--- a/cmd/bpf2go/test/test_bpfel.go
+++ b/cmd/bpf2go/test/test_bpfel.go
@@ -30,7 +30,9 @@ type testBaz struct{ A uint64 }
 type testE uint32
 
 const (
+	testHOOPY  testE = 0
 	testEHOOPY testE = 0
+	testFROOD  testE = 1
 	testEFROOD testE = 1
 )
 


### PR DESCRIPTION
Constant names emitted for enum elements end up quite unwieldy. They are
    prefixed with enum name because in C struct, union and enum names are in
    a separate namespace, allowing for overlaps with identifiers, e.g:

    enum E { E };

While such overlaps are possible in *theory*, people usually don't do
    it. If a typicall C naming convention is followed, we get

    enum something {
        SOMETHING_FOO, SOMETHING_BAR
    };

 generating `<STEM>SomethingSOMETHING_FOO` and `<STEM>SomethingSOMETHING_BAR`.

In addition to "safe" long names, generate shorter ones if the
    respective name is not taken. `<STEM>SOMETHING_FOO` and
    `<STEM>SOMETHING_BAR` are much nicer to work with.