### PR TITLE
map: check MapReplacements compatibility after applying BPF_F_MMAPABLE

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -411,14 +411,9 @@ func newCollectionLoader(coll *CollectionSpec, opts *CollectionOptions) (*collec
 	}
 
 	// Check for existing MapSpecs in the CollectionSpec for all provided replacement maps.
-	for name, m := range opts.MapReplacements {
-		spec, ok := coll.Maps[name]
-		if !ok {
+	for name := range opts.MapReplacements {
+		if _, ok := coll.Maps[name]; !ok {
 			return nil, fmt.Errorf("replacement map %s not found in CollectionSpec", name)
-		}
-
-		if err := spec.Compatible(m); err != nil {
-			return nil, fmt.Errorf("using replacement map %s: %w", spec.Name, err)
 		}
 	}
 
@@ -494,7 +489,22 @@ func (cl *collectionLoader) loadMap(mapName string) (*Map, error) {
 		return nil, fmt.Errorf("missing map %s", mapName)
 	}
 
+	mapSpec = mapSpec.Copy()
+
+	// Defer setting the mmapable flag on maps until load time. This avoids the
+	// MapSpec having different flags on some kernel versions. Also avoid running
+	// syscalls during ELF loading, so platforms like wasm can also parse an ELF.
+	if isDataSection(mapSpec.Name) && haveMmapableMaps() == nil {
+		mapSpec.Flags |= sys.BPF_F_MMAPABLE
+	}
+
 	if replaceMap, ok := cl.opts.MapReplacements[mapName]; ok {
+		// Check compatibility with the replacement map after setting
+		// feature-dependent map flags.
+		if err := mapSpec.Compatible(replaceMap); err != nil {
+			return nil, fmt.Errorf("using replacement map %s: %w", mapSpec.Name, err)
+		}
+
 		// Clone the map to avoid closing user's map later on.
 		m, err := replaceMap.Clone()
 		if err != nil {
@@ -503,13 +513,6 @@ func (cl *collectionLoader) loadMap(mapName string) (*Map, error) {
 
 		cl.maps[mapName] = m
 		return m, nil
-	}
-
-	// Defer setting the mmapable flag on maps until load time. This avoids the
-	// MapSpec having different flags on some kernel versions. Also avoid running
-	// syscalls during ELF loading, so platforms like wasm can also parse an ELF.
-	if isDataSection(mapSpec.Name) && haveMmapableMaps() == nil {
-		mapSpec.Flags |= sys.BPF_F_MMAPABLE
 	}
 
 	m, err := newMapWithOptions(mapSpec, cl.opts.Maps)


### PR DESCRIPTION
There were 2 problems with the existing implementation:
- cl.loadMap would mutate the original MapSpec before loading
- map compatibility was checked before cl.loadMap applied the BPF_F_MMAPABLE flag

To address this, the following changes were made:
- MapSpec.Copy() is called in loadMap, to follow suit with cl.loadProgram
- the compatibility check on MapReplacements was deferred to loadMap, after flags are mutated
- Added a superficial CollectionSpec mutation test after loading, using the same logic as TestLoadCollectionSpec. testutils.IsDeepCopy() isn't usable here since MapSpec.Copy() doesn't deepcopy .Contents.
- Added a regression test on using .data and .rodata in MapReplacements

Fixes issues seen in https://github.com/cilium/pwru/pull/484. cc @brb @Asphaltt 