### PR TITLE
btf: read all line info records at once in `parseLineInfoRecords`

### DIFF
--- a/btf/ext_info.go
+++ b/btf/ext_info.go
@@ -666,20 +666,19 @@ func parseLineInfos(r io.Reader, bo binary.ByteOrder, strings *stringTable) (map
 // These records appear after a btf_ext_info_sec header in the line_info
 // sub-section of .BTF.ext.
 func parseLineInfoRecords(r io.Reader, bo binary.ByteOrder, recordSize uint32, recordNum uint32, offsetInBytes bool) ([]bpfLineInfo, error) {
-	var li bpfLineInfo
-
-	if exp, got := uint32(binary.Size(li)), recordSize; exp != got {
+	if exp, got := uint32(binary.Size(bpfLineInfo{})), recordSize; exp != got {
 		// BTF blob's record size is longer than we know how to parse.
 		return nil, fmt.Errorf("expected LineInfo record size %d, but BTF blob contains %d", exp, got)
 	}
 
-	out := make([]bpfLineInfo, 0, recordNum)
-	for i := uint32(0); i < recordNum; i++ {
-		if err := binary.Read(r, bo, &li); err != nil {
-			return nil, fmt.Errorf("can't read line info: %v", err)
-		}
+	out := make([]bpfLineInfo, recordNum)
+	if err := binary.Read(r, bo, out); err != nil {
+		return nil, fmt.Errorf("can't read line info: %v", err)
+	}
 
-		if offsetInBytes {
+	if offsetInBytes {
+		for i := range out {
+			li := &out[i]
 			if li.InsnOff%asm.InstructionSize != 0 {
 				return nil, fmt.Errorf("offset %v is not aligned with instruction size", li.InsnOff)
 			}
@@ -688,8 +687,6 @@ func parseLineInfoRecords(r io.Reader, bo binary.ByteOrder, recordSize uint32, r
 			// Convert as early as possible.
 			li.InsnOff /= asm.InstructionSize
 		}
-
-		out = append(out, li)
 	}
 
 	return out, nil

--- a/btf/ext_info_test.go
+++ b/btf/ext_info_test.go
@@ -2,6 +2,7 @@ package btf
 
 import (
 	"bytes"
+	"encoding/binary"
 	"strings"
 	"testing"
 
@@ -21,5 +22,18 @@ func TestParseExtInfoBigRecordSize(t *testing.T) {
 
 	if _, err := parseLineInfos(rd, internal.NativeEndian, table); err == nil {
 		t.Error("Parsing line info with large record size doesn't return an error")
+	}
+}
+
+func BenchmarkParseLineInfoRecords(b *testing.B) {
+	size := uint32(binary.Size(bpfLineInfo{}))
+	count := uint32(4096)
+	buf := make([]byte, size*count)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		parseLineInfoRecords(bytes.NewReader(buf), internal.NativeEndian, size, count, true)
 	}
 }


### PR DESCRIPTION
When parsing line info records, we currently iterate and call `binary.Read` once per line info record. This is quite inefficient and `binary.Read` already supports out of the box being called directly on a slice and reading multiple structures at once. This is exactly what this PR does.

Benchmark:
```
                        │   old.txt   │               new.txt               │
                        │   sec/op    │   sec/op     vs base                │
ParseLineInfoRecords-10   288.6µ ± 3%   141.3µ ± 4%  -51.02% (p=0.000 n=10)

                        │   old.txt    │            new.txt             │
                        │     B/op     │     B/op      vs base          │
ParseLineInfoRecords-10   128.0Ki ± 0%   128.0Ki ± 0%  ~ (p=1.000 n=10)

                        │    old.txt    │              new.txt               │
                        │   allocs/op   │ allocs/op   vs base                │
ParseLineInfoRecords-10   4098.000 ± 0%   3.000 ± 0%  -99.93% (p=0.000 n=10)
```