### PR TITLE
internal/linux: use `unix.Auxv`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/go-quicktest/qt v1.101.0
 	github.com/google/go-cmp v0.6.0
 	github.com/jsimonetti/rtnetlink/v2 v2.0.1
-	golang.org/x/sys v0.28.0
+	golang.org/x/sys v0.30.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -23,5 +23,5 @@ golang.org/x/net v0.33.0 h1:74SYHlV8BIgHIFC/LrYkOGIwL19eTYXQ5wc6TBuO36I=
 golang.org/x/net v0.33.0/go.mod h1:HXLR5J+9DxmrqMwG9qjGCxZ+zKXxBru04zlTvWlWuN4=
 golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
 golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sys v0.28.0 h1:Fksou7UEQUWlKvIdsqzJmUmCX3cZuD2+P3XyyzwMhlA=
-golang.org/x/sys v0.28.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.30.0 h1:QjkSwP/36a20jFYWkSue1YwXzLmsV5Gfq7Eiy72C1uc=
+golang.org/x/sys v0.30.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/internal/linux/auxv.go
+++ b/internal/linux/auxv.go
@@ -1,12 +1,11 @@
 package linux
 
 import (
-	"errors"
 	"fmt"
 	"io"
-	_ "unsafe"
 
 	"github.com/cilium/ebpf/internal"
+	"github.com/cilium/ebpf/internal/unix"
 )
 
 type auxvPairReader interface {
@@ -20,11 +19,8 @@ const (
 	_AT_SYSINFO_EHDR = 33 // Offset to vDSO blob in process image
 )
 
-//go:linkname runtime_getAuxv runtime.getAuxv
-func runtime_getAuxv() []uintptr
-
 type auxvRuntimeReader struct {
-	data  []uintptr
+	data  [][2]uintptr
 	index int
 }
 
@@ -40,12 +36,12 @@ func (r *auxvRuntimeReader) ReadAuxvPair() (uint64, uint64, error) {
 	// we manually add the (_AT_NULL, _AT_NULL) pair at the end
 	// that is not provided by the go runtime
 	var tag, value uintptr
-	if r.index+1 < len(r.data) {
-		tag, value = r.data[r.index], r.data[r.index+1]
+	if r.index < len(r.data) {
+		tag, value = r.data[r.index][0], r.data[r.index][1]
 	} else {
 		tag, value = _AT_NULL, _AT_NULL
 	}
-	r.index += 2
+	r.index += 1
 	return uint64(tag), uint64(value), nil
 }
 
@@ -54,10 +50,9 @@ func newAuxvRuntimeReader() (auxvPairReader, error) {
 		return nil, fmt.Errorf("read auxv from runtime: %w", internal.ErrNotSupportedOnOS)
 	}
 
-	data := runtime_getAuxv()
-
-	if len(data)%2 != 0 {
-		return nil, errors.New("malformed auxv passed from runtime")
+	data, err := unix.Auxv()
+	if err != nil {
+		return nil, fmt.Errorf("read auxv from runtime: %w", err)
 	}
 
 	return &auxvRuntimeReader{

--- a/internal/unix/types_linux.go
+++ b/internal/unix/types_linux.go
@@ -195,3 +195,7 @@ func SchedSetaffinity(pid int, set *CPUSet) error {
 func SchedGetaffinity(pid int, set *CPUSet) error {
 	return linux.SchedGetaffinity(pid, set)
 }
+
+func Auxv() ([][2]uintptr, error) {
+	return linux.Auxv()
+}

--- a/internal/unix/types_other.go
+++ b/internal/unix/types_other.go
@@ -278,3 +278,7 @@ func SchedSetaffinity(pid int, set *CPUSet) error {
 func SchedGetaffinity(pid int, set *CPUSet) error {
 	return errNonLinux()
 }
+
+func Auxv() ([][2]uintptr, error) {
+	return nil, errNonLinux()
+}


### PR DESCRIPTION
Use the newly added `Auxv` wrapper added in `golang.org/x/sys/unix` v0.30.0 instead of manually go:linknaming `runtime.getAuxv`. This also allows to get rid of the check for malformed auxv data as it is already performed by `unix.Auxv`.