### PR TITLE
Replace internal.NativeEndian with stdlib (1/2)

### DIFF
--- a/asm/instruction.go
+++ b/asm/instruction.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/cilium/ebpf/internal"
 	"github.com/cilium/ebpf/internal/sys"
 )
 
@@ -51,7 +52,7 @@ func (ins *Instruction) Unmarshal(r io.Reader, bo binary.ByteOrder) (uint64, err
 	ins.OpCode = OpCode(data[0])
 
 	regs := data[1]
-	switch bo {
+	switch internal.NormalizeByteOrder(bo) {
 	case binary.LittleEndian:
 		ins.Dst, ins.Src = Register(regs&0xF), Register(regs>>4)
 	case binary.BigEndian:
@@ -934,7 +935,7 @@ func (iter *InstructionIterator) Next() bool {
 type bpfRegisters uint8
 
 func newBPFRegisters(dst, src Register, bo binary.ByteOrder) (bpfRegisters, error) {
-	switch bo {
+	switch internal.NormalizeByteOrder(bo) {
 	case binary.LittleEndian:
 		return bpfRegisters((src << 4) | (dst & 0xF)), nil
 	case binary.BigEndian:

--- a/btf/core.go
+++ b/btf/core.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/cilium/ebpf/asm"
+	"github.com/cilium/ebpf/internal"
 )
 
 // Code in this file is derived from libbpf, which is available under a BSD
@@ -205,8 +206,10 @@ func CORERelocate(relos []*CORERelocation, targets []*Spec, bo binary.ByteOrder,
 	resolveTargetTypeID := targets[0].TypeID
 
 	for _, target := range targets {
-		if bo != target.imm.byteOrder {
-			return nil, fmt.Errorf("can't relocate %s against %s", bo, target.imm.byteOrder)
+		if !internal.EqualByteOrder(bo, target.imm.byteOrder) {
+			return nil, fmt.Errorf("can't relocate %s against %s",
+				internal.NormalizeByteOrder(bo),
+				internal.NormalizeByteOrder(target.imm.byteOrder))
 		}
 	}
 
@@ -488,7 +491,7 @@ func coreCalculateFixup(relo *CORERelocation, target Type, bo binary.ByteOrder, 
 
 		case reloFieldLShiftU64:
 			var target uint64
-			if bo == binary.LittleEndian {
+			if internal.EqualByteOrder(bo, binary.LittleEndian) {
 				targetSize, err := targetField.sizeBits()
 				if err != nil {
 					return zero, err

--- a/elf_reader_test.go
+++ b/elf_reader_test.go
@@ -254,7 +254,7 @@ func TestLoadCollectionSpec(t *testing.T) {
 			t.Errorf("MapSpec mismatch (-want +got):\n%s", diff)
 		}
 
-		if have.ByteOrder != internal.NativeEndian {
+		if !internal.EqualByteOrder(have.ByteOrder, binary.NativeEndian) {
 			return
 		}
 
@@ -445,7 +445,7 @@ func TestLoadInitializedBTFMap(t *testing.T) {
 		}
 
 		t.Run("NewCollection", func(t *testing.T) {
-			if coll.ByteOrder != internal.NativeEndian {
+			if !internal.EqualByteOrder(coll.ByteOrder, binary.NativeEndian) {
 				t.Skipf("Skipping %s collection", coll.ByteOrder)
 			}
 

--- a/internal/endian.go
+++ b/internal/endian.go
@@ -1,0 +1,25 @@
+package internal
+
+import (
+	"encoding/binary"
+
+	"golang.org/x/sys/cpu"
+)
+
+var NativeEndian = binary.NativeEndian
+
+func EqualByteOrder(bo1, bo2 binary.ByteOrder) bool {
+	return NormalizeByteOrder(bo1) == NormalizeByteOrder(bo2)
+}
+
+// NormalizeByteOrder replaces binary.NativeEndian with the underlying
+// byte order (BigEndian or LittleEndian).
+func NormalizeByteOrder(bo binary.ByteOrder) binary.ByteOrder {
+	if bo != binary.NativeEndian {
+		return bo
+	}
+	if cpu.IsBigEndian {
+		return binary.BigEndian
+	}
+	return binary.LittleEndian
+}

--- a/internal/endian_be.go
+++ b/internal/endian_be.go
@@ -1,9 +1,0 @@
-//go:build armbe || arm64be || mips || mips64 || mips64p32 || ppc64 || s390 || s390x || sparc || sparc64
-
-package internal
-
-import "encoding/binary"
-
-// NativeEndian is set to either binary.BigEndian or binary.LittleEndian,
-// depending on the host's endianness.
-var NativeEndian = binary.BigEndian

--- a/internal/endian_le.go
+++ b/internal/endian_le.go
@@ -1,9 +1,0 @@
-//go:build 386 || amd64 || amd64p32 || arm || arm64 || loong64 || mipsle || mips64le || mips64p32le || ppc64le || riscv64
-
-package internal
-
-import "encoding/binary"
-
-// NativeEndian is set to either binary.BigEndian or binary.LittleEndian,
-// depending on the host's endianness.
-var NativeEndian = binary.LittleEndian

--- a/prog.go
+++ b/prog.go
@@ -263,8 +263,10 @@ func newProgramWithOptions(spec *ProgramSpec, opts ProgramOptions) (*Program, er
 		return nil, errors.New("can't load program of unspecified type")
 	}
 
-	if spec.ByteOrder != nil && spec.ByteOrder != internal.NativeEndian {
-		return nil, fmt.Errorf("can't load %s program on %s", spec.ByteOrder, internal.NativeEndian)
+	if spec.ByteOrder != nil && !internal.EqualByteOrder(spec.ByteOrder, binary.NativeEndian) {
+		return nil, fmt.Errorf("can't load %s program on %s",
+			internal.NormalizeByteOrder(spec.ByteOrder),
+			internal.NormalizeByteOrder(binary.NativeEndian))
 	}
 
 	// Kernels before 5.0 (6c4fc209fcf9 "bpf: remove useless version check for prog load")

--- a/prog_test.go
+++ b/prog_test.go
@@ -726,7 +726,7 @@ func TestProgramRejectIncorrectByteOrder(t *testing.T) {
 	spec := socketFilterSpec.Copy()
 
 	spec.ByteOrder = binary.BigEndian
-	if spec.ByteOrder == internal.NativeEndian {
+	if internal.EqualByteOrder(spec.ByteOrder, binary.NativeEndian) {
 		spec.ByteOrder = binary.LittleEndian
 	}
 


### PR DESCRIPTION
 ~~Yet another attempt at replacing `internal.NativeEndian` with `NativeEndian` from `"encoding/binary"`. The conversion is mostly a straight-forward replacement. The only challenge are checks whether a ByteOrder is Big/Little/NativeEndian. In stdlib, NativeEndian is a distinct type hence never compares equal to BigEndian or LittleEndian.~~

~~Introduce `internal.EqualByteOrder(bo1, bo2)`. It works by passing `[]byte{0x12, 0x34}` through `bo1.Uint16()` and `bo2.Uint16()` and comparing the results.~~

### Update 07 Feb

Stdlib introduced binary.NativeEndian. Implications are two fold:

 1. The library performs explicit byteorder checks at several occasions. It is not prepared to handle binary.NativeEndian should a library user decide to pass it.

 2. internal.NativeEndian might become unnecessary.

The challenge with binary.NativeEndian is that it is a distinct type, hence never comapres equal to binary.LittleEndian or binary.BigEndian (unlike internal.NativeEndian).

Introduce internal.EqualByteOrder() for byte order comparison. The function replaces instances of binary.NativeEndian with the underlying byte order prior to comparison.

Review byte order checks in the library and rewrite using internal.EqualByteOrder(). Eliminate byte order checks when possible.

Keep internal.NativeEndian, but make it an alias for binary.NativeEndian. This is done to reduce the size of the change set.