### PR TITLE
ci: add test run with race detector

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,47 @@ jobs:
           name: Test Results (previous stable Go)
           path: junit.xml
 
+  test-race:
+    name: Run tests with race detector
+    runs-on: ubuntu-latest
+    needs: build-and-lint
+    timeout-minutes: 15
+    env:
+      CI_KERNEL_SELFTESTS: '/usr/src/linux/tools/testing/selftests/bpf'
+      CGO_ENABLED: '1' # CGo is required by `-race`
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '${{ env.go_version }}'
+
+      - run: go install gotest.tools/gotestsum@v1.12.0
+
+      - name: Test
+        env:
+          GOTRACEBACK: crash
+        run: |
+          gotestsum --ignore-non-json-output-lines --junitfile junit.xml -- -exec 'sudo -E' -timeout 5m -short -race -count 1 -json ./...
+
+      - name: Upload coredumps
+        uses: actions/upload-artifact@v4
+        if: ${{ failure() }}
+        with:
+          name: cores
+          if-no-files-found: ignore
+          path: |
+            **/core-*
+            **/*.test
+
+      - name: Upload Test Results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: Test Results (previous stable Go)
+          path: junit.xml
+
   test-on-arm64:
     name: Run tests on arm64
     runs-on: ubuntu-22.04-arm64


### PR DESCRIPTION
As discussed in https://github.com/cilium/ebpf/pull/1673, this PR adds a test run with the race detector enabled.

In the thread it was discussed to re-use the "previous go version" run and to add `-race` to it, but it's not possible because the race detector requires CGo, this makes the test binary not static anymore, and vimto is having a hard time running it.

This PR choses the easy path and just creates a new test run closer to the arm64 one (no vimto) 