### PR TITLE
ebpf: implement PossibleCPU on Windows

### DIFF
--- a/cpu.go
+++ b/cpu.go
@@ -1,16 +1,5 @@
 package ebpf
 
-import (
-	"fmt"
-	"os"
-	"strings"
-	"sync"
-)
-
-var possibleCPU = sync.OnceValues(func() (int, error) {
-	return parseCPUsFromFile("/sys/devices/system/cpu/possible")
-})
-
 // PossibleCPU returns the max number of CPUs a system may possibly have
 // Logical CPU numbers must be of the form 0-n
 func PossibleCPU() (int, error) {
@@ -25,42 +14,4 @@ func MustPossibleCPU() int {
 		panic(err)
 	}
 	return cpus
-}
-
-func parseCPUsFromFile(path string) (int, error) {
-	spec, err := os.ReadFile(path)
-	if err != nil {
-		return 0, err
-	}
-
-	n, err := parseCPUs(string(spec))
-	if err != nil {
-		return 0, fmt.Errorf("can't parse %s: %v", path, err)
-	}
-
-	return n, nil
-}
-
-// parseCPUs parses the number of cpus from a string produced
-// by bitmap_list_string() in the Linux kernel.
-// Multiple ranges are rejected, since they can't be unified
-// into a single number.
-// This is the format of /sys/devices/system/cpu/possible, it
-// is not suitable for /sys/devices/system/cpu/online, etc.
-func parseCPUs(spec string) (int, error) {
-	if strings.Trim(spec, "\n") == "0" {
-		return 1, nil
-	}
-
-	var low, high int
-	n, err := fmt.Sscanf(spec, "%d-%d\n", &low, &high)
-	if n != 2 || err != nil {
-		return 0, fmt.Errorf("invalid format: %s", spec)
-	}
-	if low != 0 {
-		return 0, fmt.Errorf("CPU spec doesn't start at zero: %s", spec)
-	}
-
-	// cpus is 0 indexed
-	return high + 1, nil
 }

--- a/cpu_other.go
+++ b/cpu_other.go
@@ -1,0 +1,13 @@
+//go:build !windows
+
+package ebpf
+
+import (
+	"sync"
+
+	"github.com/cilium/ebpf/internal/linux"
+)
+
+var possibleCPU = sync.OnceValues(func() (int, error) {
+	return linux.ParseCPUsFromFile("/sys/devices/system/cpu/possible")
+})

--- a/cpu_test.go
+++ b/cpu_test.go
@@ -2,31 +2,12 @@ package ebpf
 
 import (
 	"testing"
+
+	"github.com/go-quicktest/qt"
 )
 
-func TestParseCPUs(t *testing.T) {
-	for str, result := range map[string]int{
-		"0-1":   2,
-		"0-2\n": 3,
-		"0":     1,
-	} {
-		n, err := parseCPUs(str)
-		if err != nil {
-			t.Errorf("Can't parse `%s`: %v", str, err)
-		} else if n != result {
-			t.Error("Parsing", str, "returns", n, "instead of", result)
-		}
-	}
-
-	for _, str := range []string{
-		"0,3-4",
-		"0-",
-		"1,",
-		"",
-	} {
-		_, err := parseCPUs(str)
-		if err == nil {
-			t.Error("Parsed invalid format:", str)
-		}
-	}
+func TestPossibleCPU(t *testing.T) {
+	num, err := PossibleCPU()
+	qt.Assert(t, qt.IsNil(err))
+	qt.Assert(t, qt.IsTrue(num > 0))
 }

--- a/cpu_windows.go
+++ b/cpu_windows.go
@@ -1,0 +1,11 @@
+package ebpf
+
+import (
+	"sync"
+
+	"golang.org/x/sys/windows"
+)
+
+var possibleCPU = sync.OnceValues(func() (int, error) {
+	return int(windows.GetMaximumProcessorCount(windows.ALL_PROCESSOR_GROUPS)), nil
+})

--- a/internal/linux/cpu.go
+++ b/internal/linux/cpu.go
@@ -1,0 +1,45 @@
+package linux
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+func ParseCPUsFromFile(path string) (int, error) {
+	spec, err := os.ReadFile(path)
+	if err != nil {
+		return 0, err
+	}
+
+	n, err := parseCPUs(string(spec))
+	if err != nil {
+		return 0, fmt.Errorf("can't parse %s: %v", path, err)
+	}
+
+	return n, nil
+}
+
+// parseCPUs parses the number of cpus from a string produced
+// by bitmap_list_string() in the Linux kernel.
+// Multiple ranges are rejected, since they can't be unified
+// into a single number.
+// This is the format of /sys/devices/system/cpu/possible, it
+// is not suitable for /sys/devices/system/cpu/online, etc.
+func parseCPUs(spec string) (int, error) {
+	if strings.Trim(spec, "\n") == "0" {
+		return 1, nil
+	}
+
+	var low, high int
+	n, err := fmt.Sscanf(spec, "%d-%d\n", &low, &high)
+	if n != 2 || err != nil {
+		return 0, fmt.Errorf("invalid format: %s", spec)
+	}
+	if low != 0 {
+		return 0, fmt.Errorf("CPU spec doesn't start at zero: %s", spec)
+	}
+
+	// cpus is 0 indexed
+	return high + 1, nil
+}

--- a/internal/linux/cpu_test.go
+++ b/internal/linux/cpu_test.go
@@ -1,0 +1,32 @@
+package linux
+
+import (
+	"testing"
+)
+
+func TestParseCPUs(t *testing.T) {
+	for str, result := range map[string]int{
+		"0-1":   2,
+		"0-2\n": 3,
+		"0":     1,
+	} {
+		n, err := parseCPUs(str)
+		if err != nil {
+			t.Errorf("Can't parse `%s`: %v", str, err)
+		} else if n != result {
+			t.Error("Parsing", str, "returns", n, "instead of", result)
+		}
+	}
+
+	for _, str := range []string{
+		"0,3-4",
+		"0-",
+		"1,",
+		"",
+	} {
+		_, err := parseCPUs(str)
+		if err == nil {
+			t.Error("Parsed invalid format:", str)
+		}
+	}
+}


### PR DESCRIPTION
Move the Linux implementation into internal/linux and add a wrapper around the Windows GetMaximumProcessorCount function.