### PR TITLE
allow verifier log size to reach max to prevent infinite loop

### DIFF
--- a/prog.go
+++ b/prog.go
@@ -450,9 +450,7 @@ func newProgramWithOptions(spec *ProgramSpec, opts ProgramOptions) (*Program, er
 
 		// Make an educated guess how large the buffer should be by multiplying.
 		// Ensure the size doesn't overflow.
-		const factor = 2
-		logSize = internal.Between(logSize, minVerifierLogSize, maxVerifierLogSize/factor)
-		logSize *= factor
+		logSize = internal.Between(logSize*2, minVerifierLogSize, maxVerifierLogSize)
 
 		if attr.LogTrueSize != 0 {
 			// The kernel has given us a hint how large the log buffer has to be.


### PR DESCRIPTION
In the case of:
- needing the max verifier log size
- kernel does not support `log_true_size` yet

https://github.com/cilium/ebpf/blob/29fedc5e2401a1edb9cb89753aaa72592ea0996e/prog.go#L453-L455

maxVerifierLogSize is `1073741823`, so integer divided by 2 = `536870911`. Multiplying by 2 equals `1073741822`. Thus we never reach `maxVerifierLogSize` in the loop. The kernel keeps returning `ENOSPC` but the size never changes and you get an infinite loop.