### PR TITLE
sys: hint that structs require host layout

### DIFF
--- a/internal/cmd/gentypes/main.go
+++ b/internal/cmd/gentypes/main.go
@@ -98,6 +98,7 @@ package sys
 
 import (
 	"unsafe"
+	"structs"
 )
 
 `)
@@ -757,6 +758,8 @@ func outputPatchedStruct(gf *btf.GoFormatter, w *bytes.Buffer, id string, s *btf
 	if err != nil {
 		return err
 	}
+
+	decl = strings.Replace(decl, "struct {", "struct { structs.HostLayout;", 1)
 
 	w.WriteString(decl)
 	w.WriteString("\n\n")

--- a/internal/sys/ptr_32_be.go
+++ b/internal/sys/ptr_32_be.go
@@ -3,12 +3,14 @@
 package sys
 
 import (
+	"structs"
 	"unsafe"
 )
 
 // Pointer wraps an unsafe.Pointer to be 64bit to
 // conform to the syscall specification.
 type Pointer struct {
+	structs.HostLayout
 	pad uint32
 	ptr unsafe.Pointer
 }

--- a/internal/sys/ptr_32_le.go
+++ b/internal/sys/ptr_32_le.go
@@ -3,12 +3,14 @@
 package sys
 
 import (
+	"structs"
 	"unsafe"
 )
 
 // Pointer wraps an unsafe.Pointer to be 64bit to
 // conform to the syscall specification.
 type Pointer struct {
+	structs.HostLayout
 	ptr unsafe.Pointer
 	pad uint32
 }

--- a/internal/sys/ptr_64.go
+++ b/internal/sys/ptr_64.go
@@ -3,11 +3,13 @@
 package sys
 
 import (
+	"structs"
 	"unsafe"
 )
 
 // Pointer wraps an unsafe.Pointer to be 64bit to
 // conform to the syscall specification.
 type Pointer struct {
+	structs.HostLayout
 	ptr unsafe.Pointer
 }

--- a/internal/sys/types.go
+++ b/internal/sys/types.go
@@ -3,6 +3,7 @@
 package sys
 
 import (
+	"structs"
 	"unsafe"
 )
 
@@ -689,6 +690,7 @@ const (
 )
 
 type BtfInfo struct {
+	structs.HostLayout
 	Btf       Pointer
 	BtfSize   uint32
 	Id        BTFID
@@ -698,11 +700,13 @@ type BtfInfo struct {
 }
 
 type FuncInfo struct {
+	structs.HostLayout
 	InsnOff uint32
 	TypeId  uint32
 }
 
 type LineInfo struct {
+	structs.HostLayout
 	InsnOff     uint32
 	FileNameOff uint32
 	LineOff     uint32
@@ -710,6 +714,7 @@ type LineInfo struct {
 }
 
 type LinkInfo struct {
+	structs.HostLayout
 	Type   LinkType
 	Id     LinkID
 	ProgId uint32
@@ -718,6 +723,7 @@ type LinkInfo struct {
 }
 
 type MapInfo struct {
+	structs.HostLayout
 	Type                  uint32
 	Id                    uint32
 	KeySize               uint32
@@ -737,6 +743,7 @@ type MapInfo struct {
 }
 
 type ProgInfo struct {
+	structs.HostLayout
 	Type                 uint32
 	Id                   uint32
 	Tag                  [8]uint8
@@ -779,6 +786,7 @@ type ProgInfo struct {
 }
 
 type SkLookup struct {
+	structs.HostLayout
 	Cookie         uint64
 	Family         uint32
 	Protocol       uint32
@@ -794,6 +802,7 @@ type SkLookup struct {
 }
 
 type XdpMd struct {
+	structs.HostLayout
 	Data           uint32
 	DataEnd        uint32
 	DataMeta       uint32
@@ -802,7 +811,10 @@ type XdpMd struct {
 	EgressIfindex  uint32
 }
 
-type BtfGetFdByIdAttr struct{ Id uint32 }
+type BtfGetFdByIdAttr struct {
+	structs.HostLayout
+	Id uint32
+}
 
 func BtfGetFdById(attr *BtfGetFdByIdAttr) (*FD, error) {
 	fd, err := BPF(BPF_BTF_GET_FD_BY_ID, unsafe.Pointer(attr), unsafe.Sizeof(*attr))
@@ -813,6 +825,7 @@ func BtfGetFdById(attr *BtfGetFdByIdAttr) (*FD, error) {
 }
 
 type BtfGetNextIdAttr struct {
+	structs.HostLayout
 	Id     BTFID
 	NextId BTFID
 }
@@ -823,6 +836,7 @@ func BtfGetNextId(attr *BtfGetNextIdAttr) error {
 }
 
 type BtfLoadAttr struct {
+	structs.HostLayout
 	Btf            Pointer
 	BtfLogBuf      Pointer
 	BtfSize        uint32
@@ -841,7 +855,10 @@ func BtfLoad(attr *BtfLoadAttr) (*FD, error) {
 	return NewFD(int(fd))
 }
 
-type EnableStatsAttr struct{ Type uint32 }
+type EnableStatsAttr struct {
+	structs.HostLayout
+	Type uint32
+}
 
 func EnableStats(attr *EnableStatsAttr) (*FD, error) {
 	fd, err := BPF(BPF_ENABLE_STATS, unsafe.Pointer(attr), unsafe.Sizeof(*attr))
@@ -852,6 +869,7 @@ func EnableStats(attr *EnableStatsAttr) (*FD, error) {
 }
 
 type IterCreateAttr struct {
+	structs.HostLayout
 	LinkFd uint32
 	Flags  uint32
 }
@@ -865,6 +883,7 @@ func IterCreate(attr *IterCreateAttr) (*FD, error) {
 }
 
 type LinkCreateAttr struct {
+	structs.HostLayout
 	ProgFd      uint32
 	TargetFd    uint32
 	AttachType  AttachType
@@ -882,6 +901,7 @@ func LinkCreate(attr *LinkCreateAttr) (*FD, error) {
 }
 
 type LinkCreateIterAttr struct {
+	structs.HostLayout
 	ProgFd      uint32
 	TargetFd    uint32
 	AttachType  AttachType
@@ -900,6 +920,7 @@ func LinkCreateIter(attr *LinkCreateIterAttr) (*FD, error) {
 }
 
 type LinkCreateKprobeMultiAttr struct {
+	structs.HostLayout
 	ProgFd           uint32
 	TargetFd         uint32
 	AttachType       AttachType
@@ -921,6 +942,7 @@ func LinkCreateKprobeMulti(attr *LinkCreateKprobeMultiAttr) (*FD, error) {
 }
 
 type LinkCreateNetfilterAttr struct {
+	structs.HostLayout
 	ProgFd         uint32
 	TargetFd       uint32
 	AttachType     AttachType
@@ -941,6 +963,7 @@ func LinkCreateNetfilter(attr *LinkCreateNetfilterAttr) (*FD, error) {
 }
 
 type LinkCreateNetkitAttr struct {
+	structs.HostLayout
 	ProgFd           uint32
 	TargetIfindex    uint32
 	AttachType       AttachType
@@ -960,6 +983,7 @@ func LinkCreateNetkit(attr *LinkCreateNetkitAttr) (*FD, error) {
 }
 
 type LinkCreatePerfEventAttr struct {
+	structs.HostLayout
 	ProgFd     uint32
 	TargetFd   uint32
 	AttachType AttachType
@@ -977,6 +1001,7 @@ func LinkCreatePerfEvent(attr *LinkCreatePerfEventAttr) (*FD, error) {
 }
 
 type LinkCreateTcxAttr struct {
+	structs.HostLayout
 	ProgFd           uint32
 	TargetIfindex    uint32
 	AttachType       AttachType
@@ -996,6 +1021,7 @@ func LinkCreateTcx(attr *LinkCreateTcxAttr) (*FD, error) {
 }
 
 type LinkCreateTracingAttr struct {
+	structs.HostLayout
 	ProgFd      uint32
 	TargetFd    uint32
 	AttachType  AttachType
@@ -1015,6 +1041,7 @@ func LinkCreateTracing(attr *LinkCreateTracingAttr) (*FD, error) {
 }
 
 type LinkCreateUprobeMultiAttr struct {
+	structs.HostLayout
 	ProgFd           uint32
 	TargetFd         uint32
 	AttachType       AttachType
@@ -1037,7 +1064,10 @@ func LinkCreateUprobeMulti(attr *LinkCreateUprobeMultiAttr) (*FD, error) {
 	return NewFD(int(fd))
 }
 
-type LinkGetFdByIdAttr struct{ Id LinkID }
+type LinkGetFdByIdAttr struct {
+	structs.HostLayout
+	Id LinkID
+}
 
 func LinkGetFdById(attr *LinkGetFdByIdAttr) (*FD, error) {
 	fd, err := BPF(BPF_LINK_GET_FD_BY_ID, unsafe.Pointer(attr), unsafe.Sizeof(*attr))
@@ -1048,6 +1078,7 @@ func LinkGetFdById(attr *LinkGetFdByIdAttr) (*FD, error) {
 }
 
 type LinkGetNextIdAttr struct {
+	structs.HostLayout
 	Id     LinkID
 	NextId LinkID
 }
@@ -1058,6 +1089,7 @@ func LinkGetNextId(attr *LinkGetNextIdAttr) error {
 }
 
 type LinkUpdateAttr struct {
+	structs.HostLayout
 	LinkFd    uint32
 	NewProgFd uint32
 	Flags     uint32
@@ -1070,6 +1102,7 @@ func LinkUpdate(attr *LinkUpdateAttr) error {
 }
 
 type MapCreateAttr struct {
+	structs.HostLayout
 	MapType               MapType
 	KeySize               uint32
 	ValueSize             uint32
@@ -1097,6 +1130,7 @@ func MapCreate(attr *MapCreateAttr) (*FD, error) {
 }
 
 type MapDeleteBatchAttr struct {
+	structs.HostLayout
 	InBatch   Pointer
 	OutBatch  Pointer
 	Keys      Pointer
@@ -1113,6 +1147,7 @@ func MapDeleteBatch(attr *MapDeleteBatchAttr) error {
 }
 
 type MapDeleteElemAttr struct {
+	structs.HostLayout
 	MapFd uint32
 	_     [4]byte
 	Key   Pointer
@@ -1125,14 +1160,20 @@ func MapDeleteElem(attr *MapDeleteElemAttr) error {
 	return err
 }
 
-type MapFreezeAttr struct{ MapFd uint32 }
+type MapFreezeAttr struct {
+	structs.HostLayout
+	MapFd uint32
+}
 
 func MapFreeze(attr *MapFreezeAttr) error {
 	_, err := BPF(BPF_MAP_FREEZE, unsafe.Pointer(attr), unsafe.Sizeof(*attr))
 	return err
 }
 
-type MapGetFdByIdAttr struct{ Id uint32 }
+type MapGetFdByIdAttr struct {
+	structs.HostLayout
+	Id uint32
+}
 
 func MapGetFdById(attr *MapGetFdByIdAttr) (*FD, error) {
 	fd, err := BPF(BPF_MAP_GET_FD_BY_ID, unsafe.Pointer(attr), unsafe.Sizeof(*attr))
@@ -1143,6 +1184,7 @@ func MapGetFdById(attr *MapGetFdByIdAttr) (*FD, error) {
 }
 
 type MapGetNextIdAttr struct {
+	structs.HostLayout
 	Id     uint32
 	NextId uint32
 }
@@ -1153,6 +1195,7 @@ func MapGetNextId(attr *MapGetNextIdAttr) error {
 }
 
 type MapGetNextKeyAttr struct {
+	structs.HostLayout
 	MapFd   uint32
 	_       [4]byte
 	Key     Pointer
@@ -1165,6 +1208,7 @@ func MapGetNextKey(attr *MapGetNextKeyAttr) error {
 }
 
 type MapLookupAndDeleteBatchAttr struct {
+	structs.HostLayout
 	InBatch   Pointer
 	OutBatch  Pointer
 	Keys      Pointer
@@ -1181,6 +1225,7 @@ func MapLookupAndDeleteBatch(attr *MapLookupAndDeleteBatchAttr) error {
 }
 
 type MapLookupAndDeleteElemAttr struct {
+	structs.HostLayout
 	MapFd uint32
 	_     [4]byte
 	Key   Pointer
@@ -1194,6 +1239,7 @@ func MapLookupAndDeleteElem(attr *MapLookupAndDeleteElemAttr) error {
 }
 
 type MapLookupBatchAttr struct {
+	structs.HostLayout
 	InBatch   Pointer
 	OutBatch  Pointer
 	Keys      Pointer
@@ -1210,6 +1256,7 @@ func MapLookupBatch(attr *MapLookupBatchAttr) error {
 }
 
 type MapLookupElemAttr struct {
+	structs.HostLayout
 	MapFd uint32
 	_     [4]byte
 	Key   Pointer
@@ -1223,6 +1270,7 @@ func MapLookupElem(attr *MapLookupElemAttr) error {
 }
 
 type MapUpdateBatchAttr struct {
+	structs.HostLayout
 	InBatch   Pointer
 	OutBatch  Pointer
 	Keys      Pointer
@@ -1239,6 +1287,7 @@ func MapUpdateBatch(attr *MapUpdateBatchAttr) error {
 }
 
 type MapUpdateElemAttr struct {
+	structs.HostLayout
 	MapFd uint32
 	_     [4]byte
 	Key   Pointer
@@ -1252,6 +1301,7 @@ func MapUpdateElem(attr *MapUpdateElemAttr) error {
 }
 
 type ObjGetAttr struct {
+	structs.HostLayout
 	Pathname  Pointer
 	BpfFd     uint32
 	FileFlags uint32
@@ -1268,6 +1318,7 @@ func ObjGet(attr *ObjGetAttr) (*FD, error) {
 }
 
 type ObjGetInfoByFdAttr struct {
+	structs.HostLayout
 	BpfFd   uint32
 	InfoLen uint32
 	Info    Pointer
@@ -1279,6 +1330,7 @@ func ObjGetInfoByFd(attr *ObjGetInfoByFdAttr) error {
 }
 
 type ObjPinAttr struct {
+	structs.HostLayout
 	Pathname  Pointer
 	BpfFd     uint32
 	FileFlags uint32
@@ -1292,6 +1344,7 @@ func ObjPin(attr *ObjPinAttr) error {
 }
 
 type ProgAttachAttr struct {
+	structs.HostLayout
 	TargetFdOrIfindex uint32
 	AttachBpfFd       uint32
 	AttachType        uint32
@@ -1307,6 +1360,7 @@ func ProgAttach(attr *ProgAttachAttr) error {
 }
 
 type ProgBindMapAttr struct {
+	structs.HostLayout
 	ProgFd uint32
 	MapFd  uint32
 	Flags  uint32
@@ -1318,6 +1372,7 @@ func ProgBindMap(attr *ProgBindMapAttr) error {
 }
 
 type ProgDetachAttr struct {
+	structs.HostLayout
 	TargetFdOrIfindex uint32
 	AttachBpfFd       uint32
 	AttachType        uint32
@@ -1332,7 +1387,10 @@ func ProgDetach(attr *ProgDetachAttr) error {
 	return err
 }
 
-type ProgGetFdByIdAttr struct{ Id uint32 }
+type ProgGetFdByIdAttr struct {
+	structs.HostLayout
+	Id uint32
+}
 
 func ProgGetFdById(attr *ProgGetFdByIdAttr) (*FD, error) {
 	fd, err := BPF(BPF_PROG_GET_FD_BY_ID, unsafe.Pointer(attr), unsafe.Sizeof(*attr))
@@ -1343,6 +1401,7 @@ func ProgGetFdById(attr *ProgGetFdByIdAttr) (*FD, error) {
 }
 
 type ProgGetNextIdAttr struct {
+	structs.HostLayout
 	Id     uint32
 	NextId uint32
 }
@@ -1353,6 +1412,7 @@ func ProgGetNextId(attr *ProgGetNextIdAttr) error {
 }
 
 type ProgLoadAttr struct {
+	structs.HostLayout
 	ProgType           ProgType
 	InsnCnt            uint32
 	Insns              Pointer
@@ -1392,6 +1452,7 @@ func ProgLoad(attr *ProgLoadAttr) (*FD, error) {
 }
 
 type ProgQueryAttr struct {
+	structs.HostLayout
 	TargetFdOrIfindex uint32
 	AttachType        AttachType
 	QueryFlags        uint32
@@ -1411,6 +1472,7 @@ func ProgQuery(attr *ProgQueryAttr) error {
 }
 
 type ProgRunAttr struct {
+	structs.HostLayout
 	ProgFd      uint32
 	Retval      uint32
 	DataSizeIn  uint32
@@ -1435,6 +1497,7 @@ func ProgRun(attr *ProgRunAttr) error {
 }
 
 type RawTracepointOpenAttr struct {
+	structs.HostLayout
 	Name   Pointer
 	ProgFd uint32
 	_      [4]byte
@@ -1450,6 +1513,7 @@ func RawTracepointOpen(attr *RawTracepointOpenAttr) (*FD, error) {
 }
 
 type CgroupLinkInfo struct {
+	structs.HostLayout
 	Type       LinkType
 	Id         LinkID
 	ProgId     uint32
@@ -1460,6 +1524,7 @@ type CgroupLinkInfo struct {
 }
 
 type IterLinkInfo struct {
+	structs.HostLayout
 	Type          LinkType
 	Id            LinkID
 	ProgId        uint32
@@ -1469,6 +1534,7 @@ type IterLinkInfo struct {
 }
 
 type KprobeLinkInfo struct {
+	structs.HostLayout
 	Type          LinkType
 	Id            LinkID
 	ProgId        uint32
@@ -1484,6 +1550,7 @@ type KprobeLinkInfo struct {
 }
 
 type KprobeMultiLinkInfo struct {
+	structs.HostLayout
 	Type    LinkType
 	Id      LinkID
 	ProgId  uint32
@@ -1497,6 +1564,7 @@ type KprobeMultiLinkInfo struct {
 }
 
 type NetNsLinkInfo struct {
+	structs.HostLayout
 	Type       LinkType
 	Id         LinkID
 	ProgId     uint32
@@ -1507,6 +1575,7 @@ type NetNsLinkInfo struct {
 }
 
 type NetfilterLinkInfo struct {
+	structs.HostLayout
 	Type     LinkType
 	Id       LinkID
 	ProgId   uint32
@@ -1519,6 +1588,7 @@ type NetfilterLinkInfo struct {
 }
 
 type NetkitLinkInfo struct {
+	structs.HostLayout
 	Type       LinkType
 	Id         LinkID
 	ProgId     uint32
@@ -1529,6 +1599,7 @@ type NetkitLinkInfo struct {
 }
 
 type PerfEventLinkInfo struct {
+	structs.HostLayout
 	Type          LinkType
 	Id            LinkID
 	ProgId        uint32
@@ -1537,6 +1608,7 @@ type PerfEventLinkInfo struct {
 }
 
 type RawTracepointLinkInfo struct {
+	structs.HostLayout
 	Type      LinkType
 	Id        LinkID
 	ProgId    uint32
@@ -1547,6 +1619,7 @@ type RawTracepointLinkInfo struct {
 }
 
 type TcxLinkInfo struct {
+	structs.HostLayout
 	Type       LinkType
 	Id         LinkID
 	ProgId     uint32
@@ -1557,6 +1630,7 @@ type TcxLinkInfo struct {
 }
 
 type TracingLinkInfo struct {
+	structs.HostLayout
 	Type        LinkType
 	Id          LinkID
 	ProgId      uint32
@@ -1568,6 +1642,7 @@ type TracingLinkInfo struct {
 }
 
 type XDPLinkInfo struct {
+	structs.HostLayout
 	Type    LinkType
 	Id      LinkID
 	ProgId  uint32


### PR DESCRIPTION
Go 1.23 introduced structs.HostLayout to tell the toolchain that a struct should be laid out in memory as it is laid out in code. Add the annotation to the generated structs.