### PR TITLE
btf: use iterators

### DIFF
--- a/btf/marshal.go
+++ b/btf/marshal.go
@@ -243,28 +243,27 @@ func (b *Builder) addString(str string) (uint32, error) {
 	return b.strings.Add(str)
 }
 
-func (e *encoder) allocateIDs(root Type) (err error) {
-	visitInPostorder(root, e.visited, func(typ Type) bool {
+func (e *encoder) allocateIDs(root Type) error {
+	for typ := range postorder(root, e.visited) {
 		if _, ok := typ.(*Void); ok {
-			return true
+			continue
 		}
 
 		if _, ok := e.ids[typ]; ok {
-			return true
+			continue
 		}
 
 		id := e.lastID + 1
 		if id < e.lastID {
-			err = errors.New("type ID overflow")
-			return false
+			return errors.New("type ID overflow")
 		}
 
 		e.pending.Push(typ)
 		e.ids[typ] = id
 		e.lastID = id
-		return true
-	})
-	return
+	}
+
+	return nil
 }
 
 // id returns the ID for the given type or panics with an error.

--- a/btf/marshal_test.go
+++ b/btf/marshal_test.go
@@ -82,7 +82,8 @@ func TestRoundtripVMlinux(t *testing.T) {
 	visited := make(map[Type]struct{})
 limitTypes:
 	for i, typ := range types {
-		visitInPostorder(typ, visited, func(_ Type) bool { return true })
+		for range postorder(typ, visited) {
+		}
 		if len(visited) >= math.MaxInt16 {
 			// IDs exceeding math.MaxUint16 can trigger a bug when loading BTF.
 			// This can be removed once the patch lands.

--- a/btf/traversal.go
+++ b/btf/traversal.go
@@ -2,16 +2,21 @@ package btf
 
 import (
 	"fmt"
+	"iter"
 )
 
 // Functions to traverse a cyclic graph of types. The below was very useful:
 // https://eli.thegreenplace.net/2015/directed-graph-traversal-orderings-and-applications-to-data-flow-analysis/#post-order-and-reverse-post-order
 
-// Visit all types reachable from root in postorder.
-//
-// Traversal stops if yield returns false.
-//
-// Returns false if traversal was aborted.
+// postorder yields all types reachable from root in post order.
+func postorder(root Type, visited map[Type]struct{}) iter.Seq[Type] {
+	return func(yield func(Type) bool) {
+		visitInPostorder(root, visited, yield)
+	}
+}
+
+// visitInPostorder is a separate function to avoid arguments escaping
+// to the heap. Don't change the setup without re-running the benchmarks.
 func visitInPostorder(root Type, visited map[Type]struct{}, yield func(typ Type) bool) bool {
 	if _, ok := visited[root]; ok {
 		return true
@@ -21,139 +26,134 @@ func visitInPostorder(root Type, visited map[Type]struct{}, yield func(typ Type)
 	}
 	visited[root] = struct{}{}
 
-	cont := children(root, func(child *Type) bool {
-		return visitInPostorder(*child, visited, yield)
-	})
-	if !cont {
-		return false
+	for child := range children(root) {
+		if !visitInPostorder(*child, visited, yield) {
+			return false
+		}
 	}
 
 	return yield(root)
 }
 
-// children calls yield on each child of typ.
-//
-// Traversal stops if yield returns false.
-//
-// Returns false if traversal was aborted.
-func children(typ Type, yield func(child *Type) bool) bool {
-	// Explicitly type switch on the most common types to allow the inliner to
-	// do its work. This avoids allocating intermediate slices from walk() on
-	// the heap.
-	var tags []string
-	switch v := typ.(type) {
-	case *Void, *Int, *Enum, *Fwd, *Float, *declTag:
-		// No children to traverse.
-		// declTags is declared as a leaf type since it's parsed into .Tags fields of other types
-		// during unmarshaling.
-	case *Pointer:
-		if !yield(&v.Target) {
-			return false
-		}
-	case *Array:
-		if !yield(&v.Index) {
-			return false
-		}
-		if !yield(&v.Type) {
-			return false
-		}
-	case *Struct:
-		for i := range v.Members {
-			if !yield(&v.Members[i].Type) {
-				return false
+// children yields all direct descendants of typ.
+func children(typ Type) iter.Seq[*Type] {
+	return func(yield func(*Type) bool) {
+		// Explicitly type switch on the most common types to allow the inliner to
+		// do its work. This avoids allocating intermediate slices from walk() on
+		// the heap.
+		var tags []string
+		switch v := typ.(type) {
+		case *Void, *Int, *Enum, *Fwd, *Float, *declTag:
+			// No children to traverse.
+			// declTags is declared as a leaf type since it's parsed into .Tags fields of other types
+			// during unmarshaling.
+		case *Pointer:
+			if !yield(&v.Target) {
+				return
 			}
-			for _, t := range v.Members[i].Tags {
-				var tag Type = &declTag{v, t, i}
-				if !yield(&tag) {
-					return false
+		case *Array:
+			if !yield(&v.Index) {
+				return
+			}
+			if !yield(&v.Type) {
+				return
+			}
+		case *Struct:
+			for i := range v.Members {
+				if !yield(&v.Members[i].Type) {
+					return
 				}
-			}
-		}
-		tags = v.Tags
-	case *Union:
-		for i := range v.Members {
-			if !yield(&v.Members[i].Type) {
-				return false
-			}
-			for _, t := range v.Members[i].Tags {
-				var tag Type = &declTag{v, t, i}
-				if !yield(&tag) {
-					return false
-				}
-			}
-		}
-		tags = v.Tags
-	case *Typedef:
-		if !yield(&v.Type) {
-			return false
-		}
-		tags = v.Tags
-	case *Volatile:
-		if !yield(&v.Type) {
-			return false
-		}
-	case *Const:
-		if !yield(&v.Type) {
-			return false
-		}
-	case *Restrict:
-		if !yield(&v.Type) {
-			return false
-		}
-	case *Func:
-		if !yield(&v.Type) {
-			return false
-		}
-		if fp, ok := v.Type.(*FuncProto); ok {
-			for i := range fp.Params {
-				if len(v.ParamTags) <= i {
-					continue
-				}
-				for _, t := range v.ParamTags[i] {
+				for _, t := range v.Members[i].Tags {
 					var tag Type = &declTag{v, t, i}
 					if !yield(&tag) {
-						return false
+						return
 					}
 				}
 			}
+			tags = v.Tags
+		case *Union:
+			for i := range v.Members {
+				if !yield(&v.Members[i].Type) {
+					return
+				}
+				for _, t := range v.Members[i].Tags {
+					var tag Type = &declTag{v, t, i}
+					if !yield(&tag) {
+						return
+					}
+				}
+			}
+			tags = v.Tags
+		case *Typedef:
+			if !yield(&v.Type) {
+				return
+			}
+			tags = v.Tags
+		case *Volatile:
+			if !yield(&v.Type) {
+				return
+			}
+		case *Const:
+			if !yield(&v.Type) {
+				return
+			}
+		case *Restrict:
+			if !yield(&v.Type) {
+				return
+			}
+		case *Func:
+			if !yield(&v.Type) {
+				return
+			}
+			if fp, ok := v.Type.(*FuncProto); ok {
+				for i := range fp.Params {
+					if len(v.ParamTags) <= i {
+						continue
+					}
+					for _, t := range v.ParamTags[i] {
+						var tag Type = &declTag{v, t, i}
+						if !yield(&tag) {
+							return
+						}
+					}
+				}
+			}
+			tags = v.Tags
+		case *FuncProto:
+			if !yield(&v.Return) {
+				return
+			}
+			for i := range v.Params {
+				if !yield(&v.Params[i].Type) {
+					return
+				}
+			}
+		case *Var:
+			if !yield(&v.Type) {
+				return
+			}
+			tags = v.Tags
+		case *Datasec:
+			for i := range v.Vars {
+				if !yield(&v.Vars[i].Type) {
+					return
+				}
+			}
+		case *TypeTag:
+			if !yield(&v.Type) {
+				return
+			}
+		case *cycle:
+			// cycle has children, but we ignore them deliberately.
+		default:
+			panic(fmt.Sprintf("don't know how to walk Type %T", v))
 		}
-		tags = v.Tags
-	case *FuncProto:
-		if !yield(&v.Return) {
-			return false
-		}
-		for i := range v.Params {
-			if !yield(&v.Params[i].Type) {
-				return false
+
+		for _, t := range tags {
+			var tag Type = &declTag{typ, t, -1}
+			if !yield(&tag) {
+				return
 			}
 		}
-	case *Var:
-		if !yield(&v.Type) {
-			return false
-		}
-		tags = v.Tags
-	case *Datasec:
-		for i := range v.Vars {
-			if !yield(&v.Vars[i].Type) {
-				return false
-			}
-		}
-	case *TypeTag:
-		if !yield(&v.Type) {
-			return false
-		}
-	case *cycle:
-		// cycle has children, but we ignore them deliberately.
-	default:
-		panic(fmt.Sprintf("don't know how to walk Type %T", v))
 	}
-
-	for _, t := range tags {
-		var tag Type = &declTag{typ, t, -1}
-		if !yield(&tag) {
-			return false
-		}
-	}
-
-	return true
 }

--- a/btf/types.go
+++ b/btf/types.go
@@ -740,10 +740,9 @@ func copyType(typ Type, ids map[Type]TypeID, copies map[Type]Type, copiedIDs map
 		copiedIDs[cpy] = id
 	}
 
-	children(cpy, func(child *Type) bool {
+	for child := range children(cpy) {
 		*child = copyType(*child, ids, copies, copiedIDs)
-		return true
-	})
+	}
 
 	return cpy
 }

--- a/btf/types_test.go
+++ b/btf/types_test.go
@@ -198,7 +198,9 @@ func TestType(t *testing.T) {
 			}
 
 			var a []*Type
-			children(typ, func(t *Type) bool { a = append(a, t); return true })
+			for t := range children(typ) {
+				a = append(a, t)
+			}
 
 			if _, ok := typ.(*cycle); !ok {
 				if n := countChildren(t, reflect.TypeOf(typ)); len(a) < n {
@@ -207,7 +209,9 @@ func TestType(t *testing.T) {
 			}
 
 			var b []*Type
-			children(typ, func(t *Type) bool { b = append(b, t); return true })
+			for t := range children(typ) {
+				b = append(b, t)
+			}
 
 			if diff := cmp.Diff(a, b, compareTypes); diff != "" {
 				t.Errorf("Walk mismatch (-want +got):\n%s", diff)
@@ -484,10 +488,9 @@ func BenchmarkWalk(b *testing.B) {
 
 			for i := 0; i < b.N; i++ {
 				var dq typeDeque
-				children(typ, func(child *Type) bool {
+				for child := range children(typ) {
 					dq.Push(child)
-					return true
-				})
+				}
 			}
 		})
 	}


### PR DESCRIPTION
Now that we're on 1.23 we can use iterators. The existing iterators don't really need to be modified. Allocations don't change, run time seems a little bit faster.

    core: 1
    goos: linux
    goarch: amd64
    pkg: github.com/cilium/ebpf/btf
    cpu: 13th Gen Intel(R) Core(TM) i7-1365U
                                        │   base.txt   │              iter.txt              │
                                        │    sec/op    │    sec/op     vs base              │
    PostorderTraversal/single_type           49.79n ± ∞ ¹   48.68n ± ∞ ¹  -2.23% (p=0.029 n=4)
    PostorderTraversal/cycle(1)              146.4n ± ∞ ¹   135.8n ± ∞ ¹  -7.24% (p=0.029 n=4)
    PostorderTraversal/cycle(10)             1.928µ ± ∞ ¹   1.861µ ± ∞ ¹  -3.45% (p=0.029 n=4)
    PostorderTraversal/gov_update_cpu_data   1.895m ± ∞ ¹   1.907m ± ∞ ¹       ~ (p=0.057 n=4)
    geomean                                  2.271µ         2.201µ        -3.12%
    ¹ need >= 6 samples for confidence interval at level 0.95