### PR TITLE
all: force consistent line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,4 @@
+# Force line ending normalisation
+*	text=auto
+# Show types.go in the PR diff view by default
 internal/sys/types.go linguist-generated=false


### PR DESCRIPTION
Ensure that files in the repository use Unix-style line endings throughout.

See https://git-scm.com/docs/gitattributes#_checking_out_and_checking_in