### PR TITLE
internal/testutils: make TempBPFFS portable

### DIFF
--- a/internal/testutils/bpffs_other.go
+++ b/internal/testutils/bpffs_other.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package testutils
 
 import (

--- a/internal/testutils/bpffs_windows.go
+++ b/internal/testutils/bpffs_windows.go
@@ -1,0 +1,44 @@
+package testutils
+
+import (
+	"errors"
+	"math/rand"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/cilium/ebpf/internal/efw"
+	"github.com/go-quicktest/qt"
+)
+
+// TempBPFFS creates a random prefix to use when pinning on Windows.
+func TempBPFFS(tb testing.TB) string {
+	tb.Helper()
+
+	path := filepath.Join("ebpf-go-test", strconv.Itoa(rand.Int()))
+	tb.Cleanup(func() {
+		tb.Helper()
+
+		cursor := path
+		for {
+			next, _, err := efw.EbpfGetNextPinnedObjectPath(cursor, efw.EBPF_OBJECT_UNKNOWN)
+			if errors.Is(err, efw.EBPF_NO_MORE_KEYS) {
+				break
+			}
+			qt.Assert(tb, qt.IsNil(err))
+
+			if !strings.HasPrefix(next, path) {
+				break
+			}
+
+			if err := efw.EbpfObjectUnpin(next); err != nil {
+				tb.Errorf("Failed to unpin %s: %s", next, err)
+			}
+
+			cursor = next
+		}
+	})
+
+	return path
+}

--- a/internal/testutils/bpffs_windows_test.go
+++ b/internal/testutils/bpffs_windows_test.go
@@ -1,0 +1,72 @@
+package testutils_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cilium/ebpf/asm"
+	"github.com/cilium/ebpf/internal"
+	"github.com/cilium/ebpf/internal/sys"
+	"github.com/cilium/ebpf/internal/testutils"
+	"github.com/go-quicktest/qt"
+)
+
+func TestTempBPFFS(t *testing.T) {
+	var progPath, mapPath string
+	t.Run("pin", func(t *testing.T) {
+		tmp := testutils.TempBPFFS(t)
+		progPath = filepath.Join(tmp, "prog")
+		mapPath = filepath.Join(tmp, "map")
+
+		var buffer bytes.Buffer
+		insns := asm.Instructions{
+			asm.LoadImm(asm.R0, 0, asm.DWord),
+			asm.Return(),
+		}
+		err := insns.Marshal(&buffer, internal.NativeEndian)
+		qt.Assert(t, qt.IsNil(err))
+
+		progFd, err := sys.ProgLoad(&sys.ProgLoadAttr{
+			ProgType: 998, // XDP_TEST
+			License:  sys.NewStringPointer(""),
+			InsnCnt:  uint32(buffer.Len() / asm.InstructionSize),
+			Insns:    sys.NewSlicePointer(buffer.Bytes()),
+		})
+		qt.Assert(t, qt.IsNil(err))
+		defer progFd.Close()
+
+		err = sys.ObjPin(&sys.ObjPinAttr{
+			BpfFd:    progFd.Uint(),
+			Pathname: sys.NewStringPointer(progPath),
+		})
+		qt.Assert(t, qt.IsNil(err))
+
+		mapFd, err := sys.MapCreate(&sys.MapCreateAttr{
+			MapType:    2, // ARRAY
+			KeySize:    4,
+			ValueSize:  4,
+			MaxEntries: 1,
+		})
+		qt.Assert(t, qt.IsNil(err))
+		defer mapFd.Close()
+
+		err = sys.ObjPin(&sys.ObjPinAttr{
+			BpfFd:    progFd.Uint(),
+			Pathname: sys.NewStringPointer(mapPath),
+		})
+		qt.Assert(t, qt.IsNil(err))
+		qt.Assert(t, qt.IsNil(mapFd.Close()))
+	})
+
+	_, err := sys.ObjGet(&sys.ObjGetAttr{
+		Pathname: sys.NewStringPointer(progPath),
+	})
+	qt.Assert(t, qt.ErrorIs(err, os.ErrNotExist))
+
+	_, err = sys.ObjGet(&sys.ObjGetAttr{
+		Pathname: sys.NewStringPointer(mapPath),
+	})
+	qt.Assert(t, qt.ErrorIs(err, os.ErrNotExist))
+}


### PR DESCRIPTION
Object pinning on Windows isn't backed by a file system, instead the path is just used as an identifier. Generate a random prefix to use for tests on Windows.