### PR TITLE
Unsafe variable pointer

### DIFF
--- a/memory.go
+++ b/memory.go
@@ -143,3 +143,16 @@ func (mm *Memory) WriteAt(p []byte, off int64) (int, error) {
 
 	return n, nil
 }
+
+func (mm *Memory) sliceAt(off uint64, size uint64) ([]byte, error) {
+	if mm.b == nil {
+		return nil, fmt.Errorf("memory-mapped region closed")
+	}
+	if mm.ro {
+		return nil, fmt.Errorf("memory-mapped region not writable: %w", ErrReadOnly)
+	}
+	if !mm.bounds(off, size) {
+		return nil, fmt.Errorf("memory-mapped region access out of bounds: %w", io.EOF)
+	}
+	return mm.b[off : off+size : off+size], nil
+}

--- a/memory.go
+++ b/memory.go
@@ -89,7 +89,7 @@ func (mm *Memory) ReadOnly() bool {
 
 // bounds returns true if an access at off of the given size is within bounds.
 func (mm *Memory) bounds(off uint64, size uint64) bool {
-	return off+size < uint64(len(mm.b))
+	return off < uint64(len(mm.b)) && off+size <= uint64(len(mm.b))
 }
 
 // ReadAt implements [io.ReaderAt]. Useful for creating a new [io.OffsetWriter].

--- a/memory_test.go
+++ b/memory_test.go
@@ -60,16 +60,16 @@ func TestMemoryBounds(t *testing.T) {
 	qt.Assert(t, qt.IsNil(err))
 
 	size := uint64(mm.Size())
-	end := size - 1
+	end := size
 
 	qt.Assert(t, qt.IsTrue(mm.bounds(0, 0)))
-	qt.Assert(t, qt.IsTrue(mm.bounds(end, 0)))
+	qt.Assert(t, qt.IsFalse(mm.bounds(end, 0)))
 	qt.Assert(t, qt.IsTrue(mm.bounds(end-8, 8)))
 	qt.Assert(t, qt.IsTrue(mm.bounds(0, end)))
 
 	qt.Assert(t, qt.IsFalse(mm.bounds(end-8, 9)))
 	qt.Assert(t, qt.IsFalse(mm.bounds(end, 1)))
-	qt.Assert(t, qt.IsFalse(mm.bounds(0, size)))
+	qt.Assert(t, qt.IsTrue(mm.bounds(0, size)))
 }
 
 func TestMemoryReadOnly(t *testing.T) {

--- a/unsafe/variable.go
+++ b/unsafe/variable.go
@@ -1,0 +1,16 @@
+package unsafe
+
+import (
+	"unsafe"
+
+	"github.com/cilium/ebpf"
+)
+
+// VariablePointer enables direct access to the variable, bypassing .Get()
+// and .Set() API.
+//
+// The pointer WILL become dangling if the Variable is collected in
+// meantime.
+//
+//go:linkname VariablePointer github.com/cilium/ebpf.unsafeVariablePointer
+func VariablePointer(v *ebpf.Variable) (unsafe.Pointer, error)

--- a/unsafe/variable_test.go
+++ b/unsafe/variable_test.go
@@ -1,0 +1,12 @@
+package unsafe
+
+import (
+	"testing"
+
+	"github.com/cilium/ebpf"
+)
+
+func TestVariablePointer(*testing.T) {
+	// ensure that linkname is correct; underlying routine tested elsewhere
+	VariablePointer(&ebpf.Variable{})
+}

--- a/unsafe_variable.go
+++ b/unsafe_variable.go
@@ -1,0 +1,19 @@
+package ebpf
+
+import (
+	"unsafe"
+)
+
+//go:linkname unsafeVariablePointer
+func unsafeVariablePointer(v *Variable) (unsafe.Pointer, error) {
+	if v.mm == nil {
+		return nil, errNoDirectVariableAccess(v)
+	}
+
+	b, err := v.mm.sliceAt(v.offset, v.size)
+	if err != nil {
+		return nil, err
+	}
+
+	return unsafe.Pointer(&b[0]), nil
+}

--- a/variable.go
+++ b/variable.go
@@ -192,7 +192,7 @@ func (v *Variable) String() string {
 // to the same length as the size of the Variable.
 func (v *Variable) Set(in any) error {
 	if v.mm == nil {
-		return fmt.Errorf("variable %s: direct access requires Linux 5.5 or later: %w", v.name, ErrNotSupported)
+		return errNoDirectVariableAccess(v)
 	}
 
 	if v.ReadOnly() {
@@ -215,7 +215,7 @@ func (v *Variable) Set(in any) error {
 // be a pointer to a value whose size matches the Variable.
 func (v *Variable) Get(out any) error {
 	if v.mm == nil {
-		return fmt.Errorf("variable %s: direct access requires Linux 5.5 or later: %w", v.name, ErrNotSupported)
+		return errNoDirectVariableAccess(v)
 	}
 
 	if !v.mm.bounds(v.offset, v.size) {
@@ -227,4 +227,8 @@ func (v *Variable) Get(out any) error {
 	}
 
 	return nil
+}
+
+func errNoDirectVariableAccess(v *Variable) error {
+	return fmt.Errorf("variable %s: direct access requires Linux 5.5 or later: %w", v.name, ErrNotSupported)
 }

--- a/variable_test.go
+++ b/variable_test.go
@@ -124,6 +124,11 @@ func TestVariable(t *testing.T) {
 
 	qt.Assert(t, qt.IsNotNil(obj.Data.Type()))
 	qt.Assert(t, qt.IsNotNil(obj.Struct.Type()))
+
+	bssPtr, err := unsafeVariablePointer(obj.BSS)
+	qt.Assert(t, qt.IsNil(err))
+	*(*uint32)(bssPtr) = 42
+	mustReturn(t, obj.GetBSS, uint32(42))
 }
 
 func TestVariableConst(t *testing.T) {
@@ -153,6 +158,9 @@ func TestVariableConst(t *testing.T) {
 
 	qt.Assert(t, qt.IsTrue(obj.Rodata.ReadOnly()))
 	qt.Assert(t, qt.ErrorIs(obj.Rodata.Set(want), ErrReadOnly))
+
+	_, err = unsafeVariablePointer(obj.Rodata)
+	qt.Assert(t, qt.ErrorIs(err, ErrReadOnly))
 }
 
 func TestVariableFallback(t *testing.T) {


### PR DESCRIPTION
Enable (unsafe) direct access to mmap-ed variable memory. It makes scanning large data areas more efficient and enables advanced synchronisation patterns, such as atomics.

Introduce a new package so that a user has to explicitly opt in for unsafe features.