### PR TITLE
CI: remove 4.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,7 +202,6 @@ jobs:
           - "5.4"
           - "4.19"
           - "4.14"
-          - "4.9"
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
4.9 has been EOLed a long time ago. Remove it from CI.

Fixes #1007 