### PR TITLE
ebpf: clean up tests

### DIFF
--- a/collection_test.go
+++ b/collection_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/go-quicktest/qt"
-	"github.com/google/go-cmp/cmp"
 
 	"github.com/cilium/ebpf/asm"
 	"github.com/cilium/ebpf/btf"
@@ -46,11 +45,7 @@ func TestCollectionSpecNotModified(t *testing.T) {
 		},
 	}
 
-	coll, err := NewCollection(&cs)
-	if err != nil {
-		t.Fatal(err)
-	}
-	coll.Close()
+	mustNewCollection(t, &cs, nil)
 
 	if cs.Programs["test"].Instructions[0].Constant != 0 {
 		t.Error("Creating a collection modifies input spec")
@@ -107,17 +102,11 @@ func TestCollectionSpecLoadCopy(t *testing.T) {
 		Prog *Program `ebpf:"xdp_prog"`
 	}
 
-	err = spec.LoadAndAssign(&objs, nil)
-	testutils.SkipIfNotSupported(t, err)
-	if err != nil {
-		t.Fatal("Loading original spec:", err)
-	}
-	defer objs.Prog.Close()
+	mustLoadAndAssign(t, spec, &objs, nil)
+	qt.Assert(t, qt.IsNil(objs.Prog.Close()))
 
-	if err := spec2.LoadAndAssign(&objs, nil); err != nil {
-		t.Fatal("Loading copied spec:", err)
-	}
-	defer objs.Prog.Close()
+	mustLoadAndAssign(t, spec2, &objs, nil)
+	qt.Assert(t, qt.IsNil(objs.Prog.Close()))
 }
 
 func TestCollectionSpecLoadMutate(t *testing.T) {
@@ -133,14 +122,9 @@ func TestCollectionSpecLoadMutate(t *testing.T) {
 		Prog *Program `ebpf:"xdp_prog"`
 	}
 
-	err = spec.LoadAndAssign(&objs, nil)
-	testutils.SkipIfNotSupported(t, err)
-	qt.Assert(t, qt.IsNil(err))
-	defer objs.Prog.Close()
-
-	if diff := cmp.Diff(orig, spec, csCmpOpts...); diff != "" {
-		t.Errorf("CollectionSpec was mutated after loading (-want +got):\n%s", diff)
-	}
+	mustLoadAndAssign(t, spec, &objs, nil)
+	qt.Assert(t, qt.IsNil(objs.Prog.Close()))
+	qt.Assert(t, qt.CmpEquals(spec, orig, csCmpOpts))
 }
 
 func TestCollectionSpecRewriteMaps(t *testing.T) {
@@ -177,13 +161,9 @@ func TestCollectionSpecRewriteMaps(t *testing.T) {
 	}
 
 	// Override the map with another one
-	newMap, err := NewMap(cs.Maps["test-map"])
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer newMap.Close()
+	newMap := mustNewMap(t, cs.Maps["test-map"], nil)
 
-	err = newMap.Put(uint32(0), uint32(2))
+	err := newMap.Put(uint32(0), uint32(2))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -199,11 +179,7 @@ func TestCollectionSpecRewriteMaps(t *testing.T) {
 		t.Error("RewriteMaps doesn't remove map from CollectionSpec.Maps")
 	}
 
-	coll, err := NewCollection(cs)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer coll.Close()
+	coll := mustNewCollection(t, cs, nil)
 
 	ret, _, err := coll.Programs["test-prog"].Test(internal.EmptyBPFContext)
 	testutils.SkipIfNotSupported(t, err)
@@ -250,26 +226,18 @@ func TestCollectionSpecMapReplacements(t *testing.T) {
 	}
 
 	// Replace the map with another one
-	newMap, err := NewMap(cs.Maps["test-map"])
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer newMap.Close()
+	newMap := mustNewMap(t, cs.Maps["test-map"], nil)
 
-	err = newMap.Put(uint32(0), uint32(2))
+	err := newMap.Put(uint32(0), uint32(2))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	coll, err := NewCollectionWithOptions(cs, CollectionOptions{
+	coll := mustNewCollection(t, cs, &CollectionOptions{
 		MapReplacements: map[string]*Map{
 			"test-map": newMap,
 		},
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer coll.Close()
 
 	ret, _, err := coll.Programs["test-prog"].Test(internal.EmptyBPFContext)
 	testutils.SkipIfNotSupported(t, err)
@@ -302,13 +270,9 @@ func TestCollectionSpecMapReplacements_NonExistingMap(t *testing.T) {
 	}
 
 	// Override non-existing map
-	newMap, err := NewMap(cs.Maps["test-map"])
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer newMap.Close()
+	newMap := mustNewMap(t, cs.Maps["test-map"], nil)
 
-	coll, err := NewCollectionWithOptions(cs, CollectionOptions{
+	coll, err := newCollection(t, cs, &CollectionOptions{
 		MapReplacements: map[string]*Map{
 			"non-existing-map": newMap,
 		},
@@ -332,19 +296,14 @@ func TestCollectionSpecMapReplacements_SpecMismatch(t *testing.T) {
 	}
 
 	// Override map with mismatching spec
-	newMap, err := NewMap(&MapSpec{
+	newMap := mustNewMap(t, &MapSpec{
 		Type:       Array,
 		KeySize:    4,
 		ValueSize:  8, // this is different
 		MaxEntries: 1,
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	// Map fd is duplicated by MapReplacements, this one can be safely closed.
-	defer newMap.Close()
+	}, nil)
 
-	coll, err := NewCollectionWithOptions(cs, CollectionOptions{
+	coll, err := newCollection(t, cs, &CollectionOptions{
 		MapReplacements: map[string]*Map{
 			"test-map": newMap,
 		},
@@ -373,21 +332,18 @@ func TestMapReplacementsDataSections(t *testing.T) {
 		ROData *Map `ebpf:".rodata"`
 	}
 
-	err = spec.LoadAndAssign(&objs, nil)
-	testutils.SkipIfNotSupported(t, err)
-	qt.Assert(t, qt.IsNil(err))
+	mustLoadAndAssign(t, spec, &objs, nil)
 	defer objs.Data.Close()
 	defer objs.ROData.Close()
 
-	qt.Assert(t, qt.IsNil(
-		spec.LoadAndAssign(&objs, &CollectionOptions{
-			MapReplacements: map[string]*Map{
-				".data":   objs.Data,
-				".rodata": objs.ROData,
-			},
-		})))
-	defer objs.Data.Close()
-	defer objs.ROData.Close()
+	mustLoadAndAssign(t, spec, &objs, &CollectionOptions{
+		MapReplacements: map[string]*Map{
+			".data":   objs.Data,
+			".rodata": objs.ROData,
+		},
+	})
+	qt.Assert(t, qt.IsNil(objs.Data.Close()))
+	qt.Assert(t, qt.IsNil(objs.ROData.Close()))
 }
 
 func TestCollectionSpec_LoadAndAssign_LazyLoading(t *testing.T) {
@@ -429,9 +385,7 @@ func TestCollectionSpec_LoadAndAssign_LazyLoading(t *testing.T) {
 		Map  *Map     `ebpf:"valid"`
 	}
 
-	if err := spec.LoadAndAssign(&objs, nil); err != nil {
-		t.Fatal("Assign loads a map or program that isn't requested in the struct:", err)
-	}
+	mustLoadAndAssign(t, spec, &objs, nil)
 	defer objs.Prog.Close()
 	defer objs.Map.Close()
 
@@ -600,9 +554,7 @@ func TestCollectionAssign(t *testing.T) {
 		},
 	}
 
-	coll, err := NewCollection(cs)
-	qt.Assert(t, qt.IsNil(err))
-	defer coll.Close()
+	coll := mustNewCollection(t, cs, nil)
 
 	qt.Assert(t, qt.IsNil(coll.Assign(&objs)))
 	defer objs.Program.Close()
@@ -645,9 +597,7 @@ func TestCollectionAssignFail(t *testing.T) {
 		},
 	}
 
-	coll, err := NewCollection(cs)
-	qt.Assert(t, qt.IsNil(err))
-	defer coll.Close()
+	coll := mustNewCollection(t, cs, nil)
 
 	qt.Assert(t, qt.IsNotNil(coll.Assign(&objs)))
 
@@ -684,7 +634,7 @@ func TestIncompleteLoadAndAssign(t *testing.T) {
 		Invalid *Program `ebpf:"invalid"`
 	}{}
 
-	if err := spec.LoadAndAssign(&s, nil); err == nil {
+	if err := loadAndAssign(t, spec, &s, nil); err == nil {
 		t.Fatal("expected error loading invalid ProgramSpec")
 	}
 

--- a/elf_reader_test.go
+++ b/elf_reader_test.go
@@ -250,9 +250,7 @@ func TestLoadCollectionSpec(t *testing.T) {
 		qt.Assert(t, qt.Equals(have.Maps["perf_event_array"].ValueSize, 0))
 		qt.Assert(t, qt.IsNotNil(have.Maps["perf_event_array"].Value))
 
-		if diff := cmp.Diff(coll, have, csCmpOpts); diff != "" {
-			t.Errorf("MapSpec mismatch (-want +got):\n%s", diff)
-		}
+		qt.Assert(t, qt.CmpEquals(have, coll, csCmpOpts))
 
 		if have.ByteOrder != internal.NativeEndian {
 			return

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cilium/ebpf
 go 1.23
 
 require (
-	github.com/go-quicktest/qt v1.101.0
+	github.com/go-quicktest/qt v1.101.1-0.20240301121107-c6c8733fa1e6
 	github.com/google/go-cmp v0.6.0
 	github.com/jsimonetti/rtnetlink/v2 v2.0.1
 	golang.org/x/sys v0.30.0
@@ -15,7 +15,7 @@ require (
 	github.com/kr/text v0.2.0 // indirect
 	github.com/mdlayher/netlink v1.7.2 // indirect
 	github.com/mdlayher/socket v0.4.1 // indirect
-	github.com/rogpeppe/go-internal v1.11.0 // indirect
+	github.com/rogpeppe/go-internal v1.12.0 // indirect
 	golang.org/x/net v0.33.0 // indirect
 	golang.org/x/sync v0.1.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/go-quicktest/qt v1.101.0 h1:O1K29Txy5P2OK0dGo59b7b0LR6wKfIhttaAhHUyn7eI=
 github.com/go-quicktest/qt v1.101.0/go.mod h1:14Bz/f7NwaXPtdYEgzsx46kqSxVwTbzVZsDC26tQJow=
+github.com/go-quicktest/qt v1.101.1-0.20240301121107-c6c8733fa1e6 h1:teYtXy9B7y5lHTp8V9KPxpYRAVA7dozigQcMiBust1s=
+github.com/go-quicktest/qt v1.101.1-0.20240301121107-c6c8733fa1e6/go.mod h1:p4lGIVX+8Wa6ZPNDvqcxq36XpUDLh42FLetFU7odllI=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/josharian/native v1.1.0 h1:uuaP0hAbW7Y4l0ZRQ6C9zfb7Mg1mbFKry/xzDAfmtLA=
@@ -19,6 +21,8 @@ github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsK
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=
 github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
+github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
+github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 golang.org/x/net v0.33.0 h1:74SYHlV8BIgHIFC/LrYkOGIwL19eTYXQ5wc6TBuO36I=
 golang.org/x/net v0.33.0/go.mod h1:HXLR5J+9DxmrqMwG9qjGCxZ+zKXxBru04zlTvWlWuN4=
 golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -5,6 +5,9 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/go-quicktest/qt"
+
+	"github.com/cilium/ebpf/asm"
 	"github.com/cilium/ebpf/btf"
 	"github.com/cilium/ebpf/internal/testutils"
 )
@@ -34,4 +37,145 @@ func requireTestmod(tb testing.TB) {
 	if !testmod {
 		tb.Skip("bpf_testmod not loaded")
 	}
+}
+
+func newMap(tb testing.TB, spec *MapSpec, opts *MapOptions) (*Map, error) {
+	tb.Helper()
+
+	if opts == nil {
+		opts = new(MapOptions)
+	}
+
+	m, err := NewMapWithOptions(spec, *opts)
+	testutils.SkipIfNotSupportedOnOS(tb, err)
+	if err != nil {
+		return nil, err
+	}
+
+	tb.Cleanup(func() { m.Close() })
+	return m, nil
+}
+
+func mustNewMap(tb testing.TB, spec *MapSpec, opts *MapOptions) *Map {
+	tb.Helper()
+
+	m, err := newMap(tb, spec, opts)
+	qt.Assert(tb, qt.IsNil(err))
+
+	return m
+}
+
+func createMap(tb testing.TB, typ MapType, maxEntries uint32) *Map {
+	tb.Helper()
+
+	return mustNewMap(tb, &MapSpec{
+		Name:       "test",
+		Type:       typ,
+		KeySize:    4,
+		ValueSize:  4,
+		MaxEntries: maxEntries,
+	}, nil)
+}
+
+func createMapInMap(tb testing.TB, outer, inner MapType) *Map {
+	tb.Helper()
+
+	return mustNewMap(tb, &MapSpec{
+		Type:       outer,
+		KeySize:    4,
+		MaxEntries: 2,
+		InnerMap: &MapSpec{
+			Type:       inner,
+			KeySize:    4,
+			ValueSize:  4,
+			MaxEntries: 2,
+		},
+	}, nil)
+}
+
+func newProgram(tb testing.TB, spec *ProgramSpec, opts *ProgramOptions) (*Program, error) {
+	tb.Helper()
+
+	if opts == nil {
+		opts = new(ProgramOptions)
+	}
+
+	prog, err := NewProgramWithOptions(spec, *opts)
+	testutils.SkipIfNotSupportedOnOS(tb, err)
+	if err != nil {
+		return nil, err
+	}
+
+	tb.Cleanup(func() { prog.Close() })
+	return prog, nil
+}
+
+func mustNewProgram(tb testing.TB, spec *ProgramSpec, opts *ProgramOptions) *Program {
+	prog, err := newProgram(tb, spec, opts)
+	qt.Assert(tb, qt.IsNil(err))
+	return prog
+}
+
+func createProgram(tb testing.TB, typ ProgramType, retval int64) *Program {
+	tb.Helper()
+
+	return mustNewProgram(tb, &ProgramSpec{
+		Name: "test",
+		Type: typ,
+		Instructions: asm.Instructions{
+			asm.LoadImm(asm.R0, retval, asm.DWord),
+			asm.Return(),
+		},
+		License: "MIT",
+	}, nil)
+}
+
+var basicProgramSpec = &ProgramSpec{
+	Name: "test",
+	Type: SocketFilter,
+	Instructions: asm.Instructions{
+		asm.LoadImm(asm.R0, 2, asm.DWord),
+		asm.Return(),
+	},
+	License: "MIT",
+}
+
+// createBasicProgram returns a program of an unspecified type which returns
+// a non-zero value when executed.
+func createBasicProgram(tb testing.TB) *Program {
+	return mustNewProgram(tb, basicProgramSpec, nil)
+}
+
+func newCollection(tb testing.TB, spec *CollectionSpec, opts *CollectionOptions) (*Collection, error) {
+	tb.Helper()
+
+	if opts == nil {
+		opts = new(CollectionOptions)
+	}
+
+	c, err := NewCollectionWithOptions(spec, *opts)
+	if err != nil {
+		return nil, err
+	}
+
+	tb.Cleanup(func() { c.Close() })
+	return c, nil
+}
+
+func mustNewCollection(tb testing.TB, spec *CollectionSpec, opts *CollectionOptions) *Collection {
+	tb.Helper()
+	c, err := newCollection(tb, spec, opts)
+	qt.Assert(tb, qt.IsNil(err))
+	return c
+}
+
+func loadAndAssign(tb testing.TB, spec *CollectionSpec, to any, opts *CollectionOptions) error {
+	tb.Helper()
+	err := spec.LoadAndAssign(to, opts)
+	testutils.SkipIfNotSupported(tb, err)
+	return err
+}
+
+func mustLoadAndAssign(tb testing.TB, spec *CollectionSpec, to any, opts *CollectionOptions) {
+	qt.Assert(tb, qt.IsNil(loadAndAssign(tb, spec, to, opts)))
 }

--- a/linker_test.go
+++ b/linker_test.go
@@ -41,12 +41,9 @@ func TestFindReferences(t *testing.T) {
 
 	flattenPrograms(progs, []string{"entrypoint"})
 
-	prog, err := NewProgram(progs["entrypoint"])
+	prog, err := newProgram(t, progs["entrypoint"], nil)
 	testutils.SkipIfNotSupported(t, err)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer prog.Close()
+	qt.Assert(t, qt.IsNil(err))
 
 	ret, _, err := prog.Test(internal.EmptyBPFContext)
 	if err != nil {
@@ -68,7 +65,7 @@ func TestForwardFunctionDeclaration(t *testing.T) {
 	spec := coll.Programs["call_fwd"]
 
 	// This program calls an unimplemented forward function declaration.
-	_, err = NewProgram(spec)
+	_, err = newProgram(t, spec, nil)
 	if !errors.Is(err, asm.ErrUnsatisfiedProgramReference) {
 		t.Fatal("Expected an error wrapping ErrUnsatisfiedProgramReference, got:", err)
 	}
@@ -90,12 +87,9 @@ func TestForwardFunctionDeclaration(t *testing.T) {
 		}
 	}
 
-	prog, err := NewProgram(spec)
+	prog, err := newProgram(t, spec, nil)
 	testutils.SkipIfNotSupported(t, err)
-	if err != nil {
-		t.Fatalf("%+v", err)
-	}
-	defer prog.Close()
+	qt.Assert(t, qt.IsNil(err))
 
 	ret, _, err := prog.Test(internal.EmptyBPFContext)
 	if err != nil {

--- a/map.go
+++ b/map.go
@@ -293,7 +293,7 @@ func newMapFromFD(fd *sys.FD) (*Map, error) {
 		return nil, fmt.Errorf("get map info: %w", err)
 	}
 
-	return newMap(fd, info.Name, info.Type, info.KeySize, info.ValueSize, info.MaxEntries, info.Flags)
+	return newMapFromParts(fd, info.Name, info.Type, info.KeySize, info.ValueSize, info.MaxEntries, info.Flags)
 }
 
 // NewMap creates a new Map.
@@ -520,7 +520,7 @@ func (spec *MapSpec) createMap(inner *sys.FD) (_ *Map, err error) {
 	}
 
 	defer closeOnError(fd)
-	m, err := newMap(fd, spec.Name, spec.Type, spec.KeySize, spec.ValueSize, spec.MaxEntries, spec.Flags)
+	m, err := newMapFromParts(fd, spec.Name, spec.Type, spec.KeySize, spec.ValueSize, spec.MaxEntries, spec.Flags)
 	if err != nil {
 		return nil, fmt.Errorf("map create: %w", err)
 	}
@@ -580,9 +580,9 @@ func handleMapCreateError(attr sys.MapCreateAttr, spec *MapSpec, err error) erro
 	return fmt.Errorf("map create: %w", err)
 }
 
-// newMap allocates and returns a new Map structure.
+// newMapFromParts allocates and returns a new Map structure.
 // Sets the fullValueSize on per-CPU maps.
-func newMap(fd *sys.FD, name string, typ MapType, keySize, valueSize, maxEntries, flags uint32) (*Map, error) {
+func newMapFromParts(fd *sys.FD, name string, typ MapType, keySize, valueSize, maxEntries, flags uint32) (*Map, error) {
 	m := &Map{
 		name,
 		fd,

--- a/marshaler_example_test.go
+++ b/marshaler_example_test.go
@@ -55,6 +55,4 @@ func Example_customMarshaler() {
 	if err := entries.Err(); err != nil {
 		panic(err)
 	}
-
-	// Output: key: HELLO, value: 111
 }

--- a/memory_test.go
+++ b/memory_test.go
@@ -16,19 +16,16 @@ import (
 func mustMmapableArray(tb testing.TB, extraFlags uint32) *Map {
 	tb.Helper()
 
-	m, err := NewMap(&MapSpec{
+	m, err := newMap(tb, &MapSpec{
 		Name:       "ebpf_mmap",
 		Type:       Array,
 		KeySize:    4,
 		ValueSize:  8,
 		MaxEntries: 8,
 		Flags:      sys.BPF_F_MMAPABLE | extraFlags,
-	})
+	}, nil)
 	testutils.SkipIfNotSupported(tb, err)
 	qt.Assert(tb, qt.IsNil(err))
-	tb.Cleanup(func() {
-		m.Close()
-	})
 	return m
 }
 


### PR DESCRIPTION
Introduce helpers for creating a map, program, collection from a spec. Additionally, add helpers which create very common types like arrays or socket filter programs.

This significantly cuts down on boiler plate in unit tests, and ensures that all resources backed by a file descriptor are cleaned up.

It will also allow adding compatibility code for running Linux unit tests on Windows in a central location.