### PR TITLE
windows: even more test fixes

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -61,8 +61,8 @@ func (cs *CollectionSpec) Copy() *CollectionSpec {
 	}
 
 	cpy := CollectionSpec{
-		Maps:      make(map[string]*MapSpec, len(cs.Maps)),
-		Programs:  make(map[string]*ProgramSpec, len(cs.Programs)),
+		Maps:      copyMapOfSpecs(cs.Maps),
+		Programs:  copyMapOfSpecs(cs.Programs),
 		Variables: make(map[string]*VariableSpec, len(cs.Variables)),
 		ByteOrder: cs.ByteOrder,
 		Types:     cs.Types.Copy(),
@@ -79,8 +79,24 @@ func (cs *CollectionSpec) Copy() *CollectionSpec {
 	for name, spec := range cs.Variables {
 		cpy.Variables[name] = spec.copy(&cpy)
 	}
+	if cs.Variables == nil {
+		cpy.Variables = nil
+	}
 
 	return &cpy
+}
+
+func copyMapOfSpecs[T interface{ Copy() T }](m map[string]T) map[string]T {
+	if m == nil {
+		return nil
+	}
+
+	cpy := make(map[string]T, len(m))
+	for k, v := range m {
+		cpy[k] = v.Copy()
+	}
+
+	return cpy
 }
 
 // RewriteMaps replaces all references to specific maps.

--- a/collection.go
+++ b/collection.go
@@ -541,6 +541,7 @@ func (cl *collectionLoader) loadMap(mapName string) (*Map, error) {
 	// that need to be finalized before invoking the verifier.
 	if !mapSpec.Type.canStoreMapOrProgram() {
 		if err := m.finalize(mapSpec); err != nil {
+			_ = m.Close()
 			return nil, fmt.Errorf("finalizing map %s: %w", mapName, err)
 		}
 	}

--- a/collection_test.go
+++ b/collection_test.go
@@ -89,26 +89,6 @@ func TestCollectionSpecCopy(t *testing.T) {
 	qt.Assert(t, testutils.IsDeepCopy(cs.Copy(), cs))
 }
 
-func TestCollectionSpecLoadCopy(t *testing.T) {
-	file := testutils.NativeFile(t, "testdata/loader-%s.elf")
-	spec, err := LoadCollectionSpec(file)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	spec2 := spec.Copy()
-
-	var objs struct {
-		Prog *Program `ebpf:"xdp_prog"`
-	}
-
-	mustLoadAndAssign(t, spec, &objs, nil)
-	qt.Assert(t, qt.IsNil(objs.Prog.Close()))
-
-	mustLoadAndAssign(t, spec2, &objs, nil)
-	qt.Assert(t, qt.IsNil(objs.Prog.Close()))
-}
-
 func TestCollectionSpecLoadMutate(t *testing.T) {
 	file := testutils.NativeFile(t, "testdata/loader-%s.elf")
 	spec, err := LoadCollectionSpec(file)

--- a/collection_test.go
+++ b/collection_test.go
@@ -438,6 +438,21 @@ func TestCollectionSpecAssign(t *testing.T) {
 	}
 }
 
+func TestNewCollectionFdLeak(t *testing.T) {
+	spec := &CollectionSpec{
+		Maps: map[string]*MapSpec{
+			"map1": {
+				Type: Array, KeySize: 4, ValueSize: 4, MaxEntries: 1,
+				// 8 byte value will cause m.finalize to fail.
+				Contents: []MapKV{{uint32(0), uint64(0)}},
+			},
+		},
+	}
+
+	_, err := newCollection(t, spec, nil)
+	qt.Assert(t, qt.IsNotNil(err))
+}
+
 func TestAssignValues(t *testing.T) {
 	zero := func(t reflect.Type, name string) (interface{}, error) {
 		return reflect.Zero(t).Interface(), nil

--- a/internal/testutils/feature.go
+++ b/internal/testutils/feature.go
@@ -18,10 +18,14 @@ const (
 )
 
 func CheckFeatureTest(t *testing.T, fn func() error) {
+	t.Helper()
+
 	checkFeatureTestError(t, fn())
 }
 
 func checkFeatureTestError(t *testing.T, err error) {
+	t.Helper()
+
 	if err == nil {
 		return
 	}

--- a/prog_test.go
+++ b/prog_test.go
@@ -286,36 +286,6 @@ func TestProgramKernelVersion(t *testing.T) {
 	}, nil)
 }
 
-func TestProgramVerifierOutput(t *testing.T) {
-	prog := mustNewProgram(t, basicProgramSpec, &ProgramOptions{
-		LogLevel: LogLevelInstruction,
-	})
-
-	if prog.VerifierLog == "" {
-		t.Error("Expected VerifierLog to be present")
-	}
-
-	// Issue 64
-	_, err := newProgram(t, &ProgramSpec{
-		Type: SocketFilter,
-		Instructions: asm.Instructions{
-			asm.Mov.Reg(asm.R0, asm.R1),
-		},
-		License: "MIT",
-	}, &ProgramOptions{
-		LogLevel: LogLevelInstruction,
-	})
-
-	if err == nil {
-		t.Fatal("Expected an error from invalid program")
-	}
-
-	var ve *internal.VerifierError
-	if !errors.As(err, &ve) {
-		t.Error("Error is not a VerifierError")
-	}
-}
-
 func TestProgramVerifierLog(t *testing.T) {
 	check := func(t *testing.T, err error) {
 		t.Helper()


### PR DESCRIPTION
More prep work to make the Windows support easier to add.

collection: remove obsolete TestCollectionSpecLoadCopy

    The test was added in bf5a6cd6 ("collection: don't copy btf.Spec in
    CollectionSpec.Copy()"). We now copy the spec, so the test doesn't add
    anything meaningful.

    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>

collection: remove TestCollectionSpecLoadMutate

    Replace the test added in 278a9141 ("map: check MapReplacements 
    compatibility after applying BPF_F_MMAPABLE") with one that doesn't rely on
    the ELF reader.

collection: fix missing Map.Close in collectionLoader.loadMap

    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>

program: rework TestProgramRunEmptyData

    Remove the test in favour of a much shorter assert in TestProgramRun. Also
    remove the now unnecessary version skip, since we don't test against such
    old kernel versions anymore.

    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>

program: remove duplicate TestProgramVerifierOutput

    The test is a less exhaustive version of TestProgramVerifierLog, remove it.

    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>

testutils: add missing t.Helper() calls

    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>
