### PR TITLE
btf: Improve Array type name generation logic

### DIFF
--- a/btf/types.go
+++ b/btf/types.go
@@ -156,7 +156,37 @@ func (arr *Array) Format(fs fmt.State, verb rune) {
 	formatType(fs, verb, arr, "index=", arr.Index, "type=", arr.Type, "n=", arr.Nelems)
 }
 
-func (arr *Array) TypeName() string { return "" }
+func (arr *Array) TypeName() string {
+	elemTypeName := getArrayTypeName(arr.Type)
+	if elemTypeName == "" {
+		return ""
+	}
+
+	return fmt.Sprintf("%s[%d]", elemTypeName, arr.Nelems)
+}
+
+func getArrayTypeName(t Type) string {
+	typeName := t.TypeName()
+	if typeName != "" {
+		return typeName
+	}
+
+	switch v := t.(type) {
+	case *Pointer:
+		if v.Target == nil {
+			return ""
+		}
+		targetName := getArrayTypeName(v.Target)
+		if targetName == "" {
+			return ""
+		}
+		return fmt.Sprintf("%s*", targetName)
+	case qualifier:
+		return getArrayTypeName(v.qualify())
+	default:
+		return ""
+	}
+}
 
 func (arr *Array) copy() Type {
 	cpy := *arr

--- a/btf/types_test.go
+++ b/btf/types_test.go
@@ -580,3 +580,81 @@ func ExampleAs() {
 	fmt.Println(As[*Pointer](a))
 	// Output: Pointer[target=Typedef:"foo"] true
 }
+
+func Test_getArrayTypeName(t *testing.T) {
+	type args struct {
+		t Type
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "char[16]",
+			args: args{t: &Array{
+				Index: &Int{
+					Name:     "__ARRAY_SIZE_TYPE__",
+					Size:     4,
+					Encoding: IntEncoding(0), // Unsigned
+				},
+				Type: &Int{
+					Name:     "char",
+					Size:     1,
+					Encoding: IntEncoding(1), // Signed
+				},
+				Nelems: 16,
+			}},
+			want: "char[16]",
+		},
+		{
+			name: "int[10]",
+			args: args{t: &Array{
+				Index: &Int{},
+				Type: &Int{
+					Name: "int",
+					Size: 4,
+				},
+				Nelems: 10,
+			}},
+			want: "int[10]",
+		},
+		{
+			name: "char[4][5]",
+			args: args{t: &Array{
+				Index: &Int{},
+				Type: &Array{
+					Index: &Int{},
+					Type: &Int{
+						Name: "char",
+						Size: 1,
+					},
+					Nelems: 4,
+				},
+				Nelems: 5,
+			}},
+			want: "char[4][5]",
+		},
+		{
+			name: "int*[8]",
+			args: args{t: &Array{
+				Index: &Int{},
+				Type: &Pointer{
+					Target: &Int{
+						Name: "int",
+						Size: 4,
+					},
+				},
+				Nelems: 8,
+			}},
+			want: "int*[8]",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getArrayTypeName(tt.args.t); got != tt.want {
+				t.Errorf("getArrayTypeName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
fixed #1672 

Add getArrayTypeName function to support more complex array type name generation, including: 
- Basic type arrays (e.g., char[16], int[10])
- Multi-dimensional arrays (e.g., char[4][5])
- Pointer arrays (e.g., int[8])