### PR TITLE
link: minimal windows support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -364,6 +364,7 @@ jobs:
           ./internal/testutils/testmain
           ./internal/tracefs
           ./internal/unix
+          ./link
 
       - name: Upload Test Results
         if: always()

--- a/internal/efw/program.go
+++ b/internal/efw/program.go
@@ -1,0 +1,39 @@
+//go:build windows
+
+package efw
+
+import (
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+/*
+Attach a program.
+
+	ebpf_result_t ebpf_program_attach_by_fds(
+		fd_t program_fd,
+		_In_opt_ const ebpf_attach_type_t* attach_type,
+		_In_reads_bytes_opt_(attach_parameters_size) void* attach_parameters,
+		size_t attach_parameters_size,
+		_Out_ fd_t* link)
+*/
+var ebpfProgramAttachByFdsProc = newProc("ebpf_program_attach_by_fds")
+
+func EbpfProgramAttachFds(fd int, attachType windows.GUID, params unsafe.Pointer, params_size uintptr) (int, error) {
+	addr, err := ebpfProgramAttachByFdsProc.Find()
+	if err != nil {
+		return 0, err
+	}
+
+	var link FD
+	err = errorResult(syscall.SyscallN(addr,
+		uintptr(fd),
+		uintptr(unsafe.Pointer(&attachType)),
+		uintptr(params),
+		params_size,
+		uintptr(unsafe.Pointer(&link)),
+	))
+	return int(link), err
+}

--- a/link/anchor.go
+++ b/link/anchor.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package link
 
 import (

--- a/link/cgroup.go
+++ b/link/cgroup.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package link
 
 import (

--- a/link/cgroup_test.go
+++ b/link/cgroup_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package link
 
 import (

--- a/link/helpers_windows_test.go
+++ b/link/helpers_windows_test.go
@@ -1,0 +1,41 @@
+package link
+
+import (
+	"testing"
+
+	"golang.org/x/sys/windows"
+
+	"github.com/go-quicktest/qt"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/internal/efw"
+	"github.com/cilium/ebpf/internal/platform"
+)
+
+// windowsProgramTypeFromGUID resolves a GUID to a ProgramType.
+func windowsProgramTypeFromGUID(tb testing.TB, guid windows.GUID) ebpf.ProgramType {
+	rawProgramType, err := efw.EbpfGetBpfProgramType(guid)
+	qt.Assert(tb, qt.IsNil(err))
+
+	if rawProgramType == 0 {
+		tb.Skipf("Program type not found for GUID %v", guid)
+	}
+
+	typ, err := ebpf.ProgramTypeForPlatform(platform.Windows, rawProgramType)
+	qt.Assert(tb, qt.IsNil(err))
+	return typ
+}
+
+// windowsAttachTypeFromGUID resolves a GUID to an AttachType.
+func windowsAttachTypeFromGUID(tb testing.TB, guid windows.GUID) ebpf.AttachType {
+	rawAttachType, err := efw.EbpfGetBpfAttachType(guid)
+	qt.Assert(tb, qt.IsNil(err))
+
+	if rawAttachType == 0 {
+		tb.Skipf("Attach type not found for GUID %v", guid)
+	}
+
+	typ, err := ebpf.AttachTypeForPlatform(platform.Windows, rawAttachType)
+	qt.Assert(tb, qt.IsNil(err))
+	return typ
+}

--- a/link/iter.go
+++ b/link/iter.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package link
 
 import (

--- a/link/iter_test.go
+++ b/link/iter_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package link
 
 import (

--- a/link/kprobe.go
+++ b/link/kprobe.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package link
 
 import (

--- a/link/kprobe_multi.go
+++ b/link/kprobe_multi.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package link
 
 import (

--- a/link/kprobe_multi_test.go
+++ b/link/kprobe_multi_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package link
 
 import (

--- a/link/kprobe_test.go
+++ b/link/kprobe_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package link
 
 import (

--- a/link/link.go
+++ b/link/link.go
@@ -219,7 +219,10 @@ func (l *RawLink) UpdateArgs(opts RawLinkUpdateOptions) error {
 		OldProgFd: uint32(oldFd),
 		Flags:     opts.Flags,
 	}
-	return sys.LinkUpdate(&attr)
+	if err := sys.LinkUpdate(&attr); err != nil {
+		return fmt.Errorf("update link: %w", err)
+	}
+	return nil
 }
 
 // Info returns metadata about the link.

--- a/link/link.go
+++ b/link/link.go
@@ -8,9 +8,11 @@ import (
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/btf"
 	"github.com/cilium/ebpf/internal"
-	"github.com/cilium/ebpf/internal/platform"
 	"github.com/cilium/ebpf/internal/sys"
 )
+
+// Type is the kind of link.
+type Type = sys.LinkType
 
 var ErrNotSupported = internal.ErrNotSupported
 
@@ -91,51 +93,6 @@ func LoadPinnedLink(fileName string, opts *ebpf.LoadPinOptions) (Link, error) {
 	return wrapRawLink(raw)
 }
 
-// wrap a RawLink in a more specific type if possible.
-//
-// The function takes ownership of raw and closes it on error.
-func wrapRawLink(raw *RawLink) (_ Link, err error) {
-	defer func() {
-		if err != nil {
-			raw.Close()
-		}
-	}()
-
-	info, err := raw.Info()
-	if err != nil {
-		return nil, err
-	}
-
-	switch info.Type {
-	case RawTracepointType:
-		return &rawTracepoint{*raw}, nil
-	case TracingType:
-		return &tracing{*raw}, nil
-	case CgroupType:
-		return &linkCgroup{*raw}, nil
-	case IterType:
-		return &Iter{*raw}, nil
-	case NetNsType:
-		return &NetNsLink{*raw}, nil
-	case KprobeMultiType:
-		return &kprobeMultiLink{*raw}, nil
-	case UprobeMultiType:
-		return &uprobeMultiLink{*raw}, nil
-	case PerfEventType:
-		return &perfEventLink{*raw, nil}, nil
-	case TCXType:
-		return &tcxLink{*raw}, nil
-	case NetfilterType:
-		return &netfilterLink{*raw}, nil
-	case NetkitType:
-		return &netkitLink{*raw}, nil
-	case XDPType:
-		return &xdpLink{*raw}, nil
-	default:
-		return raw, nil
-	}
-}
-
 // ID uniquely identifies a BPF link.
 type ID = sys.LinkID
 
@@ -161,158 +118,6 @@ type Info struct {
 	extra   interface{}
 }
 
-type TracingInfo struct {
-	AttachType  sys.AttachType
-	TargetObjId uint32
-	TargetBtfId sys.TypeID
-}
-
-type CgroupInfo struct {
-	CgroupId   uint64
-	AttachType sys.AttachType
-	_          [4]byte
-}
-
-type NetNsInfo struct {
-	NetnsIno   uint32
-	AttachType sys.AttachType
-}
-
-type TCXInfo struct {
-	Ifindex    uint32
-	AttachType sys.AttachType
-}
-
-type XDPInfo struct {
-	Ifindex uint32
-}
-
-type NetfilterInfo struct {
-	Pf       uint32
-	Hooknum  uint32
-	Priority int32
-	Flags    uint32
-}
-
-type NetkitInfo struct {
-	Ifindex    uint32
-	AttachType sys.AttachType
-}
-
-type KprobeMultiInfo struct {
-	count  uint32
-	flags  uint32
-	missed uint64
-}
-
-// AddressCount is the number of addresses hooked by the kprobe.
-func (kpm *KprobeMultiInfo) AddressCount() (uint32, bool) {
-	return kpm.count, kpm.count > 0
-}
-
-func (kpm *KprobeMultiInfo) Flags() (uint32, bool) {
-	return kpm.flags, kpm.count > 0
-}
-
-func (kpm *KprobeMultiInfo) Missed() (uint64, bool) {
-	return kpm.missed, kpm.count > 0
-}
-
-type PerfEventInfo struct {
-	Type  sys.PerfEventType
-	extra interface{}
-}
-
-func (r *PerfEventInfo) Kprobe() *KprobeInfo {
-	e, _ := r.extra.(*KprobeInfo)
-	return e
-}
-
-type KprobeInfo struct {
-	address uint64
-	missed  uint64
-}
-
-func (kp *KprobeInfo) Address() (uint64, bool) {
-	return kp.address, kp.address > 0
-}
-
-func (kp *KprobeInfo) Missed() (uint64, bool) {
-	return kp.missed, kp.address > 0
-}
-
-// Tracing returns tracing type-specific link info.
-//
-// Returns nil if the type-specific link info isn't available.
-func (r Info) Tracing() *TracingInfo {
-	e, _ := r.extra.(*TracingInfo)
-	return e
-}
-
-// Cgroup returns cgroup type-specific link info.
-//
-// Returns nil if the type-specific link info isn't available.
-func (r Info) Cgroup() *CgroupInfo {
-	e, _ := r.extra.(*CgroupInfo)
-	return e
-}
-
-// NetNs returns netns type-specific link info.
-//
-// Returns nil if the type-specific link info isn't available.
-func (r Info) NetNs() *NetNsInfo {
-	e, _ := r.extra.(*NetNsInfo)
-	return e
-}
-
-// XDP returns XDP type-specific link info.
-//
-// Returns nil if the type-specific link info isn't available.
-func (r Info) XDP() *XDPInfo {
-	e, _ := r.extra.(*XDPInfo)
-	return e
-}
-
-// TCX returns TCX type-specific link info.
-//
-// Returns nil if the type-specific link info isn't available.
-func (r Info) TCX() *TCXInfo {
-	e, _ := r.extra.(*TCXInfo)
-	return e
-}
-
-// Netfilter returns netfilter type-specific link info.
-//
-// Returns nil if the type-specific link info isn't available.
-func (r Info) Netfilter() *NetfilterInfo {
-	e, _ := r.extra.(*NetfilterInfo)
-	return e
-}
-
-// Netkit returns netkit type-specific link info.
-//
-// Returns nil if the type-specific link info isn't available.
-func (r Info) Netkit() *NetkitInfo {
-	e, _ := r.extra.(*NetkitInfo)
-	return e
-}
-
-// KprobeMulti returns kprobe-multi type-specific link info.
-//
-// Returns nil if the type-specific link info isn't available.
-func (r Info) KprobeMulti() *KprobeMultiInfo {
-	e, _ := r.extra.(*KprobeMultiInfo)
-	return e
-}
-
-// PerfEvent returns perf-event type-specific link info.
-//
-// Returns nil if the type-specific link info isn't available.
-func (r Info) PerfEvent() *PerfEventInfo {
-	e, _ := r.extra.(*PerfEventInfo)
-	return e
-}
-
 // RawLink is the low-level API to bpf_link.
 //
 // You should consider using the higher level interfaces in this
@@ -320,41 +125,6 @@ func (r Info) PerfEvent() *PerfEventInfo {
 type RawLink struct {
 	fd         *sys.FD
 	pinnedPath string
-}
-
-// AttachRawLink creates a raw link.
-func AttachRawLink(opts RawLinkOptions) (*RawLink, error) {
-	if err := haveBPFLink(); err != nil {
-		return nil, err
-	}
-
-	if opts.Target < 0 {
-		return nil, fmt.Errorf("invalid target: %s", sys.ErrClosedFd)
-	}
-
-	progFd := opts.Program.FD()
-	if progFd < 0 {
-		return nil, fmt.Errorf("invalid program: %s", sys.ErrClosedFd)
-	}
-
-	p, attachType := platform.DecodeConstant(opts.Attach)
-	if p != "linux" {
-		return nil, fmt.Errorf("attach type %s: %w", opts.Attach, internal.ErrNotSupportedOnOS)
-	}
-
-	attr := sys.LinkCreateAttr{
-		TargetFd:    uint32(opts.Target),
-		ProgFd:      uint32(progFd),
-		AttachType:  sys.AttachType(attachType),
-		TargetBtfId: opts.BTF,
-		Flags:       opts.Flags,
-	}
-	fd, err := sys.LinkCreate(&attr)
-	if err != nil {
-		return nil, fmt.Errorf("create link: %w", err)
-	}
-
-	return &RawLink{fd, ""}, nil
 }
 
 func loadPinnedRawLink(fileName string, opts *ebpf.LoadPinOptions) (*RawLink, error) {

--- a/link/link_other.go
+++ b/link/link_other.go
@@ -1,0 +1,258 @@
+package link
+
+import (
+	"fmt"
+
+	"github.com/cilium/ebpf/internal"
+	"github.com/cilium/ebpf/internal/platform"
+	"github.com/cilium/ebpf/internal/sys"
+)
+
+// Valid link types.
+const (
+	UnspecifiedType   = sys.BPF_LINK_TYPE_UNSPEC
+	RawTracepointType = sys.BPF_LINK_TYPE_RAW_TRACEPOINT
+	TracingType       = sys.BPF_LINK_TYPE_TRACING
+	CgroupType        = sys.BPF_LINK_TYPE_CGROUP
+	IterType          = sys.BPF_LINK_TYPE_ITER
+	NetNsType         = sys.BPF_LINK_TYPE_NETNS
+	XDPType           = sys.BPF_LINK_TYPE_XDP
+	PerfEventType     = sys.BPF_LINK_TYPE_PERF_EVENT
+	KprobeMultiType   = sys.BPF_LINK_TYPE_KPROBE_MULTI
+	TCXType           = sys.BPF_LINK_TYPE_TCX
+	UprobeMultiType   = sys.BPF_LINK_TYPE_UPROBE_MULTI
+	NetfilterType     = sys.BPF_LINK_TYPE_NETFILTER
+	NetkitType        = sys.BPF_LINK_TYPE_NETKIT
+)
+
+// AttachRawLink creates a raw link.
+func AttachRawLink(opts RawLinkOptions) (*RawLink, error) {
+	if err := haveBPFLink(); err != nil {
+		return nil, err
+	}
+
+	if opts.Target < 0 {
+		return nil, fmt.Errorf("invalid target: %s", sys.ErrClosedFd)
+	}
+
+	progFd := opts.Program.FD()
+	if progFd < 0 {
+		return nil, fmt.Errorf("invalid program: %s", sys.ErrClosedFd)
+	}
+
+	p, attachType := platform.DecodeConstant(opts.Attach)
+	if p != "linux" {
+		return nil, fmt.Errorf("attach type %s: %w", opts.Attach, internal.ErrNotSupportedOnOS)
+	}
+
+	attr := sys.LinkCreateAttr{
+		TargetFd:    uint32(opts.Target),
+		ProgFd:      uint32(progFd),
+		AttachType:  sys.AttachType(attachType),
+		TargetBtfId: opts.BTF,
+		Flags:       opts.Flags,
+	}
+	fd, err := sys.LinkCreate(&attr)
+	if err != nil {
+		return nil, fmt.Errorf("create link: %w", err)
+	}
+
+	return &RawLink{fd, ""}, nil
+}
+
+// wrap a RawLink in a more specific type if possible.
+//
+// The function takes ownership of raw and closes it on error.
+func wrapRawLink(raw *RawLink) (_ Link, err error) {
+	defer func() {
+		if err != nil {
+			raw.Close()
+		}
+	}()
+
+	info, err := raw.Info()
+	if err != nil {
+		return nil, err
+	}
+
+	switch info.Type {
+	case RawTracepointType:
+		return &rawTracepoint{*raw}, nil
+	case TracingType:
+		return &tracing{*raw}, nil
+	case CgroupType:
+		return &linkCgroup{*raw}, nil
+	case IterType:
+		return &Iter{*raw}, nil
+	case NetNsType:
+		return &NetNsLink{*raw}, nil
+	case KprobeMultiType:
+		return &kprobeMultiLink{*raw}, nil
+	case UprobeMultiType:
+		return &uprobeMultiLink{*raw}, nil
+	case PerfEventType:
+		return &perfEventLink{*raw, nil}, nil
+	case TCXType:
+		return &tcxLink{*raw}, nil
+	case NetfilterType:
+		return &netfilterLink{*raw}, nil
+	case NetkitType:
+		return &netkitLink{*raw}, nil
+	case XDPType:
+		return &xdpLink{*raw}, nil
+	default:
+		return raw, nil
+	}
+}
+
+type TracingInfo struct {
+	AttachType  sys.AttachType
+	TargetObjId uint32
+	TargetBtfId sys.TypeID
+}
+
+type CgroupInfo struct {
+	CgroupId   uint64
+	AttachType sys.AttachType
+	_          [4]byte
+}
+
+type NetNsInfo struct {
+	NetnsIno   uint32
+	AttachType sys.AttachType
+}
+
+type TCXInfo struct {
+	Ifindex    uint32
+	AttachType sys.AttachType
+}
+
+type XDPInfo struct {
+	Ifindex uint32
+}
+
+type NetfilterInfo struct {
+	Pf       uint32
+	Hooknum  uint32
+	Priority int32
+	Flags    uint32
+}
+
+type NetkitInfo struct {
+	Ifindex    uint32
+	AttachType sys.AttachType
+}
+
+type KprobeMultiInfo struct {
+	count  uint32
+	flags  uint32
+	missed uint64
+}
+
+// AddressCount is the number of addresses hooked by the kprobe.
+func (kpm *KprobeMultiInfo) AddressCount() (uint32, bool) {
+	return kpm.count, kpm.count > 0
+}
+
+func (kpm *KprobeMultiInfo) Flags() (uint32, bool) {
+	return kpm.flags, kpm.count > 0
+}
+
+func (kpm *KprobeMultiInfo) Missed() (uint64, bool) {
+	return kpm.missed, kpm.count > 0
+}
+
+type PerfEventInfo struct {
+	Type  sys.PerfEventType
+	extra interface{}
+}
+
+func (r *PerfEventInfo) Kprobe() *KprobeInfo {
+	e, _ := r.extra.(*KprobeInfo)
+	return e
+}
+
+type KprobeInfo struct {
+	address uint64
+	missed  uint64
+}
+
+func (kp *KprobeInfo) Address() (uint64, bool) {
+	return kp.address, kp.address > 0
+}
+
+func (kp *KprobeInfo) Missed() (uint64, bool) {
+	return kp.missed, kp.address > 0
+}
+
+// Tracing returns tracing type-specific link info.
+//
+// Returns nil if the type-specific link info isn't available.
+func (r Info) Tracing() *TracingInfo {
+	e, _ := r.extra.(*TracingInfo)
+	return e
+}
+
+// Cgroup returns cgroup type-specific link info.
+//
+// Returns nil if the type-specific link info isn't available.
+func (r Info) Cgroup() *CgroupInfo {
+	e, _ := r.extra.(*CgroupInfo)
+	return e
+}
+
+// NetNs returns netns type-specific link info.
+//
+// Returns nil if the type-specific link info isn't available.
+func (r Info) NetNs() *NetNsInfo {
+	e, _ := r.extra.(*NetNsInfo)
+	return e
+}
+
+// XDP returns XDP type-specific link info.
+//
+// Returns nil if the type-specific link info isn't available.
+func (r Info) XDP() *XDPInfo {
+	e, _ := r.extra.(*XDPInfo)
+	return e
+}
+
+// TCX returns TCX type-specific link info.
+//
+// Returns nil if the type-specific link info isn't available.
+func (r Info) TCX() *TCXInfo {
+	e, _ := r.extra.(*TCXInfo)
+	return e
+}
+
+// Netfilter returns netfilter type-specific link info.
+//
+// Returns nil if the type-specific link info isn't available.
+func (r Info) Netfilter() *NetfilterInfo {
+	e, _ := r.extra.(*NetfilterInfo)
+	return e
+}
+
+// Netkit returns netkit type-specific link info.
+//
+// Returns nil if the type-specific link info isn't available.
+func (r Info) Netkit() *NetkitInfo {
+	e, _ := r.extra.(*NetkitInfo)
+	return e
+}
+
+// KprobeMulti returns kprobe-multi type-specific link info.
+//
+// Returns nil if the type-specific link info isn't available.
+func (r Info) KprobeMulti() *KprobeMultiInfo {
+	e, _ := r.extra.(*KprobeMultiInfo)
+	return e
+}
+
+// PerfEvent returns perf-event type-specific link info.
+//
+// Returns nil if the type-specific link info isn't available.
+func (r Info) PerfEvent() *PerfEventInfo {
+	e, _ := r.extra.(*PerfEventInfo)
+	return e
+}

--- a/link/link_other.go
+++ b/link/link_other.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package link
 
 import (
@@ -41,7 +43,7 @@ func AttachRawLink(opts RawLinkOptions) (*RawLink, error) {
 	}
 
 	p, attachType := platform.DecodeConstant(opts.Attach)
-	if p != "linux" {
+	if p != platform.Linux {
 		return nil, fmt.Errorf("attach type %s: %w", opts.Attach, internal.ErrNotSupportedOnOS)
 	}
 

--- a/link/link_other_test.go
+++ b/link/link_other_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package link
 
 import (

--- a/link/link_other_test.go
+++ b/link/link_other_test.go
@@ -1,0 +1,123 @@
+package link
+
+import (
+	"os"
+	"testing"
+
+	"github.com/go-quicktest/qt"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/asm"
+	"github.com/cilium/ebpf/internal/sys"
+	"github.com/cilium/ebpf/internal/testutils"
+)
+
+func testLinkArch(t *testing.T, link Link) {
+	t.Run("link/info", func(t *testing.T) {
+		info, err := link.Info()
+		testutils.SkipIfNotSupported(t, err)
+		if err != nil {
+			t.Fatal("Link info returns an error:", err)
+		}
+
+		if info.Type == 0 {
+			t.Fatal("Failed to get link info type")
+		}
+
+		switch link.(type) {
+		case *tracing:
+			if info.Tracing() == nil {
+				t.Fatalf("Failed to get link tracing extra info")
+			}
+		case *linkCgroup:
+			cg := info.Cgroup()
+			if cg.CgroupId == 0 {
+				t.Fatalf("Failed to get link Cgroup extra info")
+			}
+		case *NetNsLink:
+			netns := info.NetNs()
+			if netns.AttachType == 0 {
+				t.Fatalf("Failed to get link NetNs extra info")
+			}
+		case *xdpLink:
+			xdp := info.XDP()
+			if xdp.Ifindex == 0 {
+				t.Fatalf("Failed to get link XDP extra info")
+			}
+		case *tcxLink:
+			tcx := info.TCX()
+			if tcx.Ifindex == 0 {
+				t.Fatalf("Failed to get link TCX extra info")
+			}
+		case *netfilterLink:
+			nf := info.Netfilter()
+			if nf.Priority == 0 {
+				t.Fatalf("Failed to get link Netfilter extra info")
+			}
+		case *kprobeMultiLink:
+			// test default Info data
+			kmulti := info.KprobeMulti()
+			if count, ok := kmulti.AddressCount(); ok {
+				qt.Assert(t, qt.Not(qt.Equals(count, 0)))
+
+				_, ok = kmulti.Missed()
+				qt.Assert(t, qt.IsTrue(ok))
+				// NB: We don't check that missed is actually correct
+				// since it's not easy to trigger from tests.
+			}
+		case *perfEventLink:
+			// test default Info data
+			pevent := info.PerfEvent()
+			switch pevent.Type {
+			case sys.BPF_PERF_EVENT_KPROBE, sys.BPF_PERF_EVENT_KRETPROBE:
+				kp := pevent.Kprobe()
+				if addr, ok := kp.Address(); ok {
+					qt.Assert(t, qt.Not(qt.Equals(addr, 0)))
+
+					_, ok := kp.Missed()
+					qt.Assert(t, qt.IsTrue(ok))
+					// NB: We don't check that missed is actually correct
+					// since it's not easy to trigger from tests.
+				}
+			}
+		}
+	})
+}
+
+func mustCgroupFixtures(t *testing.T) (*os.File, *ebpf.Program) {
+	t.Helper()
+
+	testutils.SkipIfNotSupported(t, haveProgAttach())
+
+	return testutils.CreateCgroup(t), mustLoadProgram(t, ebpf.CGroupSKB, 0, "")
+}
+
+func mustLoadProgram(tb testing.TB, typ ebpf.ProgramType, attachType ebpf.AttachType, attachTo string) *ebpf.Program {
+	tb.Helper()
+
+	license := "MIT"
+	switch typ {
+	case ebpf.RawTracepoint, ebpf.LSM:
+		license = "GPL"
+	}
+
+	prog, err := ebpf.NewProgram(&ebpf.ProgramSpec{
+		Type:       typ,
+		AttachType: attachType,
+		AttachTo:   attachTo,
+		License:    license,
+		Instructions: asm.Instructions{
+			asm.Mov.Imm(asm.R0, 0),
+			asm.Return(),
+		},
+	})
+	if err != nil {
+		tb.Fatal(err)
+	}
+
+	tb.Cleanup(func() {
+		prog.Close()
+	})
+
+	return prog
+}

--- a/link/link_other_test.go
+++ b/link/link_other_test.go
@@ -84,6 +84,24 @@ func testLinkArch(t *testing.T, link Link) {
 	})
 }
 
+func newRawLink(t *testing.T) (*RawLink, *ebpf.Program) {
+	t.Helper()
+
+	cgroup, prog := mustCgroupFixtures(t)
+	link, err := AttachRawLink(RawLinkOptions{
+		Target:  int(cgroup.Fd()),
+		Program: prog,
+		Attach:  ebpf.AttachCGroupInetEgress,
+	})
+	testutils.SkipIfNotSupported(t, err)
+	if err != nil {
+		t.Fatal("Can't create raw link:", err)
+	}
+	t.Cleanup(func() { link.Close() })
+
+	return link, prog
+}
+
 func mustCgroupFixtures(t *testing.T) (*os.File, *ebpf.Program) {
 	t.Helper()
 

--- a/link/link_test.go
+++ b/link/link_test.go
@@ -9,8 +9,6 @@ import (
 	"testing"
 
 	"github.com/cilium/ebpf"
-	"github.com/cilium/ebpf/asm"
-	"github.com/cilium/ebpf/internal/sys"
 	"github.com/cilium/ebpf/internal/testutils"
 	"github.com/cilium/ebpf/internal/testutils/testmain"
 	"github.com/cilium/ebpf/internal/unix"
@@ -172,14 +170,6 @@ func newPinnedRawLink(t *testing.T, cgroup *os.File, prog *ebpf.Program) (*RawLi
 	return link, path
 }
 
-func mustCgroupFixtures(t *testing.T) (*os.File, *ebpf.Program) {
-	t.Helper()
-
-	testutils.SkipIfNotSupported(t, haveProgAttach())
-
-	return testutils.CreateCgroup(t), mustLoadProgram(t, ebpf.CGroupSKB, 0, "")
-}
-
 func testLink(t *testing.T, link Link, prog *ebpf.Program) {
 	t.Helper()
 
@@ -236,75 +226,7 @@ func testLink(t *testing.T, link Link, prog *ebpf.Program) {
 		}()
 	})
 
-	t.Run("link/info", func(t *testing.T) {
-		info, err := link.Info()
-		testutils.SkipIfNotSupported(t, err)
-		if err != nil {
-			t.Fatal("Link info returns an error:", err)
-		}
-
-		if info.Type == 0 {
-			t.Fatal("Failed to get link info type")
-		}
-
-		switch link.(type) {
-		case *tracing:
-			if info.Tracing() == nil {
-				t.Fatalf("Failed to get link tracing extra info")
-			}
-		case *linkCgroup:
-			cg := info.Cgroup()
-			if cg.CgroupId == 0 {
-				t.Fatalf("Failed to get link Cgroup extra info")
-			}
-		case *NetNsLink:
-			netns := info.NetNs()
-			if netns.AttachType == 0 {
-				t.Fatalf("Failed to get link NetNs extra info")
-			}
-		case *xdpLink:
-			xdp := info.XDP()
-			if xdp.Ifindex == 0 {
-				t.Fatalf("Failed to get link XDP extra info")
-			}
-		case *tcxLink:
-			tcx := info.TCX()
-			if tcx.Ifindex == 0 {
-				t.Fatalf("Failed to get link TCX extra info")
-			}
-		case *netfilterLink:
-			nf := info.Netfilter()
-			if nf.Priority == 0 {
-				t.Fatalf("Failed to get link Netfilter extra info")
-			}
-		case *kprobeMultiLink:
-			// test default Info data
-			kmulti := info.KprobeMulti()
-			if count, ok := kmulti.AddressCount(); ok {
-				qt.Assert(t, qt.Not(qt.Equals(count, 0)))
-
-				_, ok = kmulti.Missed()
-				qt.Assert(t, qt.IsTrue(ok))
-				// NB: We don't check that missed is actually correct
-				// since it's not easy to trigger from tests.
-			}
-		case *perfEventLink:
-			// test default Info data
-			pevent := info.PerfEvent()
-			switch pevent.Type {
-			case sys.BPF_PERF_EVENT_KPROBE, sys.BPF_PERF_EVENT_KRETPROBE:
-				kp := pevent.Kprobe()
-				if addr, ok := kp.Address(); ok {
-					qt.Assert(t, qt.Not(qt.Equals(addr, 0)))
-
-					_, ok := kp.Missed()
-					qt.Assert(t, qt.IsTrue(ok))
-					// NB: We don't check that missed is actually correct
-					// since it's not easy to trigger from tests.
-				}
-			}
-		}
-	})
+	testLinkArch(t, link)
 
 	type FDer interface {
 		FD() int
@@ -339,36 +261,6 @@ func testLink(t *testing.T, link Link, prog *ebpf.Program) {
 	if err := link.Close(); err != nil {
 		t.Fatalf("%T.Close returns an error: %s", link, err)
 	}
-}
-
-func mustLoadProgram(tb testing.TB, typ ebpf.ProgramType, attachType ebpf.AttachType, attachTo string) *ebpf.Program {
-	tb.Helper()
-
-	license := "MIT"
-	switch typ {
-	case ebpf.RawTracepoint, ebpf.LSM:
-		license = "GPL"
-	}
-
-	prog, err := ebpf.NewProgram(&ebpf.ProgramSpec{
-		Type:       typ,
-		AttachType: attachType,
-		AttachTo:   attachTo,
-		License:    license,
-		Instructions: asm.Instructions{
-			asm.Mov.Imm(asm.R0, 0),
-			asm.Return(),
-		},
-	})
-	if err != nil {
-		tb.Fatal(err)
-	}
-
-	tb.Cleanup(func() {
-		prog.Close()
-	})
-
-	return prog
 }
 
 func TestLoadWrongPin(t *testing.T) {

--- a/link/link_windows.go
+++ b/link/link_windows.go
@@ -1,0 +1,48 @@
+package link
+
+import (
+	"fmt"
+
+	"github.com/cilium/ebpf/internal"
+	"github.com/cilium/ebpf/internal/efw"
+	"github.com/cilium/ebpf/internal/platform"
+	"github.com/cilium/ebpf/internal/sys"
+)
+
+// AttachRawLink creates a raw link.
+func AttachRawLink(opts RawLinkOptions) (*RawLink, error) {
+	if opts.Target != 0 || opts.BTF != 0 || opts.Flags != 0 {
+		return nil, fmt.Errorf("specified option(s) %w", internal.ErrNotSupportedOnOS)
+	}
+
+	plat, attachType := platform.DecodeConstant(opts.Attach)
+	if plat != platform.Windows {
+		return nil, fmt.Errorf("attach type %s: %w", opts.Attach, internal.ErrNotSupportedOnOS)
+	}
+
+	attachTypeGUID, err := efw.EbpfGetEbpfAttachType(attachType)
+	if err != nil {
+		return nil, fmt.Errorf("get attach type: %w", err)
+	}
+
+	progFd := opts.Program.FD()
+	if progFd < 0 {
+		return nil, fmt.Errorf("invalid program: %s", sys.ErrClosedFd)
+	}
+
+	raw, err := efw.EbpfProgramAttachFds(progFd, attachTypeGUID, nil, 0)
+	if err != nil {
+		return nil, fmt.Errorf("attach link: %w", err)
+	}
+
+	fd, err := sys.NewFD(int(raw))
+	if err != nil {
+		return nil, err
+	}
+
+	return &RawLink{fd: fd}, nil
+}
+
+func wrapRawLink(raw *RawLink) (Link, error) {
+	return raw, nil
+}

--- a/link/link_windows_test.go
+++ b/link/link_windows_test.go
@@ -1,0 +1,102 @@
+package link
+
+import (
+	"os/exec"
+	"testing"
+
+	"github.com/go-quicktest/qt"
+	"golang.org/x/sys/windows"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/asm"
+)
+
+// ntosebpfext has not yet assigned a stable enum value so we can't refer to
+// it via that (https://github.com/microsoft/ntosebpfext/issues/152).
+//
+// See https://github.com/microsoft/ntosebpfext/blob/75ceaac38a0254e44f3219852d79a336d10ad9f3/include/ebpf_ntos_program_attach_type_guids.h
+var (
+	programTypeProcessGUID = makeGUID(0x22ea7b37, 0x1043, 0x4d0d, [8]byte{0xb6, 0x0d, 0xca, 0xfa, 0x1c, 0x7b, 0x63, 0x8e})
+	attachTypeProcessGUID  = makeGUID(0x66e20687, 0x9805, 0x4458, [8]byte{0xa0, 0xdb, 0x38, 0xe2, 0x20, 0xd3, 0x16, 0x85})
+)
+
+func testLinkArch(t *testing.T, link Link) {}
+
+func newRawLink(t *testing.T) (*RawLink, *ebpf.Program) {
+	prog, err := ebpf.NewProgram(&ebpf.ProgramSpec{
+		Type: ebpf.WindowsBind,
+		Instructions: asm.Instructions{
+			asm.Mov.Imm(asm.R0, 0),
+			asm.Return(),
+		},
+		License: "MIT",
+	})
+	qt.Assert(t, qt.IsNil(err))
+	t.Cleanup(func() { prog.Close() })
+
+	link, err := AttachRawLink(RawLinkOptions{
+		Program: prog,
+		Attach:  ebpf.AttachWindowsBind,
+	})
+	qt.Assert(t, qt.IsNil(err))
+	t.Cleanup(func() { link.Close() })
+
+	return link, prog
+}
+
+func TestProcessLink(t *testing.T) {
+	array, err := ebpf.NewMap(&ebpf.MapSpec{
+		Type:       ebpf.WindowsArray,
+		Name:       "process_state",
+		KeySize:    4,
+		ValueSize:  4,
+		MaxEntries: 1,
+	})
+	qt.Assert(t, qt.IsNil(err))
+	defer array.Close()
+
+	prog, err := ebpf.NewProgram(&ebpf.ProgramSpec{
+		Type: windowsProgramTypeFromGUID(t, programTypeProcessGUID),
+		Name: "process_test",
+		Instructions: asm.Instructions{
+			// R1 = map
+			asm.LoadMapPtr(asm.R1, array.FD()),
+			// R2 = key
+			asm.Mov.Reg(asm.R2, asm.R10),
+			asm.Add.Imm(asm.R2, -4),
+			asm.StoreImm(asm.R2, 0, 0, asm.Word),
+			// R3 = value
+			asm.Mov.Reg(asm.R3, asm.R2),
+			asm.Add.Imm(asm.R3, -4),
+			asm.StoreImm(asm.R3, 0, 1, asm.Word),
+			// R4 = flags
+			asm.Mov.Imm(asm.R4, 0),
+			// bpf_map_update_elem(map, key, value, flags)
+			asm.WindowsFnMapUpdateElem.Call(),
+			asm.Mov.Imm(asm.R0, 0),
+			asm.Return(),
+		},
+		License: "MIT",
+	})
+	qt.Assert(t, qt.IsNil(err))
+	defer prog.Close()
+
+	link, err := AttachRawLink(RawLinkOptions{
+		Program: prog,
+		Attach:  windowsAttachTypeFromGUID(t, attachTypeProcessGUID),
+	})
+	qt.Assert(t, qt.IsNil(err))
+	defer link.Close()
+
+	qt.Assert(t, qt.IsNil(exec.Command("cmd.exe", "/c", "exit 0").Run()))
+
+	var value uint32
+	qt.Assert(t, qt.IsNil(array.Lookup(uint32(0), &value)))
+	qt.Assert(t, qt.Equals(value, 1), qt.Commentf("Executing a binary should trigger the program"))
+
+	qt.Assert(t, qt.IsNil(link.Close()))
+}
+
+func makeGUID(data1 uint32, data2 uint16, data3 uint16, data4 [8]byte) windows.GUID {
+	return windows.GUID{Data1: data1, Data2: data2, Data3: data3, Data4: data4}
+}

--- a/link/netfilter.go
+++ b/link/netfilter.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package link
 
 import (

--- a/link/netfilter_test.go
+++ b/link/netfilter_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package link
 
 import (

--- a/link/netkit.go
+++ b/link/netkit.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package link
 
 import (

--- a/link/netkit_test.go
+++ b/link/netkit_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package link
 
 import (

--- a/link/netns.go
+++ b/link/netns.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package link
 
 import (

--- a/link/netns_test.go
+++ b/link/netns_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package link
 
 import (

--- a/link/perf_event.go
+++ b/link/perf_event.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package link
 
 import (

--- a/link/perf_event_test.go
+++ b/link/perf_event_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package link
 
 import (

--- a/link/program.go
+++ b/link/program.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package link
 
 import (

--- a/link/program_test.go
+++ b/link/program_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package link
 
 import (

--- a/link/query.go
+++ b/link/query.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package link
 
 import (

--- a/link/query_test.go
+++ b/link/query_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package link
 
 import (

--- a/link/raw_tracepoint.go
+++ b/link/raw_tracepoint.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package link
 
 import (

--- a/link/raw_tracepoint_test.go
+++ b/link/raw_tracepoint_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package link
 
 import (

--- a/link/socket_filter.go
+++ b/link/socket_filter.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package link
 
 import (

--- a/link/socket_filter_test.go
+++ b/link/socket_filter_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package link
 
 import (

--- a/link/syscalls.go
+++ b/link/syscalls.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package link
 
 import (

--- a/link/syscalls.go
+++ b/link/syscalls.go
@@ -10,26 +10,6 @@ import (
 	"github.com/cilium/ebpf/internal/unix"
 )
 
-// Type is the kind of link.
-type Type = sys.LinkType
-
-// Valid link types.
-const (
-	UnspecifiedType   = sys.BPF_LINK_TYPE_UNSPEC
-	RawTracepointType = sys.BPF_LINK_TYPE_RAW_TRACEPOINT
-	TracingType       = sys.BPF_LINK_TYPE_TRACING
-	CgroupType        = sys.BPF_LINK_TYPE_CGROUP
-	IterType          = sys.BPF_LINK_TYPE_ITER
-	NetNsType         = sys.BPF_LINK_TYPE_NETNS
-	XDPType           = sys.BPF_LINK_TYPE_XDP
-	PerfEventType     = sys.BPF_LINK_TYPE_PERF_EVENT
-	KprobeMultiType   = sys.BPF_LINK_TYPE_KPROBE_MULTI
-	TCXType           = sys.BPF_LINK_TYPE_TCX
-	UprobeMultiType   = sys.BPF_LINK_TYPE_UPROBE_MULTI
-	NetfilterType     = sys.BPF_LINK_TYPE_NETFILTER
-	NetkitType        = sys.BPF_LINK_TYPE_NETKIT
-)
-
 var haveProgAttach = internal.NewFeatureTest("BPF_PROG_ATTACH", func() error {
 	prog, err := ebpf.NewProgram(&ebpf.ProgramSpec{
 		Type:    ebpf.CGroupSKB,

--- a/link/syscalls_test.go
+++ b/link/syscalls_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package link
 
 import (

--- a/link/tcx.go
+++ b/link/tcx.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package link
 
 import (

--- a/link/tcx_test.go
+++ b/link/tcx_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package link
 
 import (

--- a/link/tracepoint.go
+++ b/link/tracepoint.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package link
 
 import (

--- a/link/tracepoint_test.go
+++ b/link/tracepoint_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package link
 
 import (

--- a/link/tracing.go
+++ b/link/tracing.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package link
 
 import (

--- a/link/tracing_test.go
+++ b/link/tracing_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package link
 
 import (

--- a/link/uprobe.go
+++ b/link/uprobe.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package link
 
 import (

--- a/link/uprobe_multi.go
+++ b/link/uprobe_multi.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package link
 
 import (

--- a/link/uprobe_multi_test.go
+++ b/link/uprobe_multi_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package link
 
 import (

--- a/link/uprobe_test.go
+++ b/link/uprobe_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package link
 
 import (

--- a/link/xdp.go
+++ b/link/xdp.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package link
 
 import (

--- a/link/xdp_test.go
+++ b/link/xdp_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package link
 
 import (


### PR DESCRIPTION
link: split out platform specific code

    Move platform specific code into separate files. No other changes intended.

    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>

link: streamline test helpers

    Change test helpers so that they are easier to implement on other platforms.

    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>

link: minimal windows support

    We retain the Link interface and the RawLink type, but all other link types
    are not available on Windows. There is a possibility that we can extend the
    XDP link to Windows, but that will have to come later.

    There is no support to retrieve link information or to pass additional 
    context to the link create call.

    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>
