### PR TITLE
features: return ErrNotSupportedOnOS on windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -352,6 +352,7 @@ jobs:
           ./
           ./asm
           ./btf
+          ./features
           ./internal
           ./internal/efw
           ./internal/kallsyms

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,9 +54,9 @@ jobs:
         run: go build -v ./...
         working-directory: ./examples
 
-      - name: Cross build windows
+      - name: Cross build darwin
         env:
-          GOOS: windows
+          GOOS: darwin
         run: |
           go build -v ./...
           go test -c -o /dev/null ./... >/dev/null

--- a/cmd/bpf2go/test/api_test.go
+++ b/cmd/bpf2go/test/api_test.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build linux
 
 package test
 

--- a/features/map.go
+++ b/features/map.go
@@ -1,5 +1,3 @@
-//go:build linux
-
 package features
 
 import (

--- a/features/map_test.go
+++ b/features/map_test.go
@@ -1,5 +1,3 @@
-//go:build linux
-
 package features
 
 import (

--- a/features/misc.go
+++ b/features/misc.go
@@ -1,5 +1,3 @@
-//go:build linux
-
 package features
 
 import (

--- a/features/misc_test.go
+++ b/features/misc_test.go
@@ -1,5 +1,3 @@
-//go:build linux
-
 package features
 
 import (

--- a/features/prog.go
+++ b/features/prog.go
@@ -1,5 +1,3 @@
-//go:build linux
-
 package features
 
 import (

--- a/features/prog_test.go
+++ b/features/prog_test.go
@@ -1,5 +1,3 @@
-//go:build linux
-
 package features
 
 import (
@@ -74,6 +72,7 @@ func TestHaveProgramHelper(t *testing.T) {
 			testutils.SkipOnOldKernel(t, tc.version, feature)
 
 			err := HaveProgramHelper(tc.prog, tc.helper)
+			testutils.SkipIfNotSupportedOnOS(t, err)
 			if !errors.Is(err, tc.expected) {
 				t.Fatalf("%s/%s: %v", tc.prog.String(), tc.helper.String(), err)
 			}

--- a/features/version.go
+++ b/features/version.go
@@ -1,5 +1,3 @@
-//go:build linux
-
 package features
 
 import "github.com/cilium/ebpf/internal/linux"


### PR DESCRIPTION
features: return ErrNotSupportedOnOS on windows

    This reverts commit 8d7c47ffbd3812ed2ef7de4ada79141b9d3a8126.

    Return a sentinel error instead of removing the API outright. This avoids
    compilation failures on non-Linux platforms.

    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>

CI: cross build for darwin

    Switch the windows cross-build back to darwin. We have a dedicated Windows
    job now, so bringin the darwin build back is more useful.

    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>
