### PR TITLE
ebpf: allow retrieving program / attach type from GUID

### DIFF
--- a/link/helpers_windows_test.go
+++ b/link/helpers_windows_test.go
@@ -1,6 +1,8 @@
 package link
 
 import (
+	"errors"
+	"os"
 	"testing"
 
 	"golang.org/x/sys/windows"
@@ -8,34 +10,24 @@ import (
 	"github.com/go-quicktest/qt"
 
 	"github.com/cilium/ebpf"
-	"github.com/cilium/ebpf/internal/efw"
-	"github.com/cilium/ebpf/internal/platform"
 )
 
-// windowsProgramTypeFromGUID resolves a GUID to a ProgramType.
-func windowsProgramTypeFromGUID(tb testing.TB, guid windows.GUID) ebpf.ProgramType {
-	rawProgramType, err := efw.EbpfGetBpfProgramType(guid)
-	qt.Assert(tb, qt.IsNil(err))
-
-	if rawProgramType == 0 {
-		tb.Skipf("Program type not found for GUID %v", guid)
-	}
-
-	typ, err := ebpf.ProgramTypeForPlatform(platform.Windows, rawProgramType)
-	qt.Assert(tb, qt.IsNil(err))
-	return typ
-}
-
-// windowsAttachTypeFromGUID resolves a GUID to an AttachType.
-func windowsAttachTypeFromGUID(tb testing.TB, guid windows.GUID) ebpf.AttachType {
-	rawAttachType, err := efw.EbpfGetBpfAttachType(guid)
-	qt.Assert(tb, qt.IsNil(err))
-
-	if rawAttachType == 0 {
+// windowsProgramTypeForGUID resolves a GUID to a ProgramType.
+func windowsProgramTypeForGUID(tb testing.TB, guid windows.GUID) ebpf.ProgramType {
+	programType, err := ebpf.WindowsProgramTypeForGUID(guid.String())
+	if errors.Is(err, os.ErrNotExist) {
 		tb.Skipf("Attach type not found for GUID %v", guid)
 	}
-
-	typ, err := ebpf.AttachTypeForPlatform(platform.Windows, rawAttachType)
 	qt.Assert(tb, qt.IsNil(err))
-	return typ
+	return programType
+}
+
+// windowsAttachTypeForGUID resolves a GUID to an AttachType.
+func windowsAttachTypeForGUID(tb testing.TB, guid windows.GUID) ebpf.AttachType {
+	attachType, err := ebpf.WindowsAttachTypeForGUID(guid.String())
+	if errors.Is(err, os.ErrNotExist) {
+		tb.Skipf("Attach type not found for GUID %v", guid)
+	}
+	qt.Assert(tb, qt.IsNil(err))
+	return attachType
 }

--- a/link/link_windows_test.go
+++ b/link/link_windows_test.go
@@ -56,7 +56,7 @@ func TestProcessLink(t *testing.T) {
 	defer array.Close()
 
 	prog, err := ebpf.NewProgram(&ebpf.ProgramSpec{
-		Type: windowsProgramTypeFromGUID(t, programTypeProcessGUID),
+		Type: windowsProgramTypeForGUID(t, programTypeProcessGUID),
 		Name: "process_test",
 		Instructions: asm.Instructions{
 			// R1 = map
@@ -83,7 +83,7 @@ func TestProcessLink(t *testing.T) {
 
 	link, err := AttachRawLink(RawLinkOptions{
 		Program: prog,
-		Attach:  windowsAttachTypeFromGUID(t, attachTypeProcessGUID),
+		Attach:  windowsAttachTypeForGUID(t, attachTypeProcessGUID),
 	})
 	qt.Assert(t, qt.IsNil(err))
 	defer link.Close()

--- a/types_windows.go
+++ b/types_windows.go
@@ -1,0 +1,57 @@
+package ebpf
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/windows"
+
+	"github.com/cilium/ebpf/internal/efw"
+	"github.com/cilium/ebpf/internal/platform"
+)
+
+// WindowsProgramTypeForGUID resolves a GUID to a ProgramType.
+//
+// The GUID must be in the form of "{XXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX}".
+//
+// Returns an error wrapping [os.ErrNotExist] if the GUID is not recignized.
+func WindowsProgramTypeForGUID(guid string) (ProgramType, error) {
+	progTypeGUID, err := windows.GUIDFromString(guid)
+	if err != nil {
+		return 0, fmt.Errorf("parse GUID: %w", err)
+	}
+
+	rawProgramType, err := efw.EbpfGetBpfProgramType(progTypeGUID)
+	if err != nil {
+		return 0, fmt.Errorf("get program type: %w", err)
+	}
+
+	if rawProgramType == 0 {
+		return 0, fmt.Errorf("program type not found for GUID %v: %w", guid, os.ErrNotExist)
+	}
+
+	return ProgramTypeForPlatform(platform.Windows, rawProgramType)
+}
+
+// WindowsAttachTypeForGUID resolves a GUID to an AttachType.
+//
+// The GUID must be in the form of "{XXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX}".
+//
+// Returns an error wrapping [os.ErrNotExist] if the GUID is not recignized.
+func WindowsAttachTypeForGUID(guid string) (AttachType, error) {
+	attachTypeGUID, err := windows.GUIDFromString(guid)
+	if err != nil {
+		return 0, fmt.Errorf("parse GUID: %w", err)
+	}
+
+	rawAttachType, err := efw.EbpfGetBpfAttachType(attachTypeGUID)
+	if err != nil {
+		return 0, fmt.Errorf("get attach type: %w", err)
+	}
+
+	if rawAttachType == 0 {
+		return 0, fmt.Errorf("attach type not found for GUID %v: %w", attachTypeGUID, os.ErrNotExist)
+	}
+
+	return AttachTypeForPlatform(platform.Windows, rawAttachType)
+}

--- a/types_windows_test.go
+++ b/types_windows_test.go
@@ -1,0 +1,37 @@
+package ebpf
+
+import (
+	"os"
+	"testing"
+
+	"github.com/go-quicktest/qt"
+	"golang.org/x/sys/windows"
+)
+
+func TestWindowsProgramTypeForGUID(t *testing.T) {
+	xdpGUID := windows.GUID{
+		Data1: 0xf1832a85, Data2: 0x85d5, Data3: 0x45b0,
+		Data4: [...]byte{0x98, 0xa0, 0x70, 0x69, 0xd6, 0x30, 0x13, 0xb0},
+	}
+
+	_, err := WindowsProgramTypeForGUID("{00000000-0000-0000-0000-000000000001}")
+	qt.Assert(t, qt.ErrorIs(err, os.ErrNotExist))
+
+	programType, err := WindowsProgramTypeForGUID(xdpGUID.String())
+	qt.Assert(t, qt.IsNil(err))
+	qt.Assert(t, qt.Equals(WindowsXDP, programType))
+}
+
+func TestWindowsAttachTypeForGUID(t *testing.T) {
+	xdpGUID := windows.GUID{
+		Data1: 0x85e0d8ef, Data2: 0x579e, Data3: 0x4931,
+		Data4: [...]byte{0xb0, 0x72, 0x8e, 0xe2, 0x26, 0xbb, 0x2e, 0x9d},
+	}
+
+	_, err := WindowsAttachTypeForGUID("{00000000-0000-0000-0000-000000000001}")
+	qt.Assert(t, qt.ErrorIs(err, os.ErrNotExist))
+
+	attachType, err := WindowsAttachTypeForGUID(xdpGUID.String())
+	qt.Assert(t, qt.IsNil(err))
+	qt.Assert(t, qt.Equals(AttachWindowsXDP, attachType))
+}


### PR DESCRIPTION
Export a function which allows resolving a GUID to an AttachType. This is useful when an eBPF extension has not yet registered a stable AttachType with the eBPF for Windows runtime, as is currently the case for ntosebpfext.