### PR TITLE
docs: add user facing documentation for Windows

### DIFF
--- a/docs/ebpf/contributing/windows.md
+++ b/docs/ebpf/contributing/windows.md
@@ -1,4 +1,4 @@
-# How to work on the Windows port
+# Working on the Windows port
 
 The library has basic support for interacting with eBPF for Windows (efW).
 Things are subject to change because eBPF for Windows has not had a stable (signed) release yet.
@@ -15,16 +15,6 @@ Things are subject to change because eBPF for Windows has not had a stable (sign
 * eBPF for Windows has a large user-space component which ebpf-go calls into
   via dynamic runtime linking. This uses the same infrastructure as CGo but
   does not require a C toolchain and is therefore trivial to distribute.
-
-## Platform specific ELFs
-
-ELFs compiled against Linux and Windows headers are not binary compatible.
-Add the following to ELFs targeting Windows until there is an
-[official way to declare the platform]:
-
-```C
-const bool __ebpf_for_windows_tag __attribute__((section(".ebpf_for_windows"))) = true;
-```
 
 ## Exported API
 
@@ -184,5 +174,4 @@ efW uses several layers of error codes.
 [ntosebpfext]: https://github.com/microsoft/ntosebpfext
 [access the debug version of the msvc runtime]: https://github.com/microsoft/ebpf-for-windows/issues/3872
 [msvc debug DLLs]: https://github.com/microsoft/ebpf-for-windows/blob/7005b7ff47e7281843d6b414cd69fc5a979507c8/scripts/setup-ebpf.ps1#L17-L27
-[official way to declare the platform]: https://github.com/microsoft/ebpf-for-windows/issues/3956
 [efW CI/CD]: https://github.com/microsoft/ebpf-for-windows/actions/workflows/cicd.yml?query=branch%3Amain+is%3Acompleted

--- a/docs/ebpf/guides/windows-support.md
+++ b/docs/ebpf/guides/windows-support.md
@@ -1,0 +1,57 @@
+# Windows support
+
+The library has preliminary support for the [eBPF for Windows] runtime, allowing
+you to build Go applications for Windows using the same APIs as on Linux.
+
+!!! warning "Feature parity"
+    efW doesn't have feature parity with Linux. Many APIs in
+    the library will return `ErrNotSupported` in this case.
+
+!!! warning "Binary compatibility"
+    efW is not binary compatible with Linux. It is not possible
+    to compile an eBPF program for Linux and use it on Windows.
+
+## Platform specific constants
+
+efW only provides [source compatibility] with Linux.
+While certain Linux map or program types have an equivalent on Windows, they
+don't always behave the same.
+
+For this reason, the various type enumerations have completely distinct values
+on Windows, for example `WindowsHashMap` is the equivalent of `HashMap`.
+Attempting to create a `HashMap` on Windows will return an error, and vice versa.
+
+## Platform specific ELFs
+
+!!! note ""
+    Loading Windows ELFs is not supported yet.
+
+ELFs compiled against Linux and Windows headers are not binary compatible.
+Add the following to ELFs targeting Windows until there is an
+[official way to declare the platform](https://github.com/microsoft/ebpf-for-windows/issues/3956):
+
+```C
+const bool __ebpf_for_windows_tag __attribute__((section(".ebpf_for_windows"))) = true;
+```
+
+## Working with signed programs
+
+The runtime will most likely require all eBPF programs to be signed by
+Microsoft. Signing programs relies on packaging eBPF `.c` files as drivers using
+the [native code pipeline], converting bytecode into a `.sys` file.
+
+The interface to load such drivers does not allow modifying the bytecode or map
+definitions, therefore you can't interact with them via `CollectionSpec`, etc.
+Instead you must load them via `LoadCollection`:
+
+```go
+coll, err := LoadCollection("path\\to\\driver.sys")
+```
+
+The returned Collection contains Maps and Programs which you can interact with
+as usual.
+
+[eBPF for Windows]: https://github.com/microsoft/ebpf-for-windows
+[source compatibility]: https://github.com/microsoft/ebpf-for-windows?tab=readme-ov-file#2-does-this-provide-app-compatibility-with-ebpf-programs-written-for-linux
+[native code pipeline]: https://github.com/microsoft/ebpf-for-windows/blob/main/docs/NativeCodeGeneration.md
+[LoadCollection]: https://pkg.go.dev/github.com/cilium/ebpf#LoadCollection

--- a/docs/includes/glossary.md
+++ b/docs/includes/glossary.md
@@ -17,3 +17,4 @@
 *[libbpf]: A library for writing kernel- and user space BPF programs in C, developed by the upstream Linux project.
 *[qemu]: A popular virtual machine manager.
 *[DCO]: Developer Certificate of Origin.
+*[efW]: eBPF for Windows

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -60,6 +60,7 @@ nav:
   - 'Guides':
     - 'Getting Started': guides/getting-started.md
     - 'Portable eBPF': guides/portable-ebpf.md
+    - 'Windows support': guides/windows-support.md
   - 'Concepts':
     - 'Loading eBPF Programs': concepts/loader.md
     - 'Global Variables': concepts/global-variables.md


### PR DESCRIPTION
Add a short section to our docs which calls out the most important differences between Linux and Windows.