### PR TITLE
map, program: always sanitize names passed to the kernel

### DIFF
--- a/elf_reader.go
+++ b/elf_reader.go
@@ -742,7 +742,7 @@ func (ec *elfCode) loadMaps() error {
 			lr := io.LimitReader(r, int64(size))
 
 			spec := MapSpec{
-				Name: SanitizeName(mapName, -1),
+				Name: sanitizeName(mapName, -1),
 			}
 			switch {
 			case binary.Read(lr, ec.ByteOrder, &spec.Type) != nil:
@@ -1029,7 +1029,7 @@ func mapSpecFromBTF(es *elfSection, vs *btf.VarSecinfo, def *btf.Struct, spec *b
 	}
 
 	return &MapSpec{
-		Name:       SanitizeName(name, -1),
+		Name:       sanitizeName(name, -1),
 		Type:       MapType(mapType),
 		KeySize:    keySize,
 		ValueSize:  valueSize,
@@ -1156,7 +1156,7 @@ func (ec *elfCode) loadDataSections() error {
 		}
 
 		mapSpec := &MapSpec{
-			Name:       SanitizeName(sec.Name, -1),
+			Name:       sanitizeName(sec.Name, -1),
 			Type:       Array,
 			KeySize:    4,
 			ValueSize:  uint32(sec.Size),

--- a/map.go
+++ b/map.go
@@ -50,8 +50,9 @@ type MapID = sys.MapID
 
 // MapSpec defines a Map.
 type MapSpec struct {
-	// Name is passed to the kernel as a debug aid. Must only contain
-	// alpha numeric and '_' characters.
+	// Name is passed to the kernel as a debug aid.
+	//
+	// Unsupported characters will be stripped.
 	Name       string
 	Type       MapType
 	KeySize    uint32

--- a/map_test.go
+++ b/map_test.go
@@ -1362,20 +1362,23 @@ func TestMapMarshalUnsafe(t *testing.T) {
 }
 
 func TestMapName(t *testing.T) {
-	if err := haveObjName(); err != nil {
-		t.Skip(err)
-	}
+	testutils.SkipIfNotSupported(t, haveObjName())
 
-	m := createMap(t, Array, 1)
+	m := mustNewMap(t, &MapSpec{
+		Name:       "test!123",
+		Type:       Array,
+		KeySize:    4,
+		ValueSize:  4,
+		MaxEntries: 1,
+	}, nil)
 
 	var info sys.MapInfo
 	if err := sys.ObjInfo(m.fd, &info); err != nil {
 		t.Fatal(err)
 	}
 
-	if name := unix.ByteSliceToString(info.Name[:]); name != "test" {
-		t.Error("Expected name to be test, got", name)
-	}
+	name := unix.ByteSliceToString(info.Name[:])
+	qt.Assert(t, qt.Equals(name, "test123"))
 }
 
 func TestMapFromFD(t *testing.T) {

--- a/prog.go
+++ b/prog.go
@@ -106,8 +106,9 @@ type ProgramOptions struct {
 
 // ProgramSpec defines a Program.
 type ProgramSpec struct {
-	// Name is passed to the kernel as a debug aid. Must only contain
-	// alpha numeric and '_' characters.
+	// Name is passed to the kernel as a debug aid.
+	//
+	// Unsupported characters will be stripped.
 	Name string
 
 	// Type determines at which hook in the kernel a program will run.

--- a/prog_test.go
+++ b/prog_test.go
@@ -479,20 +479,25 @@ func TestProgramWithUnsatisfiedMap(t *testing.T) {
 }
 
 func TestProgramName(t *testing.T) {
-	if err := haveObjName(); err != nil {
-		t.Skip(err)
-	}
+	testutils.SkipIfNotSupported(t, haveObjName())
 
-	prog := createBasicProgram(t)
+	prog := mustNewProgram(t, &ProgramSpec{
+		Name: "test*123",
+		Type: SocketFilter,
+		Instructions: asm.Instructions{
+			asm.LoadImm(asm.R0, 1, asm.DWord),
+			asm.Return(),
+		},
+		License: "MIT",
+	}, nil)
 
 	var info sys.ProgInfo
 	if err := sys.ObjInfo(prog.fd, &info); err != nil {
 		t.Fatal(err)
 	}
 
-	if name := unix.ByteSliceToString(info.Name[:]); name != "test" {
-		t.Errorf("Name is not test, got '%s'", name)
-	}
+	name := unix.ByteSliceToString(info.Name[:])
+	qt.Assert(t, qt.Equals(name, "test123"))
 }
 
 func TestProgramCloneNil(t *testing.T) {

--- a/syscalls.go
+++ b/syscalls.go
@@ -27,12 +27,12 @@ var (
 	sysErrNotSupported = sys.Error(ErrNotSupported, sys.ENOTSUPP)
 )
 
-// SanitizeName replaces all invalid characters in name with replacement.
+// sanitizeName replaces all invalid characters in name with replacement.
 // Passing a negative value for replacement will delete characters instead
 // of replacing them.
 //
 // The set of allowed characters may change over time.
-func SanitizeName(name string, replacement rune) string {
+func sanitizeName(name string, replacement rune) string {
 	return strings.Map(func(char rune) rune {
 		switch {
 		case char >= 'A' && char <= 'Z':
@@ -56,6 +56,7 @@ func maybeFillObjName(name string) sys.ObjName {
 		return sys.ObjName{}
 	}
 
+	name = sanitizeName(name, -1)
 	if errors.Is(objNameAllowsDot(), ErrNotSupported) {
 		name = strings.ReplaceAll(name, ".", "")
 	}

--- a/syscalls_test.go
+++ b/syscalls_test.go
@@ -19,7 +19,7 @@ func TestSanitizeName(t *testing.T) {
 		"t_est":    "t_est",
 		"hörnchen": "hrnchen",
 	} {
-		qt.Assert(t, qt.Equals(SanitizeName(input, -1), want), qt.Commentf("input: %s", input))
+		qt.Assert(t, qt.Equals(sanitizeName(input, -1), want), qt.Commentf("input: %s", input))
 	}
 }
 


### PR DESCRIPTION
The kernel only allows a restricted set of characters when naming a map or program. So far we've required the user to call SanitizeName manually to ensure that the Name is valid.

Always sanitize names and unexport SanitizeName. The ELF reader still calls sanitizeName to avoid changing the output too much.