### PR TITLE
perf,ringbuf: switch Go build tag

### DIFF
--- a/internal/epoll/poller.go
+++ b/internal/epoll/poller.go
@@ -1,4 +1,4 @@
-//go:build linux
+//go:build !windows
 
 package epoll
 

--- a/internal/epoll/poller_test.go
+++ b/internal/epoll/poller_test.go
@@ -1,4 +1,4 @@
-//go:build linux
+//go:build !windows
 
 package epoll
 

--- a/perf/reader.go
+++ b/perf/reader.go
@@ -1,4 +1,4 @@
-//go:build linux
+//go:build !windows
 
 package perf
 

--- a/perf/reader_test.go
+++ b/perf/reader_test.go
@@ -1,4 +1,4 @@
-//go:build linux
+//go:build !windows
 
 package perf
 

--- a/perf/ring.go
+++ b/perf/ring.go
@@ -1,4 +1,4 @@
-//go:build linux
+//go:build !windows
 
 package perf
 

--- a/perf/ring_test.go
+++ b/perf/ring_test.go
@@ -1,4 +1,4 @@
-//go:build linux
+//go:build !windows
 
 package perf
 

--- a/ringbuf/reader.go
+++ b/ringbuf/reader.go
@@ -1,4 +1,4 @@
-//go:build linux
+//go:build !windows
 
 package ringbuf
 

--- a/ringbuf/reader_test.go
+++ b/ringbuf/reader_test.go
@@ -1,4 +1,4 @@
-//go:build linux
+//go:build !windows
 
 package ringbuf
 

--- a/ringbuf/ring.go
+++ b/ringbuf/ring.go
@@ -1,4 +1,4 @@
-//go:build linux
+//go:build !windows
 
 package ringbuf
 


### PR DESCRIPTION
As suggested in https://github.com/cilium/ebpf/issues/1746#issuecomment-2800923799 replace the go build tag `linux` with `!windows`.

Fixes https://github.com/cilium/ebpf/issues/1746 and https://github.com/cilium/ebpf/issues/1749.