### PR TITLE
examples: remove unnecessary -type flags to bpf2go invocations

### DIFF
--- a/examples/fentry/main.go
+++ b/examples/fentry/main.go
@@ -29,7 +29,7 @@ import (
 	"github.com/cilium/ebpf/rlimit"
 )
 
-//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -tags linux -type event bpf fentry.c -- -I../headers
+//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -tags linux bpf fentry.c -- -I../headers
 
 func main() {
 	stopper := make(chan os.Signal, 1)

--- a/examples/ringbuffer/main.go
+++ b/examples/ringbuffer/main.go
@@ -18,7 +18,7 @@ import (
 	"github.com/cilium/ebpf/rlimit"
 )
 
-//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -tags linux -type event bpf ringbuffer.c -- -I../headers
+//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -tags linux bpf ringbuffer.c -- -I../headers
 
 func main() {
 	// Name of the kernel function to trace.

--- a/examples/tcprtt/main.go
+++ b/examples/tcprtt/main.go
@@ -30,7 +30,7 @@ import (
 	"github.com/cilium/ebpf/rlimit"
 )
 
-//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -tags linux -type event bpf tcprtt.c -- -I../headers
+//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -tags linux bpf tcprtt.c -- -I../headers
 
 func main() {
 	stopper := make(chan os.Signal, 1)

--- a/examples/tcprtt_sockops/main.go
+++ b/examples/tcprtt_sockops/main.go
@@ -39,7 +39,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -tags linux -tags "linux" -type rtt_event bpf tcprtt_sockops.c -- -I../headers
+//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -tags linux -tags "linux" bpf tcprtt_sockops.c -- -I../headers
 
 func main() {
 	stopper := make(chan os.Signal, 1)

--- a/examples/uretprobe/main.go
+++ b/examples/uretprobe/main.go
@@ -22,7 +22,7 @@ import (
 	"github.com/cilium/ebpf/rlimit"
 )
 
-//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -tags linux -target amd64 -type event bpf uretprobe.c -- -I../headers
+//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -tags linux -target amd64 bpf uretprobe.c -- -I../headers
 
 const (
 	// The path to the ELF binary containing the function to trace.


### PR DESCRIPTION
These have been unnecessary since perf/ringbuf value types started being generated by bpf2go in 60405bb.