### PR TITLE
[PoC] Introduce new flag `SpecCacheDisabled` & Parse only the requires BTF types

### DIFF
--- a/btf/btf_test.go
+++ b/btf/btf_test.go
@@ -46,7 +46,7 @@ var vmlinuxTestdata = sync.OnceValues(func() (specAndRawBTF, error) {
 		return specAndRawBTF{}, err
 	}
 
-	spec, err := loadRawSpec(bytes.NewReader(b), binary.LittleEndian, nil)
+	spec, err := loadRawSpec(bytes.NewReader(b), binary.LittleEndian, nil, nil)
 	if err != nil {
 		return specAndRawBTF{}, err
 	}
@@ -210,7 +210,7 @@ func TestTypeByName(t *testing.T) {
 	}
 }
 
-func BenchmarkParseVmlinux(b *testing.B) {
+func BenchmarkParseVmlinuxWithoutFilter(b *testing.B) {
 	rd := vmlinuxTestdataReader(b)
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -220,9 +220,75 @@ func BenchmarkParseVmlinux(b *testing.B) {
 			b.Fatal(err)
 		}
 
-		if _, err := loadRawSpec(rd, binary.LittleEndian, nil); err != nil {
+		if _, err := loadRawSpec(rd, binary.LittleEndian, nil, nil); err != nil {
 			b.Fatal("Can't load BTF:", err)
 		}
+	}
+}
+
+func BenchmarkParseVmlinuxWithFilter(b *testing.B) {
+	rd := vmlinuxTestdataReader(b)
+	opts := &SpecOptions{
+		TypeNames: map[string]struct{}{
+			"task_struct":                        {},
+			"pt_regs":                            {},
+			"socket":                             {},
+			"fanotify_event":                     {},
+			"pid":                                {},
+			"trace_event_raw_sched_process_exec": {},
+			"syscall_trace_enter":                {},
+			"nsproxy":                            {},
+			"mnt_namespace":                      {},
+			"syscall_trace_exit":                 {},
+			"mm_struct":                          {},
+			"file":                               {},
+			"inode":                              {},
+			"super_block":                        {},
+			"sock":                               {},
+		},
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for n := 0; n < b.N; n++ {
+		if _, err := rd.Seek(0, io.SeekStart); err != nil {
+			b.Fatal(err)
+		}
+
+		if _, err := loadRawSpec(rd, binary.LittleEndian, nil, opts); err != nil {
+			b.Fatal("Can't load BTF:", err)
+		}
+	}
+}
+
+func TestParseVmlinuxWithFilter(t *testing.T) {
+	rd := vmlinuxTestdataReader(t)
+	opts := &SpecOptions{
+		TypeNames: map[string]struct{}{
+			"task_struct":                        {},
+			"pt_regs":                            {},
+			"socket":                             {},
+			"fanotify_event":                     {},
+			"pid":                                {},
+			"trace_event_raw_sched_process_exec": {},
+			"syscall_trace_enter":                {},
+			"nsproxy":                            {},
+			"mnt_namespace":                      {},
+			"syscall_trace_exit":                 {},
+			"mm_struct":                          {},
+			"file":                               {},
+			"inode":                              {},
+			"super_block":                        {},
+			"sock":                               {},
+		},
+	}
+
+	if _, err := rd.Seek(0, io.SeekStart); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := loadRawSpec(rd, binary.LittleEndian, nil, opts); err != nil {
+		t.Fatal("Can't load BTF:", err)
 	}
 }
 

--- a/btf/ext_info.go
+++ b/btf/ext_info.go
@@ -713,6 +713,10 @@ func (cr *CORERelocation) String() string {
 	return fmt.Sprintf("CORERelocation(%s, %s[%s], local_id=%d)", cr.kind, cr.typ, cr.accessor, cr.id)
 }
 
+func (cr *CORERelocation) TypeName() string {
+	return cr.typ.TypeName()
+}
+
 func CORERelocationMetadata(ins *asm.Instruction) *CORERelocation {
 	relo, _ := ins.Metadata.Get(coreRelocationMeta{}).(*CORERelocation)
 	return relo

--- a/btf/fuzz_test.go
+++ b/btf/fuzz_test.go
@@ -26,7 +26,7 @@ func FuzzSpec(f *testing.F) {
 			t.Skip("data is too short")
 		}
 
-		spec, err := loadRawSpec(bytes.NewReader(data), internal.NativeEndian, nil)
+		spec, err := loadRawSpec(bytes.NewReader(data), internal.NativeEndian, nil, nil)
 		if err != nil {
 			if spec != nil {
 				t.Fatal("spec is not nil")

--- a/btf/handle.go
+++ b/btf/handle.go
@@ -153,7 +153,7 @@ func (h *Handle) Spec(base *Spec) (*Spec, error) {
 		return nil, fmt.Errorf("missing base types")
 	}
 
-	return loadRawSpec(bytes.NewReader(btfBuffer), internal.NativeEndian, base)
+	return loadRawSpec(bytes.NewReader(btfBuffer), internal.NativeEndian, base, nil)
 }
 
 // Close destroys the handle.

--- a/btf/kernel_test.go
+++ b/btf/kernel_test.go
@@ -26,3 +26,105 @@ func TestLoadKernelModuleSpec(t *testing.T) {
 	_, err := LoadKernelModuleSpec("btf_testmod")
 	qt.Assert(t, qt.IsNil(err))
 }
+
+func TestLoadKernelSpecWithOpts(t *testing.T) {
+	if _, err := os.Stat("/sys/kernel/btf/vmlinux"); os.IsNotExist(err) {
+		t.Skip("/sys/kernel/btf/vmlinux not present")
+	}
+
+	kernelBTF.kernel = nil
+
+	opts := &SpecOptions{
+		TypeNames: map[string]struct{}{
+			"task_struct": {},
+			"pt_regs":     {},
+			"socket":      {},
+		},
+	}
+
+	spec1, err := LoadKernelSpecWithOptions(opts)
+	if err != nil {
+		t.Fatal("Can't load kernel spec:", err)
+	}
+
+	spec2, err := LoadKernelSpecWithOptions(opts)
+	if err != nil {
+		t.Fatal("Can't load kernel spec:", err)
+	}
+
+	qt.Assert(t, qt.Equals(len(spec1.imm.types), len(spec2.imm.types)))
+	qt.Assert(t, qt.Equals(len(spec1.imm.typeIDs), len(spec2.imm.typeIDs)))
+	qt.Assert(t, qt.DeepEquals(spec1.imm.namedTypes, spec2.imm.namedTypes))
+}
+
+func TestLoadKernelSpecWithMoreOpts(t *testing.T) {
+	if _, err := os.Stat("/sys/kernel/btf/vmlinux"); os.IsNotExist(err) {
+		t.Skip("/sys/kernel/btf/vmlinux not present")
+	}
+
+	opts1 := &SpecOptions{
+		TypeNames: map[string]struct{}{
+			"pt_regs": {},
+		},
+	}
+
+	kernelBTF.kernel = nil
+
+	spec1, err := LoadKernelSpecWithOptions(opts1)
+	if err != nil {
+		t.Fatal("Can't load kernel spec:", err)
+	}
+
+	opts2 := &SpecOptions{
+		TypeNames: map[string]struct{}{
+			"task_struct": {},
+			"socket":      {},
+		},
+	}
+
+	spec2, err := LoadKernelSpecWithOptions(opts2)
+	if err != nil {
+		t.Fatal("Can't load kernel spec:", err)
+	}
+
+	for typeName := range opts1.TypeNames {
+		contains := false
+		for _, t := range spec1.imm.types {
+			if t.TypeName() == typeName {
+				contains = true
+				break
+			}
+		}
+		qt.Assert(t, qt.IsTrue(contains))
+
+		contains = false
+		for _, t := range spec2.imm.types {
+			if t.TypeName() == typeName {
+				contains = true
+				break
+			}
+		}
+		qt.Assert(t, qt.IsTrue(contains))
+	}
+
+	for typeName := range opts2.TypeNames {
+		contains := false
+		for _, t := range spec1.imm.types {
+			if t.TypeName() == typeName {
+				contains = true
+				break
+			}
+		}
+		qt.Assert(t, qt.IsFalse(contains))
+
+		contains = false
+		for _, t := range spec2.imm.types {
+			if t.TypeName() == typeName {
+				contains = true
+				break
+			}
+		}
+		// pt_regs is included in here indirectly
+		qt.Assert(t, qt.IsTrue(contains))
+	}
+}

--- a/btf/marshal_test.go
+++ b/btf/marshal_test.go
@@ -35,7 +35,7 @@ func TestBuilderMarshal(t *testing.T) {
 	qt.Assert(t, qt.IsNil(err))
 	qt.Assert(t, qt.CmpEquals(b, &cpy, cmp.AllowUnexported(*b)), qt.Commentf("Marshaling should not change Builder state"))
 
-	have, err := loadRawSpec(bytes.NewReader(buf), internal.NativeEndian, nil)
+	have, err := loadRawSpec(bytes.NewReader(buf), internal.NativeEndian, nil, nil)
 	qt.Assert(t, qt.IsNil(err), qt.Commentf("Couldn't parse BTF"))
 	qt.Assert(t, qt.DeepEquals(have.imm.types, want))
 }
@@ -98,7 +98,7 @@ limitTypes:
 	buf, err := b.Marshal(nil, KernelMarshalOptions())
 	qt.Assert(t, qt.IsNil(err))
 
-	rebuilt, err := loadRawSpec(bytes.NewReader(buf), binary.LittleEndian, nil)
+	rebuilt, err := loadRawSpec(bytes.NewReader(buf), binary.LittleEndian, nil, nil)
 	qt.Assert(t, qt.IsNil(err), qt.Commentf("round tripping BTF failed"))
 
 	if n := len(rebuilt.imm.types); n > math.MaxUint16 {
@@ -130,7 +130,7 @@ func TestMarshalEnum64(t *testing.T) {
 	})
 	qt.Assert(t, qt.IsNil(err))
 
-	spec, err := loadRawSpec(bytes.NewReader(buf), internal.NativeEndian, nil)
+	spec, err := loadRawSpec(bytes.NewReader(buf), internal.NativeEndian, nil, nil)
 	qt.Assert(t, qt.IsNil(err))
 
 	var have *Union
@@ -166,7 +166,7 @@ func TestMarshalDeclTags(t *testing.T) {
 	})
 	qt.Assert(t, qt.IsNil(err))
 
-	spec, err := loadRawSpec(bytes.NewReader(buf), internal.NativeEndian, nil)
+	spec, err := loadRawSpec(bytes.NewReader(buf), internal.NativeEndian, nil, nil)
 	qt.Assert(t, qt.IsNil(err))
 
 	var td *Typedef
@@ -197,7 +197,7 @@ func TestMarshalTypeTags(t *testing.T) {
 	})
 	qt.Assert(t, qt.IsNil(err))
 
-	spec, err := loadRawSpec(bytes.NewReader(buf), internal.NativeEndian, nil)
+	spec, err := loadRawSpec(bytes.NewReader(buf), internal.NativeEndian, nil, nil)
 	qt.Assert(t, qt.IsNil(err))
 
 	var td *Typedef
@@ -252,7 +252,7 @@ func specFromTypes(tb testing.TB, types []Type) *Spec {
 	tb.Helper()
 
 	btf := marshalNativeEndian(tb, types)
-	spec, err := loadRawSpec(bytes.NewReader(btf), internal.NativeEndian, nil)
+	spec, err := loadRawSpec(bytes.NewReader(btf), internal.NativeEndian, nil, nil)
 	qt.Assert(tb, qt.IsNil(err))
 
 	return spec

--- a/btf/types_test.go
+++ b/btf/types_test.go
@@ -427,13 +427,18 @@ func TestInflateLegacyBitfield(t *testing.T) {
 
 	for _, test := range []struct {
 		name   string
-		reader io.Reader
+		reader *bytes.Buffer
 	}{
 		{"struct before int", &before},
 		{"struct after int", &after},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			types, err := readAndInflateTypes(test.reader, binary.LittleEndian, 2, emptyStrings, nil)
+			reader := bytes.NewReader(test.reader.Bytes())
+			reset := func(offset int64) {
+				reader.Seek(offset, io.SeekStart)
+			}
+
+			types, err := readAndInflateTypes(reader, reset, binary.LittleEndian, 2, emptyStrings, nil, nil)
 			if err != nil {
 				t.Log(before.Bytes())
 				t.Fatal(err)

--- a/prog.go
+++ b/prog.go
@@ -88,6 +88,10 @@ type ProgramOptions struct {
 	// Disables the verifier log completely, regardless of other options.
 	LogDisabled bool
 
+	// TODO: Naming
+	// Disables the use of the spec cache and only loads needed types
+	SpecCacheDisabled bool
+
 	// Type information used for CO-RE relocations.
 	//
 	// This is useful in environments where the kernel BTF is not available
@@ -319,7 +323,7 @@ func newProgramWithOptions(spec *ProgramSpec, opts ProgramOptions) (*Program, er
 	}
 
 	var b btf.Builder
-	if err := applyRelocations(insns, targets, kmodName, spec.ByteOrder, &b); err != nil {
+	if err := applyRelocations(insns, targets, kmodName, spec.ByteOrder, &b, !opts.SpecCacheDisabled); err != nil {
 		return nil, fmt.Errorf("apply CO-RE relocations: %w", err)
 	}
 


### PR DESCRIPTION
Based on https://github.com/cilium/ebpf/pull/1589

This is a proof-of-concept. The code is not ready for merging but it shows it is possible to significantly reduce the memory consumption (by 27MB).

---

This PR aims to lower the memory footprint when using the `cilium/ebpf` library. This is achieved in two ways:
1. Reducing memory usage: Adding a new flag which disables caching of the BTF spec
2. Parsing only the needed BTF types

The tradeoff is for lowering the memory footprint is of course performance while loading eBPF programs etc...

In this PoC when using the new `SpecCacheDisabled` flag (1) it will also automatically check which BTF types are needed and load/parse only those (2)

---

Benchmarks:
1. `ParseVmlinux` is always the base for both tests
2. The `new.txt` Inspektor gadget run is with the types from https://github.com/cilium/ebpf/pull/1755/#issuecomment-2820919961
3. The `new.txt` `ParseVmlinux` run is called `BenchmarkParseVmlinuxWithoutFilter` in this PR
```
goos: linux
goarch: amd64
pkg: github.com/cilium/ebpf/btf
cpu: 11th Gen Intel(R) Core(TM) i7-11370H @ 3.30GHz
                     │   old.txt   │               new.txt                │
                     │   sec/op    │   sec/op     vs base                 │
ParseVmlinux-8         29.28m ± 3%   60.62m ± 8%  +107.06% (p=0.000 n=10)
InspektorGadget-8      29.28m ± 3%   12.94m ± 3%   -55.79% (p=0.000 n=10)
geomean                29.28m        28.01m         -4.32%

                     │   old.txt    │                new.txt                │
                     │     B/op     │     B/op      vs base                 │
ParseVmlinux-8         24.43Mi ± 0%   53.58Mi ± 0%  +119.37% (p=0.000 n=10)
InspektorGadget-8      24.43Mi ± 0%   10.89Mi ± 0%   -55.40% (p=0.000 n=10)
geomean                24.43Mi        24.16Mi         -1.08%

                     │   old.txt   │               new.txt               │
                     │  allocs/op  │  allocs/op   vs base                │
ParseVmlinux-8         271.9k ± 0%   365.1k ± 0%  +34.30% (p=0.000 n=10)
InspektorGadget-8      271.9k ± 0%   110.1k ± 0%  -59.51% (p=0.000 n=10)
geomean                271.9k        200.5k       -26.26%
```