### PR TITLE
all: use binary.Append where appropriate

### DIFF
--- a/internal/kconfig/kconfig_test.go
+++ b/internal/kconfig/kconfig_test.go
@@ -1,7 +1,6 @@
 package kconfig
 
 import (
-	"bytes"
 	"encoding/binary"
 	"os"
 	"testing"
@@ -401,13 +400,9 @@ func TestPutValue(t *testing.T) {
 			continue
 		}
 
-		var buf bytes.Buffer
-		err := binary.Write(&buf, internal.NativeEndian, c.expected)
-		if err != nil {
-			t.Fatal(err)
-		}
+		expected, err := binary.Append(nil, internal.NativeEndian, c.expected)
+		qt.Assert(t, qt.IsNil(err))
 
-		expected := buf.Bytes()
 		data := make([]byte, len(expected))
 		err = PutValue(data, c.typ, c.value)
 

--- a/internal/sysenc/marshal.go
+++ b/internal/sysenc/marshal.go
@@ -51,11 +51,7 @@ func Marshal(data any, size int) (Buffer, error) {
 			return newBuffer(buf), nil
 		}
 
-		wr := internal.NewBuffer(make([]byte, 0, size))
-		defer internal.PutBuffer(wr)
-
-		err = binary.Write(wr, internal.NativeEndian, value)
-		buf = wr.Bytes()
+		buf, err = binary.Append(nil, internal.NativeEndian, value)
 	}
 	if err != nil {
 		return Buffer{}, err

--- a/internal/sysenc/marshal_test.go
+++ b/internal/sysenc/marshal_test.go
@@ -60,18 +60,16 @@ func TestMarshal(t *testing.T) {
 	for _, test := range testcases() {
 		value := test.new()
 		t.Run(fmt.Sprintf("%T", value), func(t *testing.T) {
-			var want bytes.Buffer
-			if err := binary.Write(&want, internal.NativeEndian, value); err != nil {
-				t.Fatal(err)
-			}
+			want, err := binary.Append(nil, internal.NativeEndian, value)
+			qt.Assert(t, qt.IsNil(err))
 
-			have := make([]byte, want.Len())
+			have := make([]byte, len(want))
 			buf, err := Marshal(value, binary.Size(value))
 			if err != nil {
 				t.Fatal(err)
 			}
-			qt.Assert(t, qt.Equals(buf.CopyTo(have), want.Len()))
-			qt.Assert(t, qt.CmpEquals(have, want.Bytes(), cmpopts.EquateEmpty()))
+			qt.Assert(t, qt.Equals(buf.CopyTo(have), len(want)))
+			qt.Assert(t, qt.CmpEquals(have, want, cmpopts.EquateEmpty()))
 		})
 	}
 }
@@ -143,9 +141,9 @@ func TestUnsafeBackingMemory(t *testing.T) {
 	marshalNative := func(t *testing.T, data any) []byte {
 		t.Helper()
 
-		var buf bytes.Buffer
-		qt.Assert(t, qt.IsNil(binary.Write(&buf, internal.NativeEndian, data)))
-		return buf.Bytes()
+		buf, err := binary.Append(nil, internal.NativeEndian, data)
+		qt.Assert(t, qt.IsNil(err))
+		return buf
 	}
 
 	for _, test := range []struct {

--- a/prog.go
+++ b/prog.go
@@ -856,13 +856,13 @@ func (p *Program) run(opts *RunOptions) (uint32, time.Duration, error) {
 		return 0, 0, err
 	}
 
-	var ctxBytes []byte
+	var ctxIn []byte
 	if opts.Context != nil {
-		ctx := new(bytes.Buffer)
-		if err := binary.Write(ctx, internal.NativeEndian, opts.Context); err != nil {
+		var err error
+		ctxIn, err = binary.Append(nil, internal.NativeEndian, opts.Context)
+		if err != nil {
 			return 0, 0, fmt.Errorf("cannot serialize context: %v", err)
 		}
-		ctxBytes = ctx.Bytes()
 	}
 
 	var ctxOut []byte
@@ -877,9 +877,9 @@ func (p *Program) run(opts *RunOptions) (uint32, time.Duration, error) {
 		DataIn:      sys.SlicePointer(opts.Data),
 		DataOut:     sys.SlicePointer(opts.DataOut),
 		Repeat:      uint32(opts.Repeat),
-		CtxSizeIn:   uint32(len(ctxBytes)),
+		CtxSizeIn:   uint32(len(ctxIn)),
 		CtxSizeOut:  uint32(len(ctxOut)),
-		CtxIn:       sys.SlicePointer(ctxBytes),
+		CtxIn:       sys.SlicePointer(ctxIn),
 		CtxOut:      sys.SlicePointer(ctxOut),
 		Flags:       opts.Flags,
 		Cpu:         opts.CPU,


### PR DESCRIPTION
ebpf: use binary.Append

    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>

tests: use binary.Append where appropriate

    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>

sysenc: use binary.Append when marshaling

    Using binary.Append allows us to drop allocating a bytes.Buffer from a
    sync.Pool. This reduces the number of allocations in some benchmarks.

    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>
