### PR TITLE
fix: return InvalidOpCode for StoreImm with DWord size

### DIFF
--- a/asm/load_store.go
+++ b/asm/load_store.go
@@ -202,6 +202,10 @@ func StoreImmOp(size Size) OpCode {
 
 // StoreImm emits `*(size *)(dst + offset) = value`.
 func StoreImm(dst Register, offset int16, value int64, size Size) Instruction {
+	if size == DWord {
+		return Instruction{OpCode: InvalidOpCode}
+	}
+
 	return Instruction{
 		OpCode:   StoreImmOp(size),
 		Dst:      dst,


### PR DESCRIPTION
fixed: #1767