### PR TITLE
btf: lazy decoding of string table

### DIFF
--- a/btf/btf_test.go
+++ b/btf/btf_test.go
@@ -249,7 +249,7 @@ func BenchmarkIterateVmlinux(b *testing.B) {
 func TestParseCurrentKernelBTF(t *testing.T) {
 	spec := vmlinuxSpec(t)
 
-	if len(spec.namedTypes) == 0 {
+	if len(spec.offsets) == 0 {
 		t.Fatal("Empty kernel BTF")
 	}
 }
@@ -267,7 +267,7 @@ func TestFindVMLinux(t *testing.T) {
 		t.Fatal("Can't load BTF:", err)
 	}
 
-	if len(spec.namedTypes) == 0 {
+	if len(spec.offsets) == 0 {
 		t.Fatal("Empty kernel BTF")
 	}
 }

--- a/btf/btf_test.go
+++ b/btf/btf_test.go
@@ -252,19 +252,6 @@ func TestParseCurrentKernelBTF(t *testing.T) {
 	if len(spec.namedTypes) == 0 {
 		t.Fatal("Empty kernel BTF")
 	}
-
-	totalBytes := 0
-	distinct := 0
-	seen := make(map[string]bool)
-	for _, str := range spec.strings.strings {
-		totalBytes += len(str)
-		if !seen[str] {
-			distinct++
-			seen[str] = true
-		}
-	}
-	t.Logf("%d strings total, %d distinct", len(spec.strings.strings), distinct)
-	t.Logf("Average string size: %.0f", float64(totalBytes)/float64(len(spec.strings.strings)))
 }
 
 func TestFindVMLinux(t *testing.T) {

--- a/btf/core.go
+++ b/btf/core.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"math"
 	"reflect"
-	"slices"
 	"strconv"
 	"strings"
 
@@ -265,16 +264,14 @@ func CORERelocate(relos []*CORERelocation, targets []*Spec, bo binary.ByteOrder,
 
 		var targetTypes []Type
 		for _, target := range targets {
-			namedTypeIDs := target.TypeIDsByName(essentialName)
-			targetTypes = slices.Grow(targetTypes, len(namedTypeIDs))
-			for _, id := range namedTypeIDs {
-				typ, err := target.TypeByID(id)
-				if err != nil {
-					return nil, err
-				}
-
-				targetTypes = append(targetTypes, typ)
+			namedTypes, err := target.TypesByName(essentialName)
+			if errors.Is(err, ErrNotFound) {
+				continue
+			} else if err != nil {
+				return nil, err
 			}
+
+			targetTypes = append(targetTypes, namedTypes...)
 		}
 
 		fixups, err := coreCalculateFixups(group.relos, targetTypes, bo, resolveTargetTypeID)

--- a/btf/strings.go
+++ b/btf/strings.go
@@ -1,21 +1,17 @@
 package btf
 
 import (
-	"bufio"
 	"bytes"
 	"errors"
 	"fmt"
 	"io"
 	"maps"
-	"slices"
 	"strings"
 )
 
 type stringTable struct {
-	base    *stringTable
-	offsets []uint32
-	prevIdx int
-	strings []string
+	base  *stringTable
+	bytes []byte
 }
 
 // sizedReader is implemented by bytes.Reader, io.SectionReader, strings.Reader, etc.
@@ -29,89 +25,57 @@ func readStringTable(r sizedReader, base *stringTable) (*stringTable, error) {
 	// from the last entry offset of the base BTF.
 	firstStringOffset := uint32(0)
 	if base != nil {
-		idx := len(base.offsets) - 1
-		firstStringOffset = base.offsets[idx] + uint32(len(base.strings[idx])) + 1
+		firstStringOffset = uint32(len(base.bytes))
 	}
 
-	// Derived from vmlinux BTF.
-	const averageStringLength = 16
-
-	n := int(r.Size() / averageStringLength)
-	offsets := make([]uint32, 0, n)
-	strings := make([]string, 0, n)
-
-	offset := firstStringOffset
-	scanner := bufio.NewScanner(r)
-	scanner.Split(splitNull)
-	for scanner.Scan() {
-		str := scanner.Text()
-		offsets = append(offsets, offset)
-		strings = append(strings, str)
-		offset += uint32(len(str)) + 1
-	}
-	if err := scanner.Err(); err != nil {
+	bytes := make([]byte, r.Size())
+	if _, err := io.ReadFull(r, bytes); err != nil {
 		return nil, err
 	}
 
-	if len(strings) == 0 {
+	if len(bytes) == 0 {
 		return nil, errors.New("string table is empty")
 	}
 
-	if firstStringOffset == 0 && strings[0] != "" {
+	if bytes[len(bytes)-1] != 0 {
+		return nil, errors.New("string table isn't null terminated")
+	}
+
+	if firstStringOffset == 0 && bytes[0] != 0 {
 		return nil, errors.New("first item in string table is non-empty")
 	}
 
-	return &stringTable{base, offsets, 0, strings}, nil
-}
-
-func splitNull(data []byte, atEOF bool) (advance int, token []byte, err error) {
-	i := bytes.IndexByte(data, 0)
-	if i == -1 {
-		if atEOF && len(data) > 0 {
-			return 0, nil, errors.New("string table isn't null terminated")
-		}
-		return 0, nil, nil
-	}
-
-	return i + 1, data[:i], nil
+	return &stringTable{base: base, bytes: bytes}, nil
 }
 
 func (st *stringTable) Lookup(offset uint32) (string, error) {
-	if st.base != nil && offset <= st.base.offsets[len(st.base.offsets)-1] {
-		return st.base.lookup(offset)
-	}
-	return st.lookup(offset)
-}
-
-func (st *stringTable) lookup(offset uint32) (string, error) {
 	// Fast path: zero offset is the empty string, looked up frequently.
-	if offset == 0 && st.base == nil {
+	if offset == 0 {
 		return "", nil
 	}
 
-	// Accesses tend to be globally increasing, so check if the next string is
-	// the one we want. This skips the binary search in about 50% of cases.
-	if st.prevIdx+1 < len(st.offsets) && st.offsets[st.prevIdx+1] == offset {
-		st.prevIdx++
-		return st.strings[st.prevIdx], nil
-	}
-
-	i, found := slices.BinarySearch(st.offsets, offset)
-	if !found {
-		return "", fmt.Errorf("offset %d isn't start of a string", offset)
-	}
-
-	// Set the new increment index, but only if its greater than the current.
-	if i > st.prevIdx+1 {
-		st.prevIdx = i
-	}
-
-	return st.strings[i], nil
+	return st.lookupSlow(offset)
 }
 
-// Num returns the number of strings in the table.
-func (st *stringTable) Num() int {
-	return len(st.strings)
+func (st *stringTable) lookupSlow(offset uint32) (string, error) {
+	if st.base != nil {
+		n := uint32(len(st.base.bytes))
+		if offset < n {
+			return st.base.lookupSlow(offset)
+		}
+		offset -= n
+	}
+
+	if offset > uint32(len(st.bytes)) {
+		return "", fmt.Errorf("offset %d is out of bounds of string table", offset)
+	}
+
+	if offset > 0 && st.bytes[offset-1] != 0 {
+		return "", fmt.Errorf("offset %d is not the beginning of a string", offset)
+	}
+
+	i := bytes.IndexByte(st.bytes[offset:], 0)
+	return string(st.bytes[offset : offset+uint32(i)]), nil
 }
 
 // stringTableBuilder builds BTF string tables.

--- a/btf/unmarshal_test.go
+++ b/btf/unmarshal_test.go
@@ -1,0 +1,36 @@
+package btf
+
+import (
+	"iter"
+	"math"
+	"testing"
+
+	"github.com/go-quicktest/qt"
+)
+
+func TestFuzzyStringIndex(t *testing.T) {
+	idx := newFuzzyStringIndex(10)
+	count := testing.AllocsPerRun(1, func() {
+		idx.Add([]byte("foo"), 1)
+	})
+	qt.Assert(t, qt.Equals(count, 0))
+
+	idx.entries = idx.entries[:0]
+	idx.Add([]byte("foo"), 1)
+	idx.Add([]byte("bar"), 2)
+	idx.Add([]byte("baz"), 3)
+	idx.Build()
+
+	all := func(it iter.Seq[TypeID]) (ids []TypeID) {
+		for id := range it {
+			ids = append(ids, id)
+		}
+		return
+	}
+
+	qt.Assert(t, qt.SliceContains(all(idx.Find("foo")), 1))
+	qt.Assert(t, qt.SliceContains(all(idx.Find("bar")), 2))
+	qt.Assert(t, qt.SliceContains(all(idx.Find("baz")), 3))
+
+	qt.Assert(t, qt.IsTrue(newFuzzyStringIndexEntry(0, math.MaxUint32) < newFuzzyStringIndexEntry(1, 0)))
+}


### PR DESCRIPTION
Most of the time in parsing vmlinux BTF is spent in constructing the essentialName -> TypeID index.

1. We need to allocate a lot of strings
2. We need to do a lot of hash table lookups

Replace the hash table with a "fuzzy" index, which doesn't require allocating strings. The trade-off is that lookups now become more expensive, but that is a fine trade-off to make.

    core: 1
    goos: linux
    goarch: amd64
    pkg: github.com/cilium/ebpf/btf
    cpu: 13th Gen Intel(R) Core(TM) i7-1365U
                    │  base.txt   │          lazy-strings.txt           │
                    │   sec/op    │    sec/op     vs base               │
    ParseVmlinux      27.24m ± 1%   15.49m ±  1%  -43.15% (p=0.002 n=6)
    IterateVmlinux    149.9m ± 2%   132.3m ± 15%  -11.73% (p=0.041 n=6)
    InspectorGadget   35.08m ± 2%   21.28m ±  5%  -39.34% (p=0.002 n=6)
    geomean           52.32m        35.20m        -32.73%
    
                    │   base.txt    │          lazy-strings.txt           │
                    │     B/op      │     B/op      vs base               │
    ParseVmlinux       9.969Mi ± 0%   4.960Mi ± 0%  -50.25% (p=0.002 n=6)
    IterateVmlinux     34.72Mi ± 0%   31.92Mi ± 0%   -8.07% (p=0.002 n=6)
    InspectorGadget   11.994Mi ± 0%   7.169Mi ± 0%  -40.23% (p=0.002 n=6)
    geomean            16.07Mi        10.43Mi       -35.10%
    
                    │   base.txt    │          lazy-strings.txt          │
                    │   allocs/op   │  allocs/op   vs base               │
    ParseVmlinux      146058.0 ± 0%    162.0 ± 0%  -99.89% (p=0.002 n=6)
    IterateVmlinux      272.9k ± 0%   291.5k ± 0%   +6.83% (p=0.002 n=6)
    InspectorGadget    155.03k ± 0%   24.30k ± 0%  -84.32% (p=0.002 n=6)
    geomean             183.5k        10.47k       -94.29%
