### PR TITLE
Typo: BenchmarkInspectorGadget -> BenchmarkInspektorGadget

### DIFF
--- a/btf/btf_test.go
+++ b/btf/btf_test.go
@@ -585,7 +585,7 @@ func BenchmarkSpecTypeByID(b *testing.B) {
 	}
 }
 
-func BenchmarkInspectorGadget(b *testing.B) {
+func BenchmarkInspektorGadget(b *testing.B) {
 	// This benchmark is the baseline for what Inspektor Gadget loads for a
 	// common configuration.
 	types := []string{


### PR DESCRIPTION
Just saw the typo in https://github.com/cilium/ebpf/pull/1763 in the benchmark function name