### PR TITLE
btf: fix Spec.Copy() for split BTF

### DIFF
--- a/btf/btf.go
+++ b/btf/btf.go
@@ -346,7 +346,10 @@ func fixupDatasecLayout(ds *Datasec) error {
 	return nil
 }
 
-// Copy creates a copy of Spec.
+// Copy a Spec.
+//
+// All contained types are duplicated while preserving any modifications made
+// to them.
 func (s *Spec) Copy() *Spec {
 	if s == nil {
 		return nil


### PR DESCRIPTION
Make decoder.Copy do a deep copy of the base, so that types which are inflated in the future also point at the correct copy.