### PR TITLE
map: reduce false positives of BPF_F_NO_PREALLOC hint on EINVAL

### DIFF
--- a/types.go
+++ b/types.go
@@ -174,6 +174,20 @@ func (mt MapType) canHaveValueSize() bool {
 	return true
 }
 
+// mustHaveNoPrealloc returns true if the map type does not support
+// preallocation and needs the BPF_F_NO_PREALLOC flag set to be created
+// successfully.
+func (mt MapType) mustHaveNoPrealloc() bool {
+	switch mt {
+	case CgroupStorage, InodeStorage, TaskStorage, SkStorage:
+		return true
+	case LPMTrie:
+		return true
+	}
+
+	return false
+}
+
 // ProgramType of the eBPF program
 type ProgramType uint32
 


### PR DESCRIPTION
This commit adds a new MapType.mustHaveNoPrealloc() helper to collect map types that need BPF_F_NO_PREALLOC in order to be created successfully. This reduces the potential for red herrings while troubleshooting why map creation returns EINVAL.

Also added a similar warning for map types that are known to require the flag when the user forgets to specify the flag.

Supersedes https://github.com/cilium/ebpf/pull/1720.