### PR TITLE
ci: fix efW installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,9 +270,9 @@ jobs:
               owner: 'microsoft',
               repo: 'ebpf-for-windows',
               workflow_id: 'cicd.yml',
-              event: 'push',
+              event: 'schedule',
               branch: 'main',
-              status: 'completed',
+              status: 'success', // or 'completed' if upstream is buggy again
               per_page: 1
             });
 


### PR DESCRIPTION
Seems like the CI setup for eBPF for Windows has changed. Use the scheduled CI builds on main as the source for the binaries.