### PR TITLE
ci: use real staticcheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,12 @@ jobs:
         with:
           go-version: '${{ env.go_version }}'
 
+      - name: Run staticcheck
+        uses: dominikh/staticcheck-action@v1
+        with:
+          version: "latest"
+          install-go: false
+
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v7.0.0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,9 +54,21 @@ jobs:
         run: |
           go test -v ./cmd/bpf2go
 
-      - name: Build examples
+      - name: Build
         run: go build -v ./...
-        working-directory: ./examples
+
+  cross-build:
+    name: Cross build
+    runs-on: ubuntu-22.04
+    needs: build-and-lint
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '${{ env.go_version }}'
 
       - name: Cross build darwin
         env:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -6,17 +6,8 @@ linters:
     - govet
     - ineffassign
     - misspell
-    - staticcheck
     - unused
   settings:
-    staticcheck:
-      checks:
-        [
-          # Defaults
-          "all", "-ST1000", "-ST1003", "-ST1016", "-ST1020", "-ST1021", "-ST1022",
-          # Convert slice of bytes to string when printing it.
-          "-QF1010",
-        ]
     depguard:
       rules:
         no-x-sys-unix:

--- a/asm/func_lin.go
+++ b/asm/func_lin.go
@@ -8,7 +8,7 @@ import "github.com/cilium/ebpf/internal/platform"
 
 // Built-in functions (Linux).
 const (
-	FnUnspec                     = BuiltinFunc(platform.LinuxTag | 0)
+	FnUnspec                     = BuiltinFunc(platform.LinuxTag | 0) //lint:ignore SA4016 consistency
 	FnMapLookupElem              = BuiltinFunc(platform.LinuxTag | 1)
 	FnMapUpdateElem              = BuiltinFunc(platform.LinuxTag | 2)
 	FnMapDeleteElem              = BuiltinFunc(platform.LinuxTag | 3)


### PR DESCRIPTION
golangci-lint uses a copy of staticcheck rules, which leads to funky differences between what staticcheck reports locally and what golangci-lint reports. This is annoying, and the real staticcheck is of higher quality than golangci-lint. Use it in CI instead of the copy.