### PR TITLE
refactor: use the built-in max/min

### DIFF
--- a/internal/deque.go
+++ b/internal/deque.go
@@ -75,10 +75,7 @@ func (dq *Deque[T]) Grow(n int) {
 
 	// Round up to the new power of two which is at least 8.
 	// See https://jameshfisher.com/2018/03/30/round-up-power-2/
-	capacity := 1 << (64 - bits.LeadingZeros64(need-1))
-	if capacity < 8 {
-		capacity = 8
-	}
+	capacity := max(1<<(64-bits.LeadingZeros64(need-1)), 8)
 
 	elems := make([]T, have, capacity)
 	pivot := dq.read & dq.mask

--- a/internal/version.go
+++ b/internal/version.go
@@ -66,10 +66,7 @@ func (v Version) Kernel() uint32 {
 	// Kernels 4.4 and 4.9 have their SUBLEVEL clamped to 255 to avoid
 	// overflowing into PATCHLEVEL.
 	// See kernel commit 9b82f13e7ef3 ("kbuild: clamp SUBLEVEL to 255").
-	s := v[2]
-	if s > 255 {
-		s = 255
-	}
+	s := min(v[2], 255)
 
 	// Truncate members to uint8 to prevent them from spilling over into
 	// each other when overflowing 8 bits.

--- a/map.go
+++ b/map.go
@@ -1229,17 +1229,14 @@ func (m *Map) batchLookupPerCPU(cmd sys.Cmd, cursor *MapBatchCursor, keysOut, va
 }
 
 func (m *Map) batchLookupCmd(cmd sys.Cmd, cursor *MapBatchCursor, count int, keysOut any, valuePtr sys.Pointer, opts *BatchOptions) (int, error) {
-	cursorLen := int(m.keySize)
-	if cursorLen < 4 {
-		// * generic_map_lookup_batch requires that batch_out is key_size bytes.
-		//   This is used by array and LPM maps.
-		//
-		// * __htab_map_lookup_and_delete_batch requires u32. This is used by the
-		//   various hash maps.
-		//
-		// Use a minimum of 4 bytes to avoid having to distinguish between the two.
-		cursorLen = 4
-	}
+	// * generic_map_lookup_batch requires that batch_out is key_size bytes.
+	//   This is used by array and LPM maps.
+	//
+	// * __htab_map_lookup_and_delete_batch requires u32. This is used by the
+	//   various hash maps.
+	//
+	// Use a minimum of 4 bytes to avoid having to distinguish between the two.
+	cursorLen := max(int(m.keySize), 4)
 
 	inBatch := cursor.opaque
 	if inBatch == nil {


### PR DESCRIPTION
use the built-in max/min to simplify the code