### PR TITLE
cmd/bpf2go: Use BPF2GO_CFLAGS instead of BPF2GO_FLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ container-all:
 		-v "${REPODIR}":/ebpf -w /ebpf --env MAKEFLAGS \
 		--env HOME="/tmp" \
 		--env BPF2GO_CC="$(CLANG)" \
-		--env BPF2GO_CFLAGS="-fdebug-prefix-map=/ebpf=. $(CFLAGS)" \
+		--env BPF2GO_CFLAGS="$(CFLAGS)" \
 		"${IMAGE}:${VERSION}" \
 		make all
 
@@ -73,7 +73,7 @@ container-shell:
 	${CONTAINER_ENGINE} run --rm -ti \
 		-v "${REPODIR}":/ebpf -w /ebpf \
 		--env BPF2GO_CC="$(CLANG)" \
-		--env BPF2GO_CFLAGS="-fdebug-prefix-map=/ebpf=. $(CFLAGS)" \
+		--env BPF2GO_CFLAGS="$(CFLAGS)" \
 		"${IMAGE}:${VERSION}"
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ container-all:
 		-v "${REPODIR}":/ebpf -w /ebpf --env MAKEFLAGS \
 		--env HOME="/tmp" \
 		--env BPF2GO_CC="$(CLANG)" \
-		--env BPF2GO_FLAGS="-fdebug-prefix-map=/ebpf=. $(CFLAGS)" \
+		--env BPF2GO_CFLAGS="-fdebug-prefix-map=/ebpf=. $(CFLAGS)" \
 		"${IMAGE}:${VERSION}" \
 		make all
 
@@ -73,7 +73,7 @@ container-shell:
 	${CONTAINER_ENGINE} run --rm -ti \
 		-v "${REPODIR}":/ebpf -w /ebpf \
 		--env BPF2GO_CC="$(CLANG)" \
-		--env BPF2GO_FLAGS="-fdebug-prefix-map=/ebpf=. $(CFLAGS)" \
+		--env BPF2GO_CFLAGS="-fdebug-prefix-map=/ebpf=. $(CFLAGS)" \
 		"${IMAGE}:${VERSION}"
 
 clean:

--- a/cmd/bpf2go/README.md
+++ b/cmd/bpf2go/README.md
@@ -20,9 +20,9 @@ endian systems, respectively.
 You can use environment variables to affect all bpf2go invocations
 across a project, e.g. to set specific C flags:
 
-    BPF2GO_FLAGS="-O2 -g -Wall -Werror $(CFLAGS)" go generate ./...
+    BPF2GO_CFLAGS="-O2 -g -Wall -Werror $(CFLAGS)" go generate ./...
 
-Alternatively, by exporting `$BPF2GO_FLAGS` from your build system, you can
+Alternatively, by exporting `$BPF2GO_CFLAGS` from your build system, you can
 control all builds from a single location.
 
 Most bpf2go arguments can be controlled this way. See `bpf2go -h` for an


### PR DESCRIPTION
Fix docs and Makefile that reference `BPF2GO_FLAGS`. Use `BPF2GO_CFLAGS` instead.