### PR TITLE
bpf2go: import package structs when all structs are typedefs

### DIFF
--- a/cmd/bpf2go/gen/output.go
+++ b/cmd/bpf2go/gen/output.go
@@ -169,7 +169,7 @@ func Generate(args GenerateArgs) error {
 		if err != nil {
 			return fmt.Errorf("generating %s: %w", name, err)
 		}
-		_, ok := typ.(*btf.Struct)
+		_, ok := btf.As[*btf.Struct](typ)
 		needsStructsPkg = needsStructsPkg || ok
 		typeDecls = append(typeDecls, decl)
 	}


### PR DESCRIPTION
The current code checks for the existence of any `btf.Struct` when deciding to import the "structs" package.
Change this to check the underlying type is struct. This handles cases where all the structs are using `typedef`.