### PR TITLE
elf_reader: do not panic in `loadMaps`if ELF file has no BTF

### DIFF
--- a/elf_reader.go
+++ b/elf_reader.go
@@ -728,14 +728,16 @@ func (ec *elfCode) loadMaps() error {
 		// If the ELF has BTF, pull out the btf.Var for each map definition to
 		// extract decl tags from.
 		varsByName := make(map[string]*btf.Var)
-		var ds *btf.Datasec
-		if err := ec.btf.TypeByName(sec.Name, &ds); err == nil {
-			for _, vsi := range ds.Vars {
-				v, ok := btf.As[*btf.Var](vsi.Type)
-				if !ok {
-					return fmt.Errorf("section %v: btf.VarSecInfo doesn't point to a *btf.Var: %T", sec.Name, vsi.Type)
+		if ec.btf != nil {
+			var ds *btf.Datasec
+			if err := ec.btf.TypeByName(sec.Name, &ds); err == nil {
+				for _, vsi := range ds.Vars {
+					v, ok := btf.As[*btf.Var](vsi.Type)
+					if !ok {
+						return fmt.Errorf("section %v: btf.VarSecInfo doesn't point to a *btf.Var: %T", sec.Name, vsi.Type)
+					}
+					varsByName[string(v.Name)] = v
 				}
-				varsByName[string(v.Name)] = v
 			}
 		}
 


### PR DESCRIPTION
3f1a755f1451d058e8b56b516c7a64ff6f3a33e3 introduced the ability to read btf_decl_tag attributes set on maps but `loadMaps` is crashing if the ELF file has no BTF.

Fix this by checking if the BTF is there before querying it.