### PR TITLE
linker: do not error out when there is nothing in `/sys/kernel/btf`

### DIFF
--- a/linker.go
+++ b/linker.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"math"
 	"slices"
 	"strings"
@@ -148,7 +149,9 @@ func applyRelocations(insns asm.Instructions, bo binary.ByteOrder, b *btf.Builde
 	}
 
 	modules, err := c.Modules()
-	if err != nil {
+	// Ignore ErrNotExists to cater to kernels which have CONFIG_DEBUG_INFO_BTF_MODULES
+	// or CONFIG_DEBUG_INFO_BTF disabled.
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return err
 	}
 


### PR DESCRIPTION
9958a4f58fb4e533201e0a76d6d82eeeaa91434b allowed to perform CO-RE against all kernel modules, but introduced a small regression where kernels with no BTF would fail to perform CO-RE with the manually provided types. This commit fixes the issue by skipping the modules BTF collection if there is nothing in `/sys/kernel/btf`.