### PR TITLE
program: Allow passing extra targets for CO-RE relocations

### DIFF
--- a/btf/core_reloc_test.go
+++ b/btf/core_reloc_test.go
@@ -81,28 +81,47 @@ func TestCORERelocationRead(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	for _, progSpec := range spec.Programs {
-		t.Run(progSpec.Name, func(t *testing.T) {
-			prog, err := ebpf.NewProgramWithOptions(progSpec, ebpf.ProgramOptions{
+	tests := []struct {
+		name string
+		opts ebpf.ProgramOptions
+	}{
+		{
+			name: "KernelTypes",
+			opts: ebpf.ProgramOptions{
 				KernelTypes:       targetSpec,
 				KernelModuleTypes: map[string]*btf.Spec{},
+			},
+		},
+		{
+			name: "ExtraRelocationTargets",
+			opts: ebpf.ProgramOptions{
+				ExtraRelocationTargets: []*btf.Spec{targetSpec},
+				KernelModuleTypes:      map[string]*btf.Spec{},
+			},
+		},
+	}
+
+	for _, progSpec := range spec.Programs {
+		for _, test := range tests {
+			t.Run(progSpec.Name+"_"+test.name, func(t *testing.T) {
+				prog, err := ebpf.NewProgramWithOptions(progSpec, test.opts)
+				testutils.SkipIfNotSupported(t, err)
+				if err != nil {
+					t.Fatal("Load program:", err)
+				}
+				defer prog.Close()
+
+				ret, _, err := prog.Test(internal.EmptyBPFContext)
+				testutils.SkipIfNotSupported(t, err)
+				if err != nil {
+					t.Fatal("Error when running:", err)
+				}
+
+				if ret != 0 {
+					t.Error("Assertion failed on line", ret)
+				}
 			})
-			testutils.SkipIfNotSupported(t, err)
-			if err != nil {
-				t.Fatal("Load program:", err)
-			}
-			defer prog.Close()
-
-			ret, _, err := prog.Test(internal.EmptyBPFContext)
-			testutils.SkipIfNotSupported(t, err)
-			if err != nil {
-				t.Fatal("Error when running:", err)
-			}
-
-			if ret != 0 {
-				t.Error("Assertion failed on line", ret)
-			}
-		})
+		}
 	}
 }
 

--- a/linker.go
+++ b/linker.go
@@ -124,7 +124,7 @@ func hasFunctionReferences(insns asm.Instructions) bool {
 //
 // Passing a nil target will relocate against the running kernel. insns are
 // modified in place.
-func applyRelocations(insns asm.Instructions, bo binary.ByteOrder, b *btf.Builder, c *btf.Cache) error {
+func applyRelocations(insns asm.Instructions, bo binary.ByteOrder, b *btf.Builder, c *btf.Cache, extraTargets []*btf.Spec) error {
 	var relos []*btf.CORERelocation
 	var reloInsns []*asm.Instruction
 	iter := insns.Iterate()
@@ -165,6 +165,9 @@ func applyRelocations(insns asm.Instructions, bo binary.ByteOrder, b *btf.Builde
 		}
 
 		targets = append(targets, spec)
+	}
+	if len(extraTargets) > 0 {
+		targets = append(targets, extraTargets...)
 	}
 
 	fixups, err := btf.CORERelocate(relos, targets, bo, b.Add)

--- a/prog.go
+++ b/prog.go
@@ -95,6 +95,9 @@ type ProgramOptions struct {
 	// use the kernel BTF from a well-known location if nil.
 	KernelTypes *btf.Spec
 
+	// Additional targets to consider for CO-RE relocations.
+	ExtraRelocationTargets []*btf.Spec
+
 	// Type information used for CO-RE relocations of kernel modules,
 	// indexed by module name.
 	//
@@ -293,7 +296,7 @@ func newProgramWithOptions(spec *ProgramSpec, opts ProgramOptions, c *btf.Cache)
 	copy(insns, spec.Instructions)
 
 	var b btf.Builder
-	if err := applyRelocations(insns, spec.ByteOrder, &b, c); err != nil {
+	if err := applyRelocations(insns, spec.ByteOrder, &b, c, opts.ExtraRelocationTargets); err != nil {
 		return nil, fmt.Errorf("apply CO-RE relocations: %w", err)
 	}
 


### PR DESCRIPTION
Allow users to pass additional targets (besides the kernel and modules types) to perform CO-RE relocations.

This is used in Inspektor Gadget to perform relocations against a shared map that contains fields whose sizes change according to the runtime configuration.

cc @alban 

Ref https://github.com/inspektor-gadget/inspektor-gadget/pull/4543
