### PR TITLE
prog: speed up opening pinned Programs

### DIFF
--- a/prog.go
+++ b/prog.go
@@ -978,20 +978,16 @@ func LoadPinnedProgram(fileName string, opts *LoadPinOptions) (*Program, error) 
 		return nil, fmt.Errorf("%s is not a Program", fileName)
 	}
 
-	info, err := newProgramInfoFromFd(fd)
-	if err != nil {
-		_ = fd.Close()
-		return nil, fmt.Errorf("info for %s: %w", fileName, err)
+	p, err := newProgramFromFD(fd)
+	if err == nil {
+		p.pinnedPath = fileName
+
+		if haveObjName() != nil {
+			p.name = filepath.Base(fileName)
+		}
 	}
 
-	var progName string
-	if haveObjName() == nil {
-		progName = info.Name
-	} else {
-		progName = filepath.Base(fileName)
-	}
-
-	return &Program{"", fd, progName, fileName, info.Type}, nil
+	return p, err
 }
 
 // ProgramGetNextID returns the ID of the next eBPF program.


### PR DESCRIPTION
With commit df9ebe8 the opening of programs by fd was improved. The LoadPinnedProgram still uses to full ProgramInfo instead of the sufficient minimal one.

This commit improves the load of pinned Programs as well by using the central helper for creating programs from a fd. This also makes it more consistent with the LoadPinnedMap function as well.