### PR TITLE
linker: resolve ksyms in one go

### DIFF
--- a/internal/kallsyms/kallsyms.go
+++ b/internal/kallsyms/kallsyms.go
@@ -17,29 +17,6 @@ var errAmbiguousKsym = errors.New("multiple kernel symbols with the same name")
 
 var symAddrs cache[string, uint64]
 
-// Address returns the address of the given symbol in the kernel. Returns 0 and
-// no error if the symbol is not present. Returns an error if multiple addresses
-// were found for a symbol.
-//
-// Consider [AssignAddresses] if you need to resolve multiple symbols, as it
-// will only perform one iteration over /proc/kallsyms.
-func Address(symbol string) (uint64, error) {
-	if symbol == "" {
-		return 0, nil
-	}
-
-	if addr, ok := symAddrs.Load(symbol); ok {
-		return addr, nil
-	}
-
-	request := map[string]uint64{symbol: 0}
-	if err := AssignAddresses(request); err != nil {
-		return 0, err
-	}
-
-	return request[symbol], nil
-}
-
 // AssignAddresses looks up the addresses of the requested symbols in the kernel
 // and assigns them to their corresponding values in the symbols map. Results
 // of all lookups are cached, successful or otherwise.


### PR DESCRIPTION
Calling kallsyms.Address is incredibly expensive because we need to scan all of /proc/kallsyms for a single address.

Move to AssignAddresses instead and remove Address.