### PR TITLE
ci: work around arm64 hang

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,7 +192,8 @@ jobs:
 
       - name: Test
         # Skip TestGoarches/loong64 because the GH arm64 Go toolchain seems to be weird.
-        run: gotestsum --ignore-non-json-output-lines --junitfile junit.xml -- -exec 'sudo -E' -short -count 1 -skip '^TestGoarches/loong64$' -json ./...
+        # Ubuntu 24.04 crashes when executing TestKfunc.
+        run: gotestsum --ignore-non-json-output-lines --junitfile junit.xml -- -exec 'sudo -E' -short -count 1 -skip '^TestGoarches/loong64$' -skip '^TestKfunc$' -json ./...
 
       - name: Benchmark
         run: go test -exec sudo -short -run '^$' -bench . -benchtime=1x ./...


### PR DESCRIPTION
The ubuntu 24.04 kernel used by CI seems to have a bug which causes it to crash when executing TestKfunc in our testsuite.

    === RUN   TestKfunc
    [   15.728492] BUG: unable to handle page fault for address: ffffffffea91fa00
    [   15.728724] #PF: supervisor read access in kernel mode
    [   15.728940] #PF: error_code(0x0000) - not-present page
    [   15.729302] PGD 18e3f067 P4D 18e3f067 PUD 18e41067 PMD 0
    [   15.729693] Oops: Oops: 0000 [#1] SMP NOPTI
    [   15.729973] CPU: 1 UID: 0 PID: 1947 Comm: ebpf.test Not tainted 6.11.0-1015-azure #15~24.04.1-Ubuntu
    [   15.730377] Hardware name: Bochs Bochs, BIOS Bochs 01/01/2011
    [   15.730620] RIP: 0010:bpf_test_run+0x183/0x3d0

This requires the nf_conntrack module to be loaded since we invoke bpf_skb_ct_lookup in the test.