### PR TITLE
bpf2go: Allow multiple commands inside `BPF2GO_CC`

### DIFF
--- a/cmd/bpf2go/main.go
+++ b/cmd/bpf2go/main.go
@@ -155,9 +155,12 @@ func newB2G(stdout io.Writer, args []string) (*bpf2go, error) {
 		return nil, errors.New("missing package, you should either set the go-package flag or the GOPACKAGE env")
 	}
 
-	if b2g.cc == "" {
+	// Allow CC like "ccache clang" to work.
+	ccParts := strings.Fields(b2g.cc)
+	if len(ccParts) == 0 {
 		return nil, errors.New("no compiler specified")
 	}
+	b2g.cc = ccParts[0]
 
 	args, cFlags := splitCFlagsFromArgs(fs.Args())
 
@@ -178,7 +181,7 @@ func newB2G(stdout io.Writer, args []string) (*bpf2go, error) {
 		}
 	}
 
-	b2g.cFlags = cFlags[:len(cFlags):len(cFlags)]
+	b2g.cFlags = append(ccParts[1:], cFlags[:len(cFlags):len(cFlags)]...)
 
 	if len(args) < 2 {
 		return nil, errors.New("expected at least two arguments")


### PR DESCRIPTION
Allow multiple commands to be specified inside `BPF2GO_CC`. Example:

```
BPF2GO_CC="ccache clang" go generate ../pkg/a/b
```

I'm working on https://github.com/cilium/cilium/pull/38693 where one of the checks uses `ccache clang` instead of just `clang` as the compile command substitution. Currently, this doesn't work with `bpf2go`. This change makes it possible to use the same compile command as the rest of the build in cases like this.