### PR TITLE
btf: don't try to load strings when file is empty

### DIFF
--- a/btf/btf_test.go
+++ b/btf/btf_test.go
@@ -2,6 +2,7 @@ package btf
 
 import (
 	"bytes"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -534,6 +535,23 @@ func TestSpecConcurrentAccess(t *testing.T) {
 		runtime.Gosched()
 	}
 	wg.Wait()
+}
+
+func TestLoadEmptyRawSpec(t *testing.T) {
+	buf, err := binary.Append(nil, binary.LittleEndian, &btfHeader{
+		Magic:     btfMagic,
+		Version:   1,
+		Flags:     0,
+		HdrLen:    uint32(btfHeaderLen),
+		TypeOff:   0,
+		TypeLen:   0,
+		StringOff: 0,
+		StringLen: 0,
+	})
+	qt.Assert(t, qt.IsNil(err))
+
+	_, err = loadRawSpec(buf, nil)
+	qt.Assert(t, qt.IsNil(err))
 }
 
 func BenchmarkSpecCopy(b *testing.B) {

--- a/btf/strings.go
+++ b/btf/strings.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 )
 
-// stringTable is contains a sequence of null-terminated strings.
+// stringTable contains a sequence of null-terminated strings.
 //
 // It is safe for concurrent use.
 type stringTable struct {
@@ -44,16 +44,14 @@ func newStringTable(bytes []byte, base *stringTable) (*stringTable, error) {
 		firstStringOffset = uint32(len(base.bytes))
 	}
 
-	if len(bytes) == 0 {
-		return nil, errors.New("string table is empty")
-	}
+	if len(bytes) > 0 {
+		if bytes[len(bytes)-1] != 0 {
+			return nil, errors.New("string table isn't null terminated")
+		}
 
-	if bytes[len(bytes)-1] != 0 {
-		return nil, errors.New("string table isn't null terminated")
-	}
-
-	if firstStringOffset == 0 && bytes[0] != 0 {
-		return nil, errors.New("first item in string table is non-empty")
+		if firstStringOffset == 0 && bytes[0] != 0 {
+			return nil, errors.New("first item in string table is non-empty")
+		}
 	}
 
 	return &stringTable{base: base, bytes: bytes}, nil

--- a/btf/strings_test.go
+++ b/btf/strings_test.go
@@ -62,6 +62,16 @@ func TestStringTable(t *testing.T) {
 	}
 }
 
+func TestEmptyStringTable(t *testing.T) {
+	empty, err := newStringTable(nil, nil)
+	qt.Assert(t, qt.IsNil(err))
+	str, err := empty.Lookup(0)
+	qt.Assert(t, qt.IsNil(err), qt.Commentf("Can't lookup empty string"))
+	qt.Assert(t, qt.Equals(str, ""), qt.Commentf("Empty string lookup returned %q", str))
+	_, err = empty.Lookup(1)
+	qt.Assert(t, qt.IsNotNil(err))
+}
+
 func TestStringTableBuilder(t *testing.T) {
 	stb := newStringTableBuilder(0)
 


### PR DESCRIPTION
I opened this PR to address [issue#1818](https://github.com/cilium/ebpf/issues/1818).

In my experience, the problem has been occurring since version v0.19.0 (it does not appear in v0.18.0), specifically for the `aesni_intel` kernel module. The error encountered is:

```text
apply CO-RE relocations: load BTF for kmod aesni_intel: read string section: string table is empty
exit status 1
```

I've checked `stat /sys/kernel/btf/aesni_intel`. It shows 24 bytes, which is for the BTF header, but it has no content.