### PR TITLE
ci: remove 4.14 and 4.19 and add 6.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,13 +220,12 @@ jobs:
         tag:
           - "mainline"
           - "stable"
+          - "6.12"
           - "6.6"
           - "6.1"
           - "5.15"
           - "5.10"
           - "5.4"
-          - "4.19"
-          - "4.14"
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Remove EOL kernels and add the most recent LTS.

Fixes: https://github.com/cilium/ebpf/issues/1699