### PR TITLE
link: allow attaching with ProgramFd (needed for struct_ops)

### DIFF
--- a/link/link.go
+++ b/link/link.go
@@ -108,6 +108,9 @@ type RawLinkOptions struct {
 	BTF btf.TypeID
 	// Flags control the attach behaviour.
 	Flags uint32
+	// ProgramFd allows attaching with an arbitrary FD instead of Program.
+	// Useful for link types whose target is not a bpf_prog (e.g. struct_ops maps).
+	ProgramFd int
 }
 
 // Info contains metadata on a link.

--- a/link/link_other.go
+++ b/link/link_other.go
@@ -37,7 +37,10 @@ func AttachRawLink(opts RawLinkOptions) (*RawLink, error) {
 		return nil, fmt.Errorf("invalid target: %s", sys.ErrClosedFd)
 	}
 
-	progFd := opts.Program.FD()
+	progFd := opts.ProgramFd
+	if opts.Program != nil {
+		progFd = opts.Program.FD()
+	}
 	if progFd < 0 {
 		return nil, fmt.Errorf("invalid program: %s", sys.ErrClosedFd)
 	}

--- a/link/link_test.go
+++ b/link/link_test.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/go-quicktest/qt"
@@ -69,6 +70,41 @@ func TestRawLinkLoadPinnedWithOptions(t *testing.T) {
 	})
 	if !errors.Is(err, unix.EINVAL) {
 		t.Fatal("Invalid flags don't trigger an error:", err)
+	}
+}
+
+func TestRawLinkWithProgramFd(t *testing.T) {
+	cg, prog := mustCgroupFixtures(t)
+	t.Cleanup(func() {
+		_ = prog.Close()
+		_ = cg.Close()
+	})
+
+	ln, err := AttachRawLink(RawLinkOptions{
+		Target:    int(cg.Fd()),
+		Program:   nil,
+		ProgramFd: prog.FD(),
+		Attach:    ebpf.AttachCGroupInetEgress,
+	})
+	testutils.SkipIfNotSupported(t, err)
+	if err != nil {
+		t.Fatalf("AttachRawLink with ProgramFd failed: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+}
+
+func TestRawLinkWithInvalidProgramFd(t *testing.T) {
+	cg := testutils.CreateCgroup(t)
+	t.Cleanup(func() { _ = cg.Close() })
+
+	_, err := AttachRawLink(RawLinkOptions{
+		Target:    int(cg.Fd()),
+		Program:   nil,
+		ProgramFd: -1,
+		Attach:    ebpf.AttachCGroupInetEgress,
+	})
+	if err == nil || !strings.Contains(err.Error(), "invalid program") {
+		t.Fatalf("expected invalid program error, got %v", err)
 	}
 }
 


### PR DESCRIPTION
This PR extends RawLinkOptions with an optional ProgramFd so callers can attach link types whose target isn't a bpf_prog (e.g. struct_ops maps).

See: https://github.com/cilium/ebpf/discussions/1502