### PR TITLE
struct_ops: add structOpsMeta to carry BTF hints for StructOpsMap creation

### DIFF
--- a/helpers_test.go
+++ b/helpers_test.go
@@ -44,6 +44,36 @@ func requireTestmod(tb testing.TB) {
 	}
 }
 
+var haveStructOpsDummy = sync.OnceValues(func() (bool, error) {
+	if platform.IsWindows {
+		return false, nil
+	}
+	kspec, err := btf.LoadKernelSpec()
+	if err != nil {
+		return false, nil
+	}
+	_, err = kspec.AnyTypeByName("bpf_struct_ops_bpf_dummy_ops")
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, btf.ErrNotFound) {
+		return false, nil
+	}
+	return false, err
+})
+
+func requireStructOpsDummy(tb testing.TB) {
+	tb.Helper()
+
+	ok, err := haveStructOpsDummy()
+	if err != nil {
+		tb.Fatal(err)
+	}
+	if !ok {
+		tb.Skip("struct_ops dummy_ops wrapper type not present in vmlinux BTF")
+	}
+}
+
 func newMap(tb testing.TB, spec *MapSpec, opts *MapOptions) (*Map, error) {
 	tb.Helper()
 

--- a/map.go
+++ b/map.go
@@ -556,6 +556,47 @@ func (spec *MapSpec) createMap(inner *sys.FD) (_ *Map, err error) {
 		}
 	}
 
+	if spec.Type == StructOpsMap {
+		meta, err := extractStructOpsMeta(spec.Contents)
+		if err != nil {
+			return nil, err
+		}
+
+		// we need drop meta entry here
+		if len(spec.Contents) > 0 {
+			spec.Contents = spec.Contents[1:]
+		}
+
+		var b btf.Builder
+		h, err := btf.NewHandle(&b)
+		if err != nil {
+			return nil, err
+		}
+		defer h.Close()
+
+		s, err := btf.LoadKernelSpec()
+		if err != nil {
+			return nil, fmt.Errorf("open vmlinux BTF: %w", err)
+		}
+
+		typeSpec, err := s.AnyTypeByName(meta.kernTypeName)
+		if errors.Is(err, btf.ErrNotFound) {
+			return nil, fmt.Errorf("struct_ops kernel type %q: %w", meta.kernTypeName, ErrNotSupported)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("lookup kernel type %q: %w", meta.kernTypeName, err)
+		}
+
+		btfValueTypeId, err := s.TypeID(typeSpec)
+		if err != nil {
+			return nil, fmt.Errorf("lookup type_id of %s: %w", typeSpec.TypeName(), err)
+		}
+
+		attr.ValueSize = spec.ValueSize
+		attr.BtfVmlinuxValueTypeId = btfValueTypeId
+		attr.BtfFd = uint32(h.FD())
+	}
+
 	fd, err := sys.MapCreate(&attr)
 
 	// Some map types don't support BTF k/v in earlier kernel versions.

--- a/struct_ops.go
+++ b/struct_ops.go
@@ -1,0 +1,42 @@
+package ebpf
+
+import "fmt"
+
+// structOpsMeta is a placeholder object inserted into MapSpec.Contents
+// so that later stages (loader, ELF parser) can recognise this map as
+// a struct‑ops map without adding public fields yet.
+type structOpsMeta struct {
+	userTypeName string
+	kernTypeName string
+	members      []struct {
+		name     string
+		userOfs  uint32
+		size     uint32
+		kind     uint8
+		progName string
+	}
+	initUserBlob []byte
+}
+
+// extractStructOpsMeta returns the *structops.Meta embedded in a MapSpec’s Contents
+// according to the struct-ops convention:
+//
+//	contents[0].Key   == uint32(0)
+//	contents[0].Value == *structopsMeta
+func extractStructOpsMeta(contents []MapKV) (*structOpsMeta, error) {
+	if len(contents) == 0 {
+		return nil, fmt.Errorf("struct_ops: missing meta at Contents[0]")
+	}
+
+	k, ok := contents[0].Key.(uint32)
+	if !ok || k != 0 {
+		return nil, fmt.Errorf("struct_ops: meta key must be 0")
+	}
+
+	meta, ok := contents[0].Value.(structOpsMeta)
+	if !ok {
+		return nil, fmt.Errorf("struct_ops: meta value must be structOpsMeta")
+	}
+
+	return &meta, nil
+}

--- a/struct_ops_test.go
+++ b/struct_ops_test.go
@@ -1,0 +1,35 @@
+package ebpf
+
+import (
+	"testing"
+
+	"github.com/cilium/ebpf/internal/testutils"
+)
+
+func TestCreateStructOpsMapSpecSimple(t *testing.T) {
+	requireStructOpsDummy(t)
+
+	ms := &MapSpec{
+		Name:       "dummy_ops",
+		Type:       StructOpsMap,
+		KeySize:    4,
+		ValueSize:  128,
+		MaxEntries: 1,
+		Contents: []MapKV{
+			{
+				Key: uint32(0),
+				Value: structOpsMeta{
+					userTypeName: "bpf_dummy_ops",
+					kernTypeName: "bpf_struct_ops_bpf_dummy_ops",
+				},
+			},
+		},
+	}
+
+	m, err := NewMap(ms)
+	testutils.SkipIfNotSupported(t, err)
+	if err != nil {
+		t.Fatalf("creating struct_ops map failed: %v", err)
+	}
+	t.Cleanup(func() { _ = m.Close() })
+}


### PR DESCRIPTION
1. Verify creating a StructOpsMap from a hand-crafted MapSpec with metadata.
2. Resolve attr.BtfVmlinuxValueTypeId from vmlinux BTF before MapCreate.
3. Value population is deferred to follow-up PRs.

see: https://github.com/cilium/ebpf/discussions/1502