### PR TITLE
btf: fix race when loading cached kernel (module)? spec

### DIFF
--- a/btf/kernel.go
+++ b/btf/kernel.go
@@ -60,6 +60,11 @@ func loadCachedKernelSpec() (*Spec, error) {
 	globalCache.Lock()
 	defer globalCache.Unlock()
 
+	// check again, to prevent race between multiple callers
+	if globalCache.kernel != nil {
+		return globalCache.kernel, nil
+	}
+
 	spec, err := loadKernelSpec()
 	if err != nil {
 		return nil, err
@@ -102,6 +107,11 @@ func loadCachedKernelModuleSpec(module string) (*Spec, error) {
 	// it makes a difference.
 	globalCache.Lock()
 	defer globalCache.Unlock()
+
+	// check again, to prevent race between multiple callers
+	if spec := globalCache.modules[module]; spec != nil {
+		return spec, nil
+	}
 
 	spec, err = loadKernelModuleSpec(module, base)
 	if err != nil {


### PR DESCRIPTION
When going from the fast read path to the slow write path, another thread may have already loaded the desired spec. This can cause loading the kernel spec twice, but also issues like rebasing a decoder from a base to another with the same content (both kernel spec) but different addresses.