### PR TITLE
ringbuf: fix read after close panic

### DIFF
--- a/ringbuf/reader.go
+++ b/ringbuf/reader.go
@@ -108,7 +108,13 @@ func (r *Reader) Close() error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	return r.ring.Close()
+	var err error
+	if r.ring != nil {
+		err = r.ring.Close()
+		r.ring = nil
+	}
+
+	return err
 }
 
 // SetDeadline controls how long Read and ReadInto will block waiting for samples.


### PR DESCRIPTION
Fix the issue describe in #1857.
Following https://github.com/cilium/ebpf/pull/1849, the `Close` function was changed to not set the ring to nil.
The panic happens when `r.haveData` is true, a `Close` happens and then another `Read`.
Added a test that reproduces the panic.