### PR TITLE
bpf2go: Generate constant names for maps, programs, and variables

### DIFF
--- a/cmd/bpf2go/gen/output.tpl
+++ b/cmd/bpf2go/gen/output.tpl
@@ -22,6 +22,23 @@ import (
 {{ end }}
 {{- end }}
 
+{{- if or .Maps (or .Variables .Programs) }}
+// Names of all BPF objects in the ELF.
+//
+// Used for safe lookups in a Collection or CollectionSpec.
+const (
+{{- range $name, $id := .Maps }}
+	{{ $.Name }}Map{{ $id }} = "{{ $name }}"
+{{- end }}
+{{- range $name, $id := .Programs }}
+	{{ $.Name }}Prog{{ $id }} = "{{ $name }}"
+{{- end }}
+{{- range $name, $id := .Variables }}
+	{{ $.Name }}Var{{ $id }} = "{{ $name }}"
+{{- end }}
+)
+{{- end }}
+
 // {{ .Name.Load }} returns the embedded CollectionSpec for {{ .Name }}.
 func {{ .Name.Load }}() (*ebpf.CollectionSpec, error) {
 	reader := bytes.NewReader({{ .Name.Bytes }})

--- a/cmd/bpf2go/gen/output_test.go
+++ b/cmd/bpf2go/gen/output_test.go
@@ -117,6 +117,10 @@ func TestObjects(t *testing.T) {
 	qt.Assert(t, qt.StringContains(str, "Map1 *ebpf.Map `ebpf:\"map1\"`"))
 	qt.Assert(t, qt.StringContains(str, "Var1 *ebpf.Variable `ebpf:\"var_1\"`"))
 	qt.Assert(t, qt.StringContains(str, "ProgFoo1 *ebpf.Program `ebpf:\"prog_foo_1\"`"))
+
+	qt.Assert(t, qt.StringContains(str, "barMapMap1      = \"map1\""))
+	qt.Assert(t, qt.StringContains(str, "barVarVar1      = \"var_1\""))
+	qt.Assert(t, qt.StringContains(str, "barProgProgFoo1 = \"prog_foo_1\""))
 }
 
 func TestGenerateStructTypes(t *testing.T) {

--- a/cmd/bpf2go/test/test_bpfeb.go
+++ b/cmd/bpf2go/test/test_bpfeb.go
@@ -46,6 +46,21 @@ type testUbar struct {
 	_ [4]byte
 }
 
+// Names of all BPF objects in the ELF.
+//
+// Used for safe lookups in a Collection or CollectionSpec.
+const (
+	testMapMap1        = "map1"
+	testProgFilter     = "filter"
+	testVarAnInt       = "an_int"
+	testVarIntArray    = "int_array"
+	testVarMyConstant  = "my_constant"
+	testVarStructArray = "struct_array"
+	testVarStructConst = "struct_const"
+	testVarStructVar   = "struct_var"
+	testVarUnionVar    = "union_var"
+)
+
 // loadTest returns the embedded CollectionSpec for test.
 func loadTest() (*ebpf.CollectionSpec, error) {
 	reader := bytes.NewReader(_TestBytes)

--- a/cmd/bpf2go/test/test_bpfel.go
+++ b/cmd/bpf2go/test/test_bpfel.go
@@ -46,6 +46,21 @@ type testUbar struct {
 	_ [4]byte
 }
 
+// Names of all BPF objects in the ELF.
+//
+// Used for safe lookups in a Collection or CollectionSpec.
+const (
+	testMapMap1        = "map1"
+	testProgFilter     = "filter"
+	testVarAnInt       = "an_int"
+	testVarIntArray    = "int_array"
+	testVarMyConstant  = "my_constant"
+	testVarStructArray = "struct_array"
+	testVarStructConst = "struct_const"
+	testVarStructVar   = "struct_var"
+	testVarUnionVar    = "union_var"
+)
+
 // loadTest returns the embedded CollectionSpec for test.
 func loadTest() (*ebpf.CollectionSpec, error) {
 	reader := bytes.NewReader(_TestBytes)

--- a/docs/examples/getting_started/counter_bpfeb.go
+++ b/docs/examples/getting_started/counter_bpfeb.go
@@ -12,6 +12,14 @@ import (
 	"github.com/cilium/ebpf"
 )
 
+// Names of all BPF objects in the ELF.
+//
+// Used for safe lookups in a Collection or CollectionSpec.
+const (
+	counterMapPktCount      = "pkt_count"
+	counterProgCountPackets = "count_packets"
+)
+
 // loadCounter returns the embedded CollectionSpec for counter.
 func loadCounter() (*ebpf.CollectionSpec, error) {
 	reader := bytes.NewReader(_CounterBytes)

--- a/docs/examples/getting_started/counter_bpfel.go
+++ b/docs/examples/getting_started/counter_bpfel.go
@@ -12,6 +12,14 @@ import (
 	"github.com/cilium/ebpf"
 )
 
+// Names of all BPF objects in the ELF.
+//
+// Used for safe lookups in a Collection or CollectionSpec.
+const (
+	counterMapPktCount      = "pkt_count"
+	counterProgCountPackets = "count_packets"
+)
+
 // loadCounter returns the embedded CollectionSpec for counter.
 func loadCounter() (*ebpf.CollectionSpec, error) {
 	reader := bytes.NewReader(_CounterBytes)

--- a/docs/examples/variables/variables_bpfeb.go
+++ b/docs/examples/variables/variables_bpfeb.go
@@ -12,6 +12,17 @@ import (
 	"github.com/cilium/ebpf"
 )
 
+// Names of all BPF objects in the ELF.
+//
+// Used for safe lookups in a Collection or CollectionSpec.
+const (
+	variablesProgConstExample  = "const_example"
+	variablesProgGlobalExample = "global_example"
+	variablesProgHiddenExample = "hidden_example"
+	variablesVarConstU32       = "const_u32"
+	variablesVarGlobalU16      = "global_u16"
+)
+
 // loadVariables returns the embedded CollectionSpec for variables.
 func loadVariables() (*ebpf.CollectionSpec, error) {
 	reader := bytes.NewReader(_VariablesBytes)

--- a/docs/examples/variables/variables_bpfel.go
+++ b/docs/examples/variables/variables_bpfel.go
@@ -12,6 +12,17 @@ import (
 	"github.com/cilium/ebpf"
 )
 
+// Names of all BPF objects in the ELF.
+//
+// Used for safe lookups in a Collection or CollectionSpec.
+const (
+	variablesProgConstExample  = "const_example"
+	variablesProgGlobalExample = "global_example"
+	variablesProgHiddenExample = "hidden_example"
+	variablesVarConstU32       = "const_u32"
+	variablesVarGlobalU16      = "global_u16"
+)
+
 // loadVariables returns the embedded CollectionSpec for variables.
 func loadVariables() (*ebpf.CollectionSpec, error) {
 	reader := bytes.NewReader(_VariablesBytes)

--- a/examples/cgroup_skb/bpf_bpfeb.go
+++ b/examples/cgroup_skb/bpf_bpfeb.go
@@ -12,6 +12,14 @@ import (
 	"github.com/cilium/ebpf"
 )
 
+// Names of all BPF objects in the ELF.
+//
+// Used for safe lookups in a Collection or CollectionSpec.
+const (
+	bpfMapPktCount            = "pkt_count"
+	bpfProgCountEgressPackets = "count_egress_packets"
+)
+
 // loadBpf returns the embedded CollectionSpec for bpf.
 func loadBpf() (*ebpf.CollectionSpec, error) {
 	reader := bytes.NewReader(_BpfBytes)

--- a/examples/cgroup_skb/bpf_bpfel.go
+++ b/examples/cgroup_skb/bpf_bpfel.go
@@ -12,6 +12,14 @@ import (
 	"github.com/cilium/ebpf"
 )
 
+// Names of all BPF objects in the ELF.
+//
+// Used for safe lookups in a Collection or CollectionSpec.
+const (
+	bpfMapPktCount            = "pkt_count"
+	bpfProgCountEgressPackets = "count_egress_packets"
+)
+
 // loadBpf returns the embedded CollectionSpec for bpf.
 func loadBpf() (*ebpf.CollectionSpec, error) {
 	reader := bytes.NewReader(_BpfBytes)

--- a/examples/fentry/bpf_bpfeb.go
+++ b/examples/fentry/bpf_bpfeb.go
@@ -22,6 +22,14 @@ type bpfEvent struct {
 	Daddr uint32
 }
 
+// Names of all BPF objects in the ELF.
+//
+// Used for safe lookups in a Collection or CollectionSpec.
+const (
+	bpfMapEvents      = "events"
+	bpfProgTcpConnect = "tcp_connect"
+)
+
 // loadBpf returns the embedded CollectionSpec for bpf.
 func loadBpf() (*ebpf.CollectionSpec, error) {
 	reader := bytes.NewReader(_BpfBytes)

--- a/examples/fentry/bpf_bpfel.go
+++ b/examples/fentry/bpf_bpfel.go
@@ -22,6 +22,14 @@ type bpfEvent struct {
 	Daddr uint32
 }
 
+// Names of all BPF objects in the ELF.
+//
+// Used for safe lookups in a Collection or CollectionSpec.
+const (
+	bpfMapEvents      = "events"
+	bpfProgTcpConnect = "tcp_connect"
+)
+
 // loadBpf returns the embedded CollectionSpec for bpf.
 func loadBpf() (*ebpf.CollectionSpec, error) {
 	reader := bytes.NewReader(_BpfBytes)

--- a/examples/kprobe/bpf_bpfeb.go
+++ b/examples/kprobe/bpf_bpfeb.go
@@ -12,6 +12,14 @@ import (
 	"github.com/cilium/ebpf"
 )
 
+// Names of all BPF objects in the ELF.
+//
+// Used for safe lookups in a Collection or CollectionSpec.
+const (
+	bpfMapKprobeMap     = "kprobe_map"
+	bpfProgKprobeExecve = "kprobe_execve"
+)
+
 // loadBpf returns the embedded CollectionSpec for bpf.
 func loadBpf() (*ebpf.CollectionSpec, error) {
 	reader := bytes.NewReader(_BpfBytes)

--- a/examples/kprobe/bpf_bpfel.go
+++ b/examples/kprobe/bpf_bpfel.go
@@ -12,6 +12,14 @@ import (
 	"github.com/cilium/ebpf"
 )
 
+// Names of all BPF objects in the ELF.
+//
+// Used for safe lookups in a Collection or CollectionSpec.
+const (
+	bpfMapKprobeMap     = "kprobe_map"
+	bpfProgKprobeExecve = "kprobe_execve"
+)
+
 // loadBpf returns the embedded CollectionSpec for bpf.
 func loadBpf() (*ebpf.CollectionSpec, error) {
 	reader := bytes.NewReader(_BpfBytes)

--- a/examples/kprobe_percpu/bpf_bpfeb.go
+++ b/examples/kprobe_percpu/bpf_bpfeb.go
@@ -12,6 +12,14 @@ import (
 	"github.com/cilium/ebpf"
 )
 
+// Names of all BPF objects in the ELF.
+//
+// Used for safe lookups in a Collection or CollectionSpec.
+const (
+	bpfMapKprobeMap     = "kprobe_map"
+	bpfProgKprobeExecve = "kprobe_execve"
+)
+
 // loadBpf returns the embedded CollectionSpec for bpf.
 func loadBpf() (*ebpf.CollectionSpec, error) {
 	reader := bytes.NewReader(_BpfBytes)

--- a/examples/kprobe_percpu/bpf_bpfel.go
+++ b/examples/kprobe_percpu/bpf_bpfel.go
@@ -12,6 +12,14 @@ import (
 	"github.com/cilium/ebpf"
 )
 
+// Names of all BPF objects in the ELF.
+//
+// Used for safe lookups in a Collection or CollectionSpec.
+const (
+	bpfMapKprobeMap     = "kprobe_map"
+	bpfProgKprobeExecve = "kprobe_execve"
+)
+
 // loadBpf returns the embedded CollectionSpec for bpf.
 func loadBpf() (*ebpf.CollectionSpec, error) {
 	reader := bytes.NewReader(_BpfBytes)

--- a/examples/kprobepin/bpf_bpfeb.go
+++ b/examples/kprobepin/bpf_bpfeb.go
@@ -12,6 +12,14 @@ import (
 	"github.com/cilium/ebpf"
 )
 
+// Names of all BPF objects in the ELF.
+//
+// Used for safe lookups in a Collection or CollectionSpec.
+const (
+	bpfMapKprobeMap     = "kprobe_map"
+	bpfProgKprobeExecve = "kprobe_execve"
+)
+
 // loadBpf returns the embedded CollectionSpec for bpf.
 func loadBpf() (*ebpf.CollectionSpec, error) {
 	reader := bytes.NewReader(_BpfBytes)

--- a/examples/kprobepin/bpf_bpfel.go
+++ b/examples/kprobepin/bpf_bpfel.go
@@ -12,6 +12,14 @@ import (
 	"github.com/cilium/ebpf"
 )
 
+// Names of all BPF objects in the ELF.
+//
+// Used for safe lookups in a Collection or CollectionSpec.
+const (
+	bpfMapKprobeMap     = "kprobe_map"
+	bpfProgKprobeExecve = "kprobe_execve"
+)
+
 // loadBpf returns the embedded CollectionSpec for bpf.
 func loadBpf() (*ebpf.CollectionSpec, error) {
 	reader := bytes.NewReader(_BpfBytes)

--- a/examples/ringbuffer/bpf_bpfeb.go
+++ b/examples/ringbuffer/bpf_bpfeb.go
@@ -19,6 +19,14 @@ type bpfEvent struct {
 	Comm [16]uint8
 }
 
+// Names of all BPF objects in the ELF.
+//
+// Used for safe lookups in a Collection or CollectionSpec.
+const (
+	bpfMapEvents        = "events"
+	bpfProgKprobeExecve = "kprobe_execve"
+)
+
 // loadBpf returns the embedded CollectionSpec for bpf.
 func loadBpf() (*ebpf.CollectionSpec, error) {
 	reader := bytes.NewReader(_BpfBytes)

--- a/examples/ringbuffer/bpf_bpfel.go
+++ b/examples/ringbuffer/bpf_bpfel.go
@@ -19,6 +19,14 @@ type bpfEvent struct {
 	Comm [16]uint8
 }
 
+// Names of all BPF objects in the ELF.
+//
+// Used for safe lookups in a Collection or CollectionSpec.
+const (
+	bpfMapEvents        = "events"
+	bpfProgKprobeExecve = "kprobe_execve"
+)
+
 // loadBpf returns the embedded CollectionSpec for bpf.
 func loadBpf() (*ebpf.CollectionSpec, error) {
 	reader := bytes.NewReader(_BpfBytes)

--- a/examples/sched_ext/bpf_bpfeb.go
+++ b/examples/sched_ext/bpf_bpfeb.go
@@ -12,6 +12,13 @@ import (
 	"github.com/cilium/ebpf"
 )
 
+// Names of all BPF objects in the ELF.
+//
+// Used for safe lookups in a Collection or CollectionSpec.
+const (
+	bpfMapMinimalSched = "minimal_sched"
+)
+
 // loadBpf returns the embedded CollectionSpec for bpf.
 func loadBpf() (*ebpf.CollectionSpec, error) {
 	reader := bytes.NewReader(_BpfBytes)

--- a/examples/sched_ext/bpf_bpfel.go
+++ b/examples/sched_ext/bpf_bpfel.go
@@ -12,6 +12,13 @@ import (
 	"github.com/cilium/ebpf"
 )
 
+// Names of all BPF objects in the ELF.
+//
+// Used for safe lookups in a Collection or CollectionSpec.
+const (
+	bpfMapMinimalSched = "minimal_sched"
+)
+
 // loadBpf returns the embedded CollectionSpec for bpf.
 func loadBpf() (*ebpf.CollectionSpec, error) {
 	reader := bytes.NewReader(_BpfBytes)

--- a/examples/tcprtt/bpf_bpfeb.go
+++ b/examples/tcprtt/bpf_bpfeb.go
@@ -22,6 +22,14 @@ type bpfEvent struct {
 	Srtt  uint32
 }
 
+// Names of all BPF objects in the ELF.
+//
+// Used for safe lookups in a Collection or CollectionSpec.
+const (
+	bpfMapEvents    = "events"
+	bpfProgTcpClose = "tcp_close"
+)
+
 // loadBpf returns the embedded CollectionSpec for bpf.
 func loadBpf() (*ebpf.CollectionSpec, error) {
 	reader := bytes.NewReader(_BpfBytes)

--- a/examples/tcprtt/bpf_bpfel.go
+++ b/examples/tcprtt/bpf_bpfel.go
@@ -22,6 +22,14 @@ type bpfEvent struct {
 	Srtt  uint32
 }
 
+// Names of all BPF objects in the ELF.
+//
+// Used for safe lookups in a Collection or CollectionSpec.
+const (
+	bpfMapEvents    = "events"
+	bpfProgTcpClose = "tcp_close"
+)
+
 // loadBpf returns the embedded CollectionSpec for bpf.
 func loadBpf() (*ebpf.CollectionSpec, error) {
 	reader := bytes.NewReader(_BpfBytes)

--- a/examples/tcprtt_sockops/bpf_bpfeb.go
+++ b/examples/tcprtt_sockops/bpf_bpfeb.go
@@ -37,6 +37,15 @@ type bpfSkKey struct {
 	RemotePort uint32
 }
 
+// Names of all BPF objects in the ELF.
+//
+// Used for safe lookups in a Collection or CollectionSpec.
+const (
+	bpfMapMapEstabSk    = "map_estab_sk"
+	bpfMapRttEvents     = "rtt_events"
+	bpfProgBpfSockopsCb = "bpf_sockops_cb"
+)
+
 // loadBpf returns the embedded CollectionSpec for bpf.
 func loadBpf() (*ebpf.CollectionSpec, error) {
 	reader := bytes.NewReader(_BpfBytes)

--- a/examples/tcprtt_sockops/bpf_bpfel.go
+++ b/examples/tcprtt_sockops/bpf_bpfel.go
@@ -37,6 +37,15 @@ type bpfSkKey struct {
 	RemotePort uint32
 }
 
+// Names of all BPF objects in the ELF.
+//
+// Used for safe lookups in a Collection or CollectionSpec.
+const (
+	bpfMapMapEstabSk    = "map_estab_sk"
+	bpfMapRttEvents     = "rtt_events"
+	bpfProgBpfSockopsCb = "bpf_sockops_cb"
+)
+
 // loadBpf returns the embedded CollectionSpec for bpf.
 func loadBpf() (*ebpf.CollectionSpec, error) {
 	reader := bytes.NewReader(_BpfBytes)

--- a/examples/tcx/bpf_bpfeb.go
+++ b/examples/tcx/bpf_bpfeb.go
@@ -12,6 +12,16 @@ import (
 	"github.com/cilium/ebpf"
 )
 
+// Names of all BPF objects in the ELF.
+//
+// Used for safe lookups in a Collection or CollectionSpec.
+const (
+	bpfProgEgressProgFunc  = "egress_prog_func"
+	bpfProgIngressProgFunc = "ingress_prog_func"
+	bpfVarEgressPktCount   = "egress_pkt_count"
+	bpfVarIngressPktCount  = "ingress_pkt_count"
+)
+
 // loadBpf returns the embedded CollectionSpec for bpf.
 func loadBpf() (*ebpf.CollectionSpec, error) {
 	reader := bytes.NewReader(_BpfBytes)

--- a/examples/tcx/bpf_bpfel.go
+++ b/examples/tcx/bpf_bpfel.go
@@ -12,6 +12,16 @@ import (
 	"github.com/cilium/ebpf"
 )
 
+// Names of all BPF objects in the ELF.
+//
+// Used for safe lookups in a Collection or CollectionSpec.
+const (
+	bpfProgEgressProgFunc  = "egress_prog_func"
+	bpfProgIngressProgFunc = "ingress_prog_func"
+	bpfVarEgressPktCount   = "egress_pkt_count"
+	bpfVarIngressPktCount  = "ingress_pkt_count"
+)
+
 // loadBpf returns the embedded CollectionSpec for bpf.
 func loadBpf() (*ebpf.CollectionSpec, error) {
 	reader := bytes.NewReader(_BpfBytes)

--- a/examples/tracepoint_in_c/bpf_bpfeb.go
+++ b/examples/tracepoint_in_c/bpf_bpfeb.go
@@ -12,6 +12,14 @@ import (
 	"github.com/cilium/ebpf"
 )
 
+// Names of all BPF objects in the ELF.
+//
+// Used for safe lookups in a Collection or CollectionSpec.
+const (
+	bpfMapCountingMap  = "counting_map"
+	bpfProgMmPageAlloc = "mm_page_alloc"
+)
+
 // loadBpf returns the embedded CollectionSpec for bpf.
 func loadBpf() (*ebpf.CollectionSpec, error) {
 	reader := bytes.NewReader(_BpfBytes)

--- a/examples/tracepoint_in_c/bpf_bpfel.go
+++ b/examples/tracepoint_in_c/bpf_bpfel.go
@@ -12,6 +12,14 @@ import (
 	"github.com/cilium/ebpf"
 )
 
+// Names of all BPF objects in the ELF.
+//
+// Used for safe lookups in a Collection or CollectionSpec.
+const (
+	bpfMapCountingMap  = "counting_map"
+	bpfProgMmPageAlloc = "mm_page_alloc"
+)
+
 // loadBpf returns the embedded CollectionSpec for bpf.
 func loadBpf() (*ebpf.CollectionSpec, error) {
 	reader := bytes.NewReader(_BpfBytes)

--- a/examples/uretprobe/bpf_x86_bpfel.go
+++ b/examples/uretprobe/bpf_x86_bpfel.go
@@ -19,6 +19,14 @@ type bpfEvent struct {
 	Line [80]uint8
 }
 
+// Names of all BPF objects in the ELF.
+//
+// Used for safe lookups in a Collection or CollectionSpec.
+const (
+	bpfMapEvents                 = "events"
+	bpfProgUretprobeBashReadline = "uretprobe_bash_readline"
+)
+
 // loadBpf returns the embedded CollectionSpec for bpf.
 func loadBpf() (*ebpf.CollectionSpec, error) {
 	reader := bytes.NewReader(_BpfBytes)

--- a/examples/xdp/bpf_bpfeb.go
+++ b/examples/xdp/bpf_bpfeb.go
@@ -12,6 +12,14 @@ import (
 	"github.com/cilium/ebpf"
 )
 
+// Names of all BPF objects in the ELF.
+//
+// Used for safe lookups in a Collection or CollectionSpec.
+const (
+	bpfMapXdpStatsMap  = "xdp_stats_map"
+	bpfProgXdpProgFunc = "xdp_prog_func"
+)
+
 // loadBpf returns the embedded CollectionSpec for bpf.
 func loadBpf() (*ebpf.CollectionSpec, error) {
 	reader := bytes.NewReader(_BpfBytes)

--- a/examples/xdp/bpf_bpfel.go
+++ b/examples/xdp/bpf_bpfel.go
@@ -12,6 +12,14 @@ import (
 	"github.com/cilium/ebpf"
 )
 
+// Names of all BPF objects in the ELF.
+//
+// Used for safe lookups in a Collection or CollectionSpec.
+const (
+	bpfMapXdpStatsMap  = "xdp_stats_map"
+	bpfProgXdpProgFunc = "xdp_prog_func"
+)
+
 // loadBpf returns the embedded CollectionSpec for bpf.
 func loadBpf() (*ebpf.CollectionSpec, error) {
 	reader := bytes.NewReader(_BpfBytes)

--- a/examples/xdp_live_frame/bpf_bpfeb.go
+++ b/examples/xdp_live_frame/bpf_bpfeb.go
@@ -12,6 +12,14 @@ import (
 	"github.com/cilium/ebpf"
 )
 
+// Names of all BPF objects in the ELF.
+//
+// Used for safe lookups in a Collection or CollectionSpec.
+const (
+	bpfProgXdpProgPass = "xdp_prog_pass"
+	bpfProgXdpProgTx   = "xdp_prog_tx"
+)
+
 // loadBpf returns the embedded CollectionSpec for bpf.
 func loadBpf() (*ebpf.CollectionSpec, error) {
 	reader := bytes.NewReader(_BpfBytes)

--- a/examples/xdp_live_frame/bpf_bpfel.go
+++ b/examples/xdp_live_frame/bpf_bpfel.go
@@ -12,6 +12,14 @@ import (
 	"github.com/cilium/ebpf"
 )
 
+// Names of all BPF objects in the ELF.
+//
+// Used for safe lookups in a Collection or CollectionSpec.
+const (
+	bpfProgXdpProgPass = "xdp_prog_pass"
+	bpfProgXdpProgTx   = "xdp_prog_tx"
+)
+
 // loadBpf returns the embedded CollectionSpec for bpf.
 func loadBpf() (*ebpf.CollectionSpec, error) {
 	reader := bytes.NewReader(_BpfBytes)


### PR DESCRIPTION
Idea https://github.com/cilium/ebpf/discussions/1833.

Add bpf2go functionality that generates constant string names for maps, programs, and variables. Useful when working with `ebpf.Collection` and `ebpf.CollectionSpec`.

Example output from `TestObjects`:
```go
// Names of all BPF objects in the ELF.
//
// Used for safe lookups in a Collection or CollectionSpec.
const (
	barMapMap1      = "map1"
	barProgProgFoo1 = "prog_foo_1"
	barVarVar1      = "var_1"
)
```