### PR TITLE
memory: set cleanup on *Memory instead of **Memory

### DIFF
--- a/memory.go
+++ b/memory.go
@@ -65,7 +65,7 @@ func newMemory(fd, size int) (*Memory, error) {
 	}
 
 	mm := &Memory{b: b, ro: ro, heap: false}
-	mm.cleanup = runtime.AddCleanup(&mm, memoryCleanupFunc(), b)
+	mm.cleanup = runtime.AddCleanup(mm, memoryCleanupFunc(), b)
 
 	return mm, nil
 }

--- a/memory_test.go
+++ b/memory_test.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"math"
 	"os"
+	"runtime"
 	"testing"
 
 	"github.com/go-quicktest/qt"
@@ -31,6 +32,10 @@ func mustMmapableArray(tb testing.TB, extraFlags uint32) *Map {
 func TestMemory(t *testing.T) {
 	mm, err := mustMmapableArray(t, 0).Memory()
 	qt.Assert(t, qt.IsNil(err))
+
+	// Ensure the cleanup is set correctly and doesn't unmap the region while
+	// we're using it.
+	runtime.GC()
 
 	// The mapping is always at least one page long, and the Map created here fits
 	// in a single page.


### PR DESCRIPTION
Flagged in https://github.com/cilium/ebpf/issues/1862.

Stupid oversight on my part. Added a simple GC test to make sure the backing array stays mapped.