### PR TITLE
all: use testing.B.Loop()

### DIFF
--- a/asm/instruction_test.go
+++ b/asm/instruction_test.go
@@ -35,7 +35,7 @@ func TestRead64bitImmediate(t *testing.T) {
 
 func BenchmarkRead64bitImmediate(b *testing.B) {
 	r := &bytes.Reader{}
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		r.Reset(test64bitImmProg)
 
 		var ins Instruction
@@ -64,7 +64,7 @@ func BenchmarkWrite64BitImmediate(b *testing.B) {
 	ins := LoadImm(R0, math.MinInt32-1, DWord)
 
 	var buf bytes.Buffer
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		buf.Reset()
 
 		if _, err := ins.Marshal(&buf, binary.LittleEndian); err != nil {

--- a/asm/metadata_test.go
+++ b/asm/metadata_test.go
@@ -54,7 +54,7 @@ func BenchmarkMetadata(b *testing.B) {
 	b.Run("add first", func(b *testing.B) {
 		b.ReportAllocs()
 
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			var v Metadata
 			v.Set(t{}, 0)
 		}
@@ -67,9 +67,8 @@ func BenchmarkMetadata(b *testing.B) {
 		}
 
 		b.ReportAllocs()
-		b.ResetTimer()
 
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			v := m
 			v.Set(t{}, 0)
 		}
@@ -83,9 +82,8 @@ func BenchmarkMetadata(b *testing.B) {
 		m.Set(t{}, 0)
 
 		b.ReportAllocs()
-		b.ResetTimer()
 
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			v := m
 			v.Set(t{}, 0)
 		}
@@ -98,9 +96,8 @@ func BenchmarkMetadata(b *testing.B) {
 		}
 
 		b.ReportAllocs()
-		b.ResetTimer()
 
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			if m.Get(t{}) != nil {
 				b.Fatal("got result from miss")
 			}

--- a/btf/btf_test.go
+++ b/btf/btf_test.go
@@ -212,9 +212,8 @@ func TestTypeByName(t *testing.T) {
 func BenchmarkParseVmlinux(b *testing.B) {
 	vmlinux := vmlinuxTestdataBytes(b)
 	b.ReportAllocs()
-	b.ResetTimer()
 
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		if _, err := loadRawSpec(vmlinux, nil); err != nil {
 			b.Fatal("Can't load BTF:", err)
 		}
@@ -224,9 +223,8 @@ func BenchmarkParseVmlinux(b *testing.B) {
 func BenchmarkIterateVmlinux(b *testing.B) {
 	vmlinux := vmlinuxTestdataBytes(b)
 	b.ReportAllocs()
-	b.ResetTimer()
 
-	for range b.N {
+	for b.Loop() {
 		spec, err := loadRawSpec(vmlinux, nil)
 		if err != nil {
 			b.Fatal("Can't load BTF:", err)
@@ -556,9 +554,8 @@ func TestLoadEmptyRawSpec(t *testing.T) {
 
 func BenchmarkSpecCopy(b *testing.B) {
 	spec := vmlinuxTestdataSpec(b)
-	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		spec.Copy()
 	}
 }
@@ -567,8 +564,7 @@ func BenchmarkSpecTypeByID(b *testing.B) {
 	spec := vmlinuxTestdataSpec(b)
 
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, err := spec.TypeByID(1)
 		if err != nil {
 			b.Fatal(err)
@@ -612,9 +608,7 @@ func BenchmarkInspektorGadget(b *testing.B) {
 
 	var rd bytes.Reader
 
-	b.ResetTimer()
-
-	for range b.N {
+	for b.Loop() {
 		rd.Reset(vmlinux)
 		spec, err := LoadSpecFromReader(&rd)
 		if err != nil {

--- a/btf/core_test.go
+++ b/btf/core_test.go
@@ -695,7 +695,7 @@ func BenchmarkCORESkBuff(b *testing.B) {
 		b.Run(relo.kind.String(), func(b *testing.B) {
 			b.ReportAllocs()
 
-			for i := 0; i < b.N; i++ {
+			for b.Loop() {
 				_, err = CORERelocate([]*CORERelocation{relo}, []*Spec{spec}, spec.byteOrder, spec.TypeID)
 				if err != nil {
 					b.Fatal(err)

--- a/btf/ext_info_test.go
+++ b/btf/ext_info_test.go
@@ -33,9 +33,8 @@ func BenchmarkParseLineInfoRecords(b *testing.B) {
 	buf := make([]byte, size*count)
 
 	b.ReportAllocs()
-	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		parseLineInfoRecords(bytes.NewReader(buf), internal.NativeEndian, size, count, true)
 	}
 }

--- a/btf/marshal_test.go
+++ b/btf/marshal_test.go
@@ -210,9 +210,8 @@ func BenchmarkMarshaler(b *testing.B) {
 	types := typesFromSpec(b, vmlinuxTestdataSpec(b))[:100]
 
 	b.ReportAllocs()
-	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		var b Builder
 		for _, typ := range types {
 			_, _ = b.Add(typ)
@@ -225,9 +224,8 @@ func BenchmarkBuildVmlinux(b *testing.B) {
 	types := typesFromSpec(b, vmlinuxTestdataSpec(b))
 
 	b.ReportAllocs()
-	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		var b Builder
 		for _, typ := range types {
 			_, _ = b.Add(typ)

--- a/btf/strings_test.go
+++ b/btf/strings_test.go
@@ -101,8 +101,7 @@ func TestStringTableBuilder(t *testing.T) {
 func BenchmarkStringTableZeroLookup(b *testing.B) {
 	strings := vmlinuxTestdataSpec(b).strings
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		s, err := strings.Lookup(0)
 		if err != nil {
 			b.Fatal(err)

--- a/btf/traversal_test.go
+++ b/btf/traversal_test.go
@@ -105,8 +105,7 @@ func BenchmarkPostorderTraversal(b *testing.B) {
 	} {
 		b.Run(test.name, func(b *testing.B) {
 			b.ReportAllocs()
-			b.ResetTimer()
-			for range b.N {
+			for b.Loop() {
 				for range postorder(test.typ, nil) {
 				}
 			}

--- a/btf/types_test.go
+++ b/btf/types_test.go
@@ -111,9 +111,8 @@ func BenchmarkCopy(b *testing.B) {
 	typ := newCyclicalType(10)
 
 	b.ReportAllocs()
-	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		Copy(typ)
 	}
 }
@@ -493,7 +492,7 @@ func BenchmarkWalk(b *testing.B) {
 		b.Run(fmt.Sprint(typ), func(b *testing.B) {
 			b.ReportAllocs()
 
-			for i := 0; i < b.N; i++ {
+			for b.Loop() {
 				var dq typeDeque
 				for child := range children(typ) {
 					dq.Push(child)
@@ -563,9 +562,8 @@ func BenchmarkUnderlyingType(b *testing.B) {
 	b.Run("no unwrapping", func(b *testing.B) {
 		v := &Int{}
 		b.ReportAllocs()
-		b.ResetTimer()
 
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			UnderlyingType(v)
 		}
 	})
@@ -573,9 +571,8 @@ func BenchmarkUnderlyingType(b *testing.B) {
 	b.Run("single unwrapping", func(b *testing.B) {
 		v := &Typedef{Type: &Int{}}
 		b.ReportAllocs()
-		b.ResetTimer()
 
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			UnderlyingType(v)
 		}
 	})

--- a/collection_test.go
+++ b/collection_test.go
@@ -643,9 +643,8 @@ func BenchmarkNewCollection(b *testing.B) {
 	spec = fixupCollectionSpec(spec)
 
 	b.ReportAllocs()
-	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		coll, err := NewCollection(spec)
 		if err != nil {
 			b.Fatal(err)
@@ -664,9 +663,8 @@ func BenchmarkNewCollectionManyProgs(b *testing.B) {
 	spec = fixupCollectionSpec(spec)
 
 	b.ReportAllocs()
-	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		coll, err := NewCollection(spec)
 		if err != nil {
 			b.Fatal(err)
@@ -681,9 +679,8 @@ func BenchmarkLoadCollectionManyProgs(b *testing.B) {
 	defer file.Close()
 
 	b.ReportAllocs()
-	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, err := file.Seek(0, io.SeekStart)
 		if err != nil {
 			b.Fatal(err)

--- a/elf_reader_test.go
+++ b/elf_reader_test.go
@@ -301,7 +301,7 @@ func TestLoadCollectionSpec(t *testing.T) {
 func BenchmarkELFLoader(b *testing.B) {
 	b.ReportAllocs()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = LoadCollectionSpec("testdata/loader-el.elf")
 	}
 }

--- a/info_test.go
+++ b/info_test.go
@@ -110,8 +110,7 @@ func BenchmarkNewMapFromFD(b *testing.B) {
 
 	m := mustNewMap(b, hashMapSpec, nil)
 
-	b.ResetTimer()
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		if _, err := newMapFromFD(m.fd); err != nil {
 			b.Fatal(err)
 		}
@@ -123,8 +122,7 @@ func BenchmarkMapInfo(b *testing.B) {
 
 	m := mustNewMap(b, hashMapSpec, nil)
 
-	b.ResetTimer()
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		if _, err := newMapInfoFromFd(m.fd); err != nil {
 			b.Fatal(err)
 		}
@@ -213,8 +211,7 @@ func BenchmarkNewProgramFromFD(b *testing.B) {
 	spec := fixupProgramSpec(basicProgramSpec)
 	prog := mustNewProgram(b, spec, nil)
 
-	b.ResetTimer()
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		if _, err := newProgramFromFD(prog.fd); err != nil {
 			b.Fatal(err)
 		}
@@ -227,8 +224,7 @@ func BenchmarkProgramInfo(b *testing.B) {
 	spec := fixupProgramSpec(basicProgramSpec)
 	prog := mustNewProgram(b, spec, nil)
 
-	b.ResetTimer()
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		if _, err := newProgramInfoFromFd(prog.fd); err != nil {
 			b.Fatal(err)
 		}
@@ -389,8 +385,7 @@ func BenchmarkScanFdInfoReader(b *testing.B) {
 	var val string
 	fields := map[string]any{"foo": &val}
 
-	b.ResetTimer()
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		val = ""
 		r.Reset(input)
 
@@ -435,10 +430,10 @@ func BenchmarkStats(b *testing.B) {
 
 	prog := createBasicProgram(b)
 
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		if err := testStats(b, prog); err != nil {
 			testutils.SkipIfNotSupportedOnOS(b, err)
-			b.Fatal(fmt.Errorf("iter %d: %w", n, err))
+			b.Fatal(err)
 		}
 	}
 }

--- a/internal/kallsyms/kallsyms_test.go
+++ b/internal/kallsyms/kallsyms_test.go
@@ -95,7 +95,7 @@ func TestAssignAddresses(t *testing.T) {
 
 func BenchmarkAssignAddresses(b *testing.B) {
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		b.StopTimer()
 		f := bytes.NewBuffer(syms)
 		want := map[string]uint64{"bench_sym": 0}
@@ -110,7 +110,7 @@ func BenchmarkAssignAddresses(b *testing.B) {
 // Benchmark getting 5 kernel symbols from /proc/kallsyms.
 func BenchmarkAssignAddressesKallsyms(b *testing.B) {
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		b.StopTimer()
 		f := mustOpenProcKallsyms(b)
 		want := map[string]uint64{

--- a/internal/kconfig/kconfig_test.go
+++ b/internal/kconfig/kconfig_test.go
@@ -19,9 +19,8 @@ func BenchmarkParse(b *testing.B) {
 	defer f.Close()
 
 	b.ReportAllocs()
-	b.ResetTimer()
 
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		_, err := Parse(f, nil)
 		if err != nil {
 			b.Fatal(err)
@@ -37,14 +36,13 @@ func BenchmarkParseFiltered(b *testing.B) {
 	defer f.Close()
 
 	b.ReportAllocs()
-	b.ResetTimer()
 
 	// CONFIG_ARCH_USE_MEMTEST is the last CONFIG_ in the file.
 	// So, we will easily be able to see how many allocated bytes the filtering
 	// permits reducing compared to unfiltered benchmark.
 	filter := map[string]struct{}{"CONFIG_ARCH_USE_MEMTEST": {}}
 
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		_, err := Parse(f, filter)
 		if err != nil {
 			b.Fatal(err)

--- a/internal/sysenc/marshal_test.go
+++ b/internal/sysenc/marshal_test.go
@@ -248,9 +248,8 @@ func BenchmarkMarshal(b *testing.B) {
 		value := test.new()
 		b.Run(fmt.Sprintf("%T", value), func(b *testing.B) {
 			size := binary.Size(value)
-			b.ResetTimer()
 			b.ReportAllocs()
-			for i := 0; i < b.N; i++ {
+			for b.Loop() {
 				_, _ = Marshal(value, size)
 			}
 		})
@@ -267,9 +266,8 @@ func BenchmarkUnmarshal(b *testing.B) {
 		b.Run(fmt.Sprintf("%T", value), func(b *testing.B) {
 			size := binary.Size(value)
 			buf := make([]byte, size)
-			b.ResetTimer()
 			b.ReportAllocs()
-			for i := 0; i < b.N; i++ {
+			for b.Loop() {
 				_ = Unmarshal(value, buf)
 			}
 		})

--- a/link/kprobe_test.go
+++ b/link/kprobe_test.go
@@ -172,7 +172,7 @@ func TestKprobePMUUnavailable(t *testing.T) {
 }
 
 func BenchmarkKprobeCreatePMU(b *testing.B) {
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		pr, err := pmuProbe(tracefs.ProbeArgs{Type: tracefs.Kprobe, Symbol: ksym})
 		if err != nil {
 			b.Error("error creating perf_kprobe PMU:", err)
@@ -236,7 +236,7 @@ func TestKprobeTraceFS(t *testing.T) {
 }
 
 func BenchmarkKprobeCreateTraceFS(b *testing.B) {
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		// Include <tracefs>/kprobe_events operations in the benchmark loop
 		// because we create one per perf event.
 		pr, err := tracefsProbe(tracefs.ProbeArgs{Symbol: ksym})

--- a/map_test.go
+++ b/map_test.go
@@ -1786,11 +1786,10 @@ func BenchmarkMarshaling(b *testing.B) {
 
 	b.Run("ValueUnmarshalReflect", func(b *testing.B) {
 		b.ReportAllocs()
-		b.ResetTimer()
 
 		var value benchValue
 
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			err := m.Lookup(unsafe.Pointer(&key), &value)
 			if err != nil {
 				b.Fatal("Can't get key:", err)
@@ -1800,11 +1799,10 @@ func BenchmarkMarshaling(b *testing.B) {
 
 	b.Run("KeyMarshalReflect", func(b *testing.B) {
 		b.ReportAllocs()
-		b.ResetTimer()
 
 		var value benchValue
 
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			err := m.Lookup(&key, unsafe.Pointer(&value))
 			if err != nil {
 				b.Fatal("Can't get key:", err)
@@ -1814,11 +1812,10 @@ func BenchmarkMarshaling(b *testing.B) {
 
 	b.Run("ValueBinaryUnmarshaler", func(b *testing.B) {
 		b.ReportAllocs()
-		b.ResetTimer()
 
 		var value customBenchValue
 
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			err := m.Lookup(unsafe.Pointer(&key), &value)
 			if err != nil {
 				b.Fatal("Can't get key:", err)
@@ -1828,12 +1825,11 @@ func BenchmarkMarshaling(b *testing.B) {
 
 	b.Run("KeyBinaryMarshaler", func(b *testing.B) {
 		b.ReportAllocs()
-		b.ResetTimer()
 
 		var key benchKey
 		var value customBenchValue
 
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			err := m.Lookup(&key, unsafe.Pointer(&value))
 			if err != nil {
 				b.Fatal("Can't get key:", err)
@@ -1843,11 +1839,10 @@ func BenchmarkMarshaling(b *testing.B) {
 
 	b.Run("KeyValueUnsafe", func(b *testing.B) {
 		b.ReportAllocs()
-		b.ResetTimer()
 
 		var value benchValue
 
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			err := m.Lookup(unsafe.Pointer(&key), unsafe.Pointer(&value))
 			if err != nil {
 				b.Fatal("Can't get key:", err)
@@ -1876,11 +1871,10 @@ func BenchmarkPerCPUMarshalling(b *testing.B) {
 
 	b.Run("reflection", func(b *testing.B) {
 		b.ReportAllocs()
-		b.ResetTimer()
 
 		var value []uint64
 
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			err := m.Lookup(unsafe.Pointer(&key), &value)
 			if err != nil {
 				b.Fatal("Can't get key:", err)
@@ -1901,7 +1895,7 @@ func BenchmarkMap(b *testing.B) {
 
 		b.ReportAllocs()
 
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			err := m.Lookup(unsafe.Pointer(&key), unsafe.Pointer(&value))
 			if err != nil {
 				b.Fatal(err)
@@ -1914,7 +1908,7 @@ func BenchmarkMap(b *testing.B) {
 
 		b.ReportAllocs()
 
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			err := m.Update(unsafe.Pointer(&key), unsafe.Pointer(&value), UpdateAny)
 			if err != nil {
 				b.Fatal(err)
@@ -1927,7 +1921,7 @@ func BenchmarkMap(b *testing.B) {
 
 		b.ReportAllocs()
 
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			err := m.NextKey(nil, unsafe.Pointer(&key))
 			if err != nil {
 				b.Fatal(err)
@@ -1940,7 +1934,7 @@ func BenchmarkMap(b *testing.B) {
 
 		b.ReportAllocs()
 
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			err := m.Delete(unsafe.Pointer(&key))
 			if err != nil && !errors.Is(err, ErrKeyNotExist) {
 				b.Fatal(err)
@@ -1985,9 +1979,8 @@ func BenchmarkIterate(b *testing.B) {
 				v := make([]uint64, possibleCPU)
 
 				b.ReportAllocs()
-				b.ResetTimer()
 
-				for i := 0; i < b.N; i++ {
+				for b.Loop() {
 					iter := m.Iterate()
 					for iter.Next(&k, v) {
 						continue
@@ -2003,9 +1996,8 @@ func BenchmarkIterate(b *testing.B) {
 				v := make([]uint64, possibleCPU)
 
 				b.ReportAllocs()
-				b.ResetTimer()
 
-				for i := 0; i < b.N; i++ {
+				for b.Loop() {
 					b.StopTimer()
 					if _, err := m.BatchUpdate(keys, values, nil); err != nil {
 						b.Fatal(err)
@@ -2029,9 +2021,8 @@ func BenchmarkIterate(b *testing.B) {
 				v := make([]uint64, m.MaxEntries()*uint32(possibleCPU))
 
 				b.ReportAllocs()
-				b.ResetTimer()
 
-				for i := 0; i < b.N; i++ {
+				for b.Loop() {
 					var cursor MapBatchCursor
 					for {
 						_, err := m.BatchLookup(&cursor, k, v, nil)
@@ -2050,9 +2041,8 @@ func BenchmarkIterate(b *testing.B) {
 				v := make([]uint64, m.MaxEntries()*uint32(possibleCPU))
 
 				b.ReportAllocs()
-				b.ResetTimer()
 
-				for i := 0; i < b.N; i++ {
+				for b.Loop() {
 					b.StopTimer()
 					if _, err := m.BatchUpdate(keys, values, nil); err != nil {
 						b.Fatal(err)
@@ -2074,9 +2064,8 @@ func BenchmarkIterate(b *testing.B) {
 
 			b.Run("BatchDelete", func(b *testing.B) {
 				b.ReportAllocs()
-				b.ResetTimer()
 
-				for i := 0; i < b.N; i++ {
+				for b.Loop() {
 					b.StopTimer()
 					if _, err := m.BatchUpdate(keys, values, nil); err != nil {
 						b.Fatal(err)

--- a/perf/reader_test.go
+++ b/perf/reader_test.go
@@ -625,9 +625,8 @@ func BenchmarkReader(b *testing.B) {
 
 	buf := internal.EmptyBPFContext
 
-	b.ResetTimer()
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		ret, _, err := prog.Test(buf)
 		if err != nil {
 			b.Fatal(err)
@@ -653,11 +652,10 @@ func BenchmarkReadInto(b *testing.B) {
 
 	buf := internal.EmptyBPFContext
 
-	b.ResetTimer()
 	b.ReportAllocs()
 
 	var rec Record
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		// NB: Submitting samples into the perf event ring dominates
 		// the benchmark time unfortunately.
 		ret, _, err := prog.Test(buf)

--- a/prog_test.go
+++ b/prog_test.go
@@ -908,9 +908,8 @@ func BenchmarkNewProgram(b *testing.B) {
 	qt.Assert(b, qt.IsNil(err))
 
 	b.ReportAllocs()
-	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, err := NewProgram(spec.Programs["benchmark"])
 		if !errors.Is(err, unix.EACCES) {
 			b.Fatal("Unexpected error:", err)

--- a/ringbuf/reader_test.go
+++ b/ringbuf/reader_test.go
@@ -434,10 +434,9 @@ func BenchmarkReader(b *testing.B) {
 
 			buf := internal.EmptyBPFContext
 
-			b.ResetTimer()
 			b.ReportAllocs()
 
-			for i := 0; i < b.N; i++ {
+			for b.Loop() {
 				ret, _, err := prog.Test(buf)
 				if err != nil {
 					b.Fatal(err)
@@ -466,11 +465,10 @@ func BenchmarkReadInto(b *testing.B) {
 
 	buf := internal.EmptyBPFContext
 
-	b.ResetTimer()
 	b.ReportAllocs()
 
 	var rec Record
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		ret, _, err := prog.Test(buf)
 		if err != nil {
 			b.Fatal(err)


### PR DESCRIPTION
Switch to using b.Loop() which prevents the compiler from optimising away the body.