### PR TITLE
elf: allow WEAK binding for map

### DIFF
--- a/elf_reader.go
+++ b/elf_reader.go
@@ -510,7 +510,7 @@ func (ec *elfCode) relocateInstruction(ins *asm.Instruction, rel elf.Symbol) err
 			return fmt.Errorf("possible erroneous static qualifier on map definition: found reference to %q", name)
 		}
 
-		if bind != elf.STB_GLOBAL {
+		if bind != elf.STB_GLOBAL && bind != elf.STB_WEAK {
 			return fmt.Errorf("map %q: %w: %s", name, errUnsupportedBinding, bind)
 		}
 


### PR DESCRIPTION
It seems like the current implementation already allow __weak map. Lift the limit so that users can use ebpf-go with libbpf's usdt.bpf.h. There is a similar fix ([0]) for libbpf.

  [0]: https://lore.kernel.org/bpf/20220407230446.3980075-2-andrii@kernel.org/