### PR TITLE
map: add the ability to pin maps in different paths

### DIFF
--- a/types.go
+++ b/types.go
@@ -353,6 +353,8 @@ const (
 	PinNone PinType = iota
 	// Pin an object by using its name as the filename.
 	PinByName
+	// Pin an object using its path as the full path.
+	PinByPath
 )
 
 // LoadPinOptions control how a pinned object is loaded.


### PR DESCRIPTION
This PR allows to pin maps of a program in different directories. 

This is useful for the following usecase:
- I want a CNI-like structure where I attach an ebpf program to different virtual interfaces on a host 
- I want all maps used in this program to be pinned
- I want some maps to be shared across instances of this program and some maps to be isolated so that each program only interact with their own data

Without this PR all map pinning had to happen in the same directory. Now each map can be configured to be pinned in a specific location, which can be in a different directory. 