### PR TITLE
staticcheck: run main, remove staticcheck.conf

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Run staticcheck
         uses: dominikh/staticcheck-action@v1
         with:
-          version: "latest"
+          version: "master"
           install-go: false
 
       - name: Run golangci-lint

--- a/staticcheck.conf
+++ b/staticcheck.conf
@@ -1,3 +1,0 @@
-# Default configuration from https://staticcheck.dev/docs/configuration with
-# SA4003 disabled. Remove when https://github.com/cilium/ebpf/issues/1876 is fixed.
-checks = ["all", "-SA9003", "-ST1000", "-ST1003", "-ST1016", "-ST1020", "-ST1021", "-ST1022", "-ST1023", "-SA4003"]


### PR DESCRIPTION
Pick up dominikh/go-tools@8273271 and drop the config to override enabled checks. Adding the config was needed to make staticcheck pass after stringer made a change violating SA4003. Generated files are now ignored for this check.