### PR TITLE
windows: Increase default map count in call to ebpf_object_load_native_by_fds

### DIFF
--- a/collection_windows.go
+++ b/collection_windows.go
@@ -11,8 +11,8 @@ import (
 )
 
 func loadCollectionFromNativeImage(file string) (_ *Collection, err error) {
-	mapFds := make([]efw.FD, 16)
-	programFds := make([]efw.FD, 16)
+	mapFds := make([]efw.FD, 32)
+	programFds := make([]efw.FD, 32)
 	var maps map[string]*Map
 	var programs map[string]*Program
 


### PR DESCRIPTION
On Windows, a call to `ebpf_object_load_native_by_fds` may fail due to the loaded collection having a higher number of maps than allocated in mapFds array.  A subsequent call, with correct number of maps may not succeed due to flaky nature of Windows service deletion, which is a step in driver loading.

This PR attempts to reduce the impact of the issue by increasing the number of maps allocated in mapFds array in the initial the call to ebpf_object_load_native_by_fds.