### PR TITLE
link: change QueryResult.HaveLinkInfo heuristic

### DIFF
--- a/link/query.go
+++ b/link/query.go
@@ -4,6 +4,7 @@ package link
 
 import (
 	"fmt"
+	"slices"
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/internal/sys"
@@ -33,7 +34,12 @@ type QueryResult struct {
 // HaveLinkInfo returns true if the kernel supports querying link information
 // for a particular [ebpf.AttachType].
 func (qr *QueryResult) HaveLinkInfo() bool {
-	return qr.Revision > 0
+	return slices.ContainsFunc(qr.Programs,
+		func(ap AttachedProgram) bool {
+			_, ok := ap.LinkID()
+			return ok
+		},
+	)
 }
 
 type AttachedProgram struct {
@@ -44,8 +50,7 @@ type AttachedProgram struct {
 // LinkID returns the ID associated with the program.
 //
 // Returns 0, false if the kernel doesn't support retrieving the ID or if the
-// program wasn't attached via a link. See [QueryResult.HaveLinkInfo] if you
-// need to tell the two apart.
+// program wasn't attached via a link.
 func (ap *AttachedProgram) LinkID() (ID, bool) {
 	return ap.linkID, ap.linkID != 0
 }


### PR DESCRIPTION
Commit torvalds/linux@120933984460 ("bpf: Implement mprog API on top of existing cgroup progs") started populating the revision field for cgroup queries, but this still doesn't mean Link.Info() works for cgroup links created using PROG_ATTACH.

Change the heuristic used by QueryResult.HaveLinkInfo to checking if there is at least one attached program with a non-zero link ID in the query result.