### PR TITLE
Add codeowner for windows specific code

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,14 +1,14 @@
 * @cilium/ebpf-lib-maintainers
 
-features/ @rgo3
-link/ @mmat11
+/features/ @rgo3
+/link/ @mmat11
 
-perf/ @florianl
-ringbuf/ @florianl
+/perf/ @florianl
+/ringbuf/ @florianl
 
-btf/ @dylandreimerink
+/btf/ @dylandreimerink
 
-docs/ @ti-mo
+/docs/ @ti-mo
 
 # Windows specific code.
 /docs/**/windows*.md @cilium/ebpf-go-windows-reviewers


### PR DESCRIPTION
Add the new ebpf-go-windows-reviewers team as a code owner of the Windows specific code.