### PR TITLE
features: export link features

### DIFF
--- a/features/link.go
+++ b/features/link.go
@@ -1,0 +1,157 @@
+package features
+
+import (
+	"errors"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/asm"
+	"github.com/cilium/ebpf/internal"
+	"github.com/cilium/ebpf/internal/sys"
+	"github.com/cilium/ebpf/internal/unix"
+)
+
+// HaveBPFLinkUprobeMulti probes the running kernel if uprobe_multi link is supported.
+//
+// See the package documentation for the meaning of the error return value.
+func HaveBPFLinkUprobeMulti() error {
+	return haveBPFLinkUprobeMulti()
+}
+
+var haveBPFLinkUprobeMulti = internal.NewFeatureTest("bpf_link_uprobe_multi", func() error {
+	prog, err := ebpf.NewProgram(&ebpf.ProgramSpec{
+		Name: "probe_upm_link",
+		Type: ebpf.Kprobe,
+		Instructions: asm.Instructions{
+			asm.Mov.Imm(asm.R0, 0),
+			asm.Return(),
+		},
+		AttachType: ebpf.AttachTraceUprobeMulti,
+		License:    "MIT",
+	})
+	if errors.Is(err, unix.E2BIG) {
+		// Kernel doesn't support AttachType field.
+		return ebpf.ErrNotSupported
+	}
+	if err != nil {
+		return err
+	}
+	defer prog.Close()
+
+	// We try to create uprobe multi link on '/' path which results in
+	// error with -EBADF in case uprobe multi link is supported.
+	fd, err := sys.LinkCreateUprobeMulti(&sys.LinkCreateUprobeMultiAttr{
+		ProgFd:     uint32(prog.FD()),
+		AttachType: sys.BPF_TRACE_UPROBE_MULTI,
+		Path:       sys.NewStringPointer("/"),
+		Offsets:    sys.SlicePointer([]uint64{0}),
+		Count:      1,
+	})
+	switch {
+	case errors.Is(err, unix.EBADF):
+		return nil
+	case errors.Is(err, unix.EINVAL):
+		return ebpf.ErrNotSupported
+	case err != nil:
+		return err
+	}
+
+	// should not happen
+	fd.Close()
+	return errors.New("successfully attached uprobe_multi to /, kernel bug?")
+}, "6.6")
+
+// HaveBPFLinkKprobeMulti probes the running kernel if kprobe_multi link is supported.
+//
+// See the package documentation for the meaning of the error return value.
+func HaveBPFLinkKprobeMulti() error {
+	return haveBPFLinkKprobeMulti()
+}
+
+var haveBPFLinkKprobeMulti = internal.NewFeatureTest("bpf_link_kprobe_multi", func() error {
+	prog, err := ebpf.NewProgram(&ebpf.ProgramSpec{
+		Name: "probe_kpm_link",
+		Type: ebpf.Kprobe,
+		Instructions: asm.Instructions{
+			asm.Mov.Imm(asm.R0, 0),
+			asm.Return(),
+		},
+		AttachType: ebpf.AttachTraceKprobeMulti,
+		License:    "MIT",
+	})
+	if errors.Is(err, unix.E2BIG) {
+		// Kernel doesn't support AttachType field.
+		return ebpf.ErrNotSupported
+	}
+	if err != nil {
+		return err
+	}
+	defer prog.Close()
+
+	fd, err := sys.LinkCreateKprobeMulti(&sys.LinkCreateKprobeMultiAttr{
+		ProgFd:     uint32(prog.FD()),
+		AttachType: sys.BPF_TRACE_KPROBE_MULTI,
+		Count:      1,
+		Syms:       sys.NewStringSlicePointer([]string{"vprintk"}),
+	})
+	switch {
+	case errors.Is(err, unix.EINVAL):
+		return ebpf.ErrNotSupported
+	// If CONFIG_FPROBE isn't set.
+	case errors.Is(err, unix.EOPNOTSUPP):
+		return ebpf.ErrNotSupported
+	case err != nil:
+		return err
+	}
+
+	fd.Close()
+
+	return nil
+}, "5.18")
+
+// HaveBPFLinkKprobeSession probes the running kernel if kprobe_session link is supported.
+//
+// See the package documentation for the meaning of the error return value.
+func HaveBPFLinkKprobeSession() error {
+	return haveBPFLinkKprobeSession()
+}
+
+var haveBPFLinkKprobeSession = internal.NewFeatureTest("bpf_link_kprobe_session", func() error {
+	prog, err := ebpf.NewProgram(&ebpf.ProgramSpec{
+		Name: "probe_kps_link",
+		Type: ebpf.Kprobe,
+		Instructions: asm.Instructions{
+			asm.Mov.Imm(asm.R0, 0),
+			asm.Return(),
+		},
+		AttachType: ebpf.AttachTraceKprobeSession,
+		License:    "MIT",
+	})
+	if errors.Is(err, unix.E2BIG) {
+		// Kernel doesn't support AttachType field.
+		return ebpf.ErrNotSupported
+	}
+	if err != nil {
+		return err
+	}
+	defer prog.Close()
+
+	fd, err := sys.LinkCreateKprobeMulti(&sys.LinkCreateKprobeMultiAttr{
+		ProgFd:     uint32(prog.FD()),
+		AttachType: sys.BPF_TRACE_KPROBE_SESSION,
+		Count:      1,
+		Syms:       sys.NewStringSlicePointer([]string{"vprintk"}),
+	})
+	switch {
+	case errors.Is(err, unix.EINVAL):
+		return ebpf.ErrNotSupported
+	// If CONFIG_FPROBE isn't set.
+	case errors.Is(err, unix.EOPNOTSUPP):
+		return ebpf.ErrNotSupported
+	case err != nil:
+		return err
+	}
+
+	fd.Close()
+
+	return nil
+}, "6.10")

--- a/features/link_test.go
+++ b/features/link_test.go
@@ -1,0 +1,19 @@
+package features
+
+import (
+	"testing"
+
+	"github.com/cilium/ebpf/internal/testutils"
+)
+
+func TestHaveBPFLinkUprobeMulti(t *testing.T) {
+	testutils.CheckFeatureTest(t, HaveBPFLinkUprobeMulti)
+}
+
+func TestHaveBPFLinkKprobeMulti(t *testing.T) {
+	testutils.CheckFeatureTest(t, HaveBPFLinkKprobeMulti)
+}
+
+func TestHaveBPFLinkKprobeSession(t *testing.T) {
+	testutils.CheckFeatureTest(t, HaveBPFLinkKprobeSession)
+}

--- a/link/kprobe_multi.go
+++ b/link/kprobe_multi.go
@@ -8,8 +8,7 @@ import (
 	"os"
 
 	"github.com/cilium/ebpf"
-	"github.com/cilium/ebpf/asm"
-	"github.com/cilium/ebpf/internal"
+	"github.com/cilium/ebpf/features"
 	"github.com/cilium/ebpf/internal/sys"
 	"github.com/cilium/ebpf/internal/unix"
 )
@@ -126,11 +125,11 @@ func kprobeMulti(prog *ebpf.Program, opts KprobeMultiOptions, flags uint32) (Lin
 	}
 
 	if opts.Session {
-		if haveFeatErr := haveBPFLinkKprobeSession(); haveFeatErr != nil {
+		if haveFeatErr := features.HaveBPFLinkKprobeSession(); haveFeatErr != nil {
 			return nil, haveFeatErr
 		}
 	} else {
-		if haveFeatErr := haveBPFLinkKprobeMulti(); haveFeatErr != nil {
+		if haveFeatErr := features.HaveBPFLinkKprobeMulti(); haveFeatErr != nil {
 			return nil, haveFeatErr
 		}
 	}
@@ -172,85 +171,3 @@ func (kml *kprobeMultiLink) Info() (*Info, error) {
 		extra,
 	}, nil
 }
-
-var haveBPFLinkKprobeMulti = internal.NewFeatureTest("bpf_link_kprobe_multi", func() error {
-	prog, err := ebpf.NewProgram(&ebpf.ProgramSpec{
-		Name: "probe_kpm_link",
-		Type: ebpf.Kprobe,
-		Instructions: asm.Instructions{
-			asm.Mov.Imm(asm.R0, 0),
-			asm.Return(),
-		},
-		AttachType: ebpf.AttachTraceKprobeMulti,
-		License:    "MIT",
-	})
-	if errors.Is(err, unix.E2BIG) {
-		// Kernel doesn't support AttachType field.
-		return internal.ErrNotSupported
-	}
-	if err != nil {
-		return err
-	}
-	defer prog.Close()
-
-	fd, err := sys.LinkCreateKprobeMulti(&sys.LinkCreateKprobeMultiAttr{
-		ProgFd:     uint32(prog.FD()),
-		AttachType: sys.BPF_TRACE_KPROBE_MULTI,
-		Count:      1,
-		Syms:       sys.NewStringSlicePointer([]string{"vprintk"}),
-	})
-	switch {
-	case errors.Is(err, unix.EINVAL):
-		return internal.ErrNotSupported
-	// If CONFIG_FPROBE isn't set.
-	case errors.Is(err, unix.EOPNOTSUPP):
-		return internal.ErrNotSupported
-	case err != nil:
-		return err
-	}
-
-	fd.Close()
-
-	return nil
-}, "5.18")
-
-var haveBPFLinkKprobeSession = internal.NewFeatureTest("bpf_link_kprobe_session", func() error {
-	prog, err := ebpf.NewProgram(&ebpf.ProgramSpec{
-		Name: "probe_kps_link",
-		Type: ebpf.Kprobe,
-		Instructions: asm.Instructions{
-			asm.Mov.Imm(asm.R0, 0),
-			asm.Return(),
-		},
-		AttachType: ebpf.AttachTraceKprobeSession,
-		License:    "MIT",
-	})
-	if errors.Is(err, unix.E2BIG) {
-		// Kernel doesn't support AttachType field.
-		return internal.ErrNotSupported
-	}
-	if err != nil {
-		return err
-	}
-	defer prog.Close()
-
-	fd, err := sys.LinkCreateKprobeMulti(&sys.LinkCreateKprobeMultiAttr{
-		ProgFd:     uint32(prog.FD()),
-		AttachType: sys.BPF_TRACE_KPROBE_SESSION,
-		Count:      1,
-		Syms:       sys.NewStringSlicePointer([]string{"vprintk"}),
-	})
-	switch {
-	case errors.Is(err, unix.EINVAL):
-		return internal.ErrNotSupported
-	// If CONFIG_FPROBE isn't set.
-	case errors.Is(err, unix.EOPNOTSUPP):
-		return internal.ErrNotSupported
-	case err != nil:
-		return err
-	}
-
-	fd.Close()
-
-	return nil
-}, "6.10")

--- a/link/kprobe_multi_test.go
+++ b/link/kprobe_multi_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/go-quicktest/qt"
 
 	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/features"
 	"github.com/cilium/ebpf/internal/linux"
 	"github.com/cilium/ebpf/internal/testutils"
 	"github.com/cilium/ebpf/internal/unix"
@@ -18,7 +19,7 @@ import (
 var kprobeMultiSyms = []string{"vprintk", "inet6_release"}
 
 func TestKprobeMulti(t *testing.T) {
-	testutils.SkipIfNotSupported(t, haveBPFLinkKprobeMulti())
+	testutils.SkipIfNotSupported(t, features.HaveBPFLinkKprobeMulti())
 
 	prog := mustLoadProgram(t, ebpf.Kprobe, ebpf.AttachTraceKprobeMulti, "")
 
@@ -61,7 +62,7 @@ func TestKprobeMultiInput(t *testing.T) {
 }
 
 func TestKprobeMultiErrors(t *testing.T) {
-	testutils.SkipIfNotSupported(t, haveBPFLinkKprobeMulti())
+	testutils.SkipIfNotSupported(t, features.HaveBPFLinkKprobeMulti())
 
 	prog := mustLoadProgram(t, ebpf.Kprobe, ebpf.AttachTraceKprobeMulti, "")
 
@@ -82,7 +83,7 @@ func TestKprobeMultiErrors(t *testing.T) {
 }
 
 func TestKprobeMultiCookie(t *testing.T) {
-	testutils.SkipIfNotSupported(t, haveBPFLinkKprobeMulti())
+	testutils.SkipIfNotSupported(t, features.HaveBPFLinkKprobeMulti())
 
 	prog := mustLoadProgram(t, ebpf.Kprobe, ebpf.AttachTraceKprobeMulti, "")
 
@@ -97,7 +98,7 @@ func TestKprobeMultiCookie(t *testing.T) {
 }
 
 func TestKprobeMultiProgramCall(t *testing.T) {
-	testutils.SkipIfNotSupported(t, haveBPFLinkKprobeMulti())
+	testutils.SkipIfNotSupported(t, features.HaveBPFLinkKprobeMulti())
 
 	m, p := newUpdaterMapProg(t, ebpf.Kprobe, ebpf.AttachTraceKprobeMulti)
 
@@ -139,12 +140,8 @@ func TestKprobeMultiProgramCall(t *testing.T) {
 	assertMapValue(t, m, 0, 0)
 }
 
-func TestHaveBPFLinkKprobeMulti(t *testing.T) {
-	testutils.CheckFeatureTest(t, haveBPFLinkKprobeMulti)
-}
-
 func TestKprobeSession(t *testing.T) {
-	testutils.SkipIfNotSupported(t, haveBPFLinkKprobeMulti())
+	testutils.SkipIfNotSupported(t, features.HaveBPFLinkKprobeSession())
 
 	prog := mustLoadProgram(t, ebpf.Kprobe, ebpf.AttachTraceKprobeSession, "")
 
@@ -154,8 +151,4 @@ func TestKprobeSession(t *testing.T) {
 	defer km.Close()
 
 	testLink(t, km, prog)
-}
-
-func TestHaveBPFLinkKprobeSession(t *testing.T) {
-	testutils.CheckFeatureTest(t, haveBPFLinkKprobeSession)
 }

--- a/link/uprobe_multi_test.go
+++ b/link/uprobe_multi_test.go
@@ -12,11 +12,12 @@ import (
 	"github.com/go-quicktest/qt"
 
 	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/features"
 	"github.com/cilium/ebpf/internal/testutils"
 )
 
 func TestUprobeMulti(t *testing.T) {
-	testutils.SkipIfNotSupported(t, haveBPFLinkUprobeMulti())
+	testutils.SkipIfNotSupported(t, features.HaveBPFLinkUprobeMulti())
 
 	prog := mustLoadProgram(t, ebpf.Kprobe, ebpf.AttachTraceUprobeMulti, "")
 
@@ -40,7 +41,7 @@ func TestUprobeMulti(t *testing.T) {
 }
 
 func TestUprobeMultiInput(t *testing.T) {
-	testutils.SkipIfNotSupported(t, haveBPFLinkUprobeMulti())
+	testutils.SkipIfNotSupported(t, features.HaveBPFLinkUprobeMulti())
 
 	prog := mustLoadProgram(t, ebpf.Kprobe, ebpf.AttachTraceUprobeMulti, "")
 
@@ -147,7 +148,7 @@ func TestUprobeMultiResolveFail(t *testing.T) {
 }
 
 func TestUprobeMultiCookie(t *testing.T) {
-	testutils.SkipIfNotSupported(t, haveBPFLinkUprobeMulti())
+	testutils.SkipIfNotSupported(t, features.HaveBPFLinkUprobeMulti())
 
 	prog := mustLoadProgram(t, ebpf.Kprobe, ebpf.AttachTraceUprobeMulti, "")
 
@@ -173,7 +174,7 @@ func TestUprobeMultiCookie(t *testing.T) {
 }
 
 func TestUprobeMultiProgramCall(t *testing.T) {
-	testutils.SkipIfNotSupported(t, haveBPFLinkUprobeMulti())
+	testutils.SkipIfNotSupported(t, features.HaveBPFLinkUprobeMulti())
 
 	// We execute 'bash --help'
 	args := []string{"--help"}
@@ -243,8 +244,4 @@ func TestUprobeMultiProgramCall(t *testing.T) {
 	// functions, but only check_dev_tty is triggered, because 'bash --help'
 	// calls exit(0).
 	test(true, 1)
-}
-
-func TestHaveBPFLinkUprobeMulti(t *testing.T) {
-	testutils.CheckFeatureTest(t, haveBPFLinkUprobeMulti)
 }


### PR DESCRIPTION
The use of multi-attach for uprobes/kprobes requires both loading the program with the appropriate attach type, and then using the correct call to do the attach. Sometimes the program loading is not tightly coupled to the attach so it's painful to have to fail later and then re-load the program. More generally, forcing consumers of this package to track their own feature availability on top of which things return unsupported errors is bad -- we should make most feature probing available and exported to the extent possible.

This PR exports from `features`:
 * `HaveBPFLinkUprobeMulti`
 * `HaveBPFLinkKprobeMulti`
 * `HaveBPFLinkKprobeSession` 