### PR TITLE
fix(elf): set attach_type to BPF_XDP for XDP section

### DIFF
--- a/elf_reader.go
+++ b/elf_reader.go
@@ -1556,14 +1556,6 @@ func getProgType(sectionName string) (ProgramType, AttachType, uint32, string) {
 		if t.flags&_SEC_XDP_FRAGS > 0 {
 			flags |= sys.BPF_F_XDP_HAS_FRAGS
 		}
-		if t.flags&_SEC_EXP_ATTACH_OPT > 0 {
-			if programType == XDP {
-				// The library doesn't yet have code to fallback to not specifying
-				// attach type. Only do this for XDP since we've enforced correct
-				// attach type for all other program types.
-				attachType = AttachNone
-			}
-		}
 		if t.flags&ignoreExtra > 0 {
 			extra = ""
 		}

--- a/elf_reader_test.go
+++ b/elf_reader_test.go
@@ -180,6 +180,7 @@ func TestLoadCollectionSpec(t *testing.T) {
 				Name:        "xdp_prog",
 				Type:        XDP,
 				SectionName: "xdp",
+				AttachType:  AttachXDP,
 				License:     "MIT",
 			},
 			"no_relocation": {
@@ -1296,7 +1297,7 @@ func TestELFSectionProgramTypes(t *testing.T) {
 		{"xdp_cpumap/", XDP, AttachXDPCPUMap, 0, ""},
 		// Used incorrect attach type.
 		{"xdp.frags/foo", XDP, AttachXDP, sys.BPF_F_XDP_HAS_FRAGS, ""},
-		{"xdp/foo", XDP, AttachNone, 0, ""},
+		{"xdp/foo", XDP, AttachXDP, 0, ""},
 		{"perf_event", PerfEvent, AttachNone, 0, ""},
 		{"lwt_in", LWTIn, AttachNone, 0, ""},
 		{"lwt_out", LWTOut, AttachNone, 0, ""},


### PR DESCRIPTION
Summary: Since
4540aed51b12 ("bpf: Enforce expected_attach_type for tailcall compatibility")

expected_attach_type is enforced for tailcall:
https://lore.kernel.org/bpf/20250926171201.188490-1-daniel@iogearbox.net/

When an XDP program is loaded though cillium/ebpf, its `AttachType` is set to `AttachNone`.
When chaining programs using a `BPF_MAP_TYPE_PROG_ARRAY` of XDP programs, it works fine as long as all XDP program are loaded using `cillium/ebpf`.

Programs based off libbpf will have their `expected_attach_type` set to XDP: https://github.com/libbpf/libbpf/blob/afb8b17bc50b0b7606ad4ea468cbc9f5aede8dae/src/libbpf.c#L9868

Until 4540aed51b12 it was fine, but with 4540aed51b12, the second program to register to the PROG_ARRAY map would fail with:
```
libbpf: prog 'demo_chainer': BPF program load failed: Invalid argument
libbpf: prog 'demo_chainer': -- BEGIN PROG LOAD LOG --
processed 235 insns (limit 1000000) max_states_per_insn 1 total_states 19 peak_states 19 mark_read 7
-- END PROG LOAD LOG --
libbpf: prog 'demo_chainer': failed to load: -22
libbpf: failed to load object 'demo_chainer_bpf'
libbpf: failed to load BPF skeleton 'demo_chainer_bpf': -22
```

Test Plan:
* Updated unittests
* Tested on a custom deployment where both a cillium/bpf based program and a libbpf_rs one call into each others.