### PR TITLE
ringbuf: add zero-copy reader callback API

### DIFF
--- a/ringbuf/reader.go
+++ b/ringbuf/reader.go
@@ -135,7 +135,7 @@ func (r *Reader) SetDeadline(t time.Time) {
 // Returns [os.ErrDeadlineExceeded] if a deadline was set and after all records
 // have been read from the ring.
 //
-// See [ReadInto] for a more efficient version of this method.
+// See [ReadInto] or [ReadZeroCopy] for more efficient versions of this method.
 func (r *Reader) Read() (Record, error) {
 	var rec Record
 	err := r.ReadInto(&rec)
@@ -144,6 +144,20 @@ func (r *Reader) Read() (Record, error) {
 
 // ReadInto is like Read except that it allows reusing Record and associated buffers.
 func (r *Reader) ReadInto(rec *Record) error {
+	return r.readLockedPoll(func() error {
+		return r.ring.readRecord(rec)
+	})
+}
+
+// ReadZeroCopy reads the next record from the BPF ringbuf using a zero-copy callback.
+// The sample slice is only valid until the callback returns.
+func (r *Reader) ReadZeroCopy(f func(sample []byte, remaining int) error) error {
+	return r.readLockedPoll(func() error {
+		return r.ring.readRecordZeroCopy(f)
+	})
+}
+
+func (r *Reader) readLockedPoll(read func() error) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -171,7 +185,7 @@ func (r *Reader) ReadInto(rec *Record) error {
 		}
 
 		for {
-			err := r.ring.readRecord(rec)
+			err := read()
 			// Not using errors.Is which is quite a bit slower
 			// For a tight loop it might make a difference
 			if err == errBusy {


### PR DESCRIPTION
Ringbuf reads currently copy every sample into a user buffer via Read/ReadInto, even when callers only need to inspect data once. This change adds a zero-copy read API so consumers can process records directly from the mmap-backed ring buffer without an intermediate copy.

Changes
- Add Reader.ReadZeroCopy(callback) to read a record and invoke a callback with a zero-copy sample view plus the remaining-bytes count.
- Refactor the shared read loop so ReadInto and ReadZeroCopy use the same poll/epoll path and error handling.
- Add ringReader.readRecordZeroCopy as the internal zero-copy path; readRecord now delegates to it and performs the copy inside the callback.

API/behavior notes
- Read/ReadInto semantics remain unchanged.
- If the callback returns an error, the record is still consumed (consumer position is advanced) and the error is returned to the caller.

Benchmarks[1]
Results below are from benchmark-result.txt (read-into copy vs read-view zero-copy). Event sizes cover 80–2048 bytes in 16-byte steps (124 sizes).
- Speedup range: 1.00x to 5.63x; median 3.43x (mean 3.16x).
- Small sizes can be flat (e.g., 80B at 1.00x).
- Larger records benefit more as copy throughput drops while zero-copy stays roughly flat.

Sample sizes (Mevents/s):
| event-size (B) | copy | zero-copy | speedup |
| --- | --- | --- | --- |
| 80 | 43.89 | 43.70 | 1.00x |
| 128 | 42.92 | 43.82 | 1.01x |
| 256 | 28.84 | 30.97 | 1.07x |
| 512 | 24.40 | 31.42 | 1.29x |
| 1024 | 8.97 | 30.87 | 3.44x |
| 2048 | 4.41 | 24.85 | 5.63x |

[1] https://github.com/jschwinger233/bpf_ringbuf_zc_benchmark
