### PR TITLE
elf: drop legacy non-libbpf xdp* and seccomp attach types

### DIFF
--- a/docs/ebpf/concepts/section-naming.md
+++ b/docs/ebpf/concepts/section-naming.md
@@ -226,6 +226,7 @@ godoc('ProgramSpec.SectionName') }}.
 | cgroup/getsockopt     | CGroupSockopt              | AttachCGroupGetsockopt           |                            |
 | cgroup/setsockopt     | CGroupSockopt              | AttachCGroupSetsockopt           |                            |
 | struct_ops+           | StructOps                  |                                  |                            |
+| struct_ops.s+         | StructOps                  |                                  | BPF_F_SLEEPABLE            |
 | sk_lookup/            | SkLookup                   | AttachSkLookup                   |                            |
 | kprobe.multi          | Kprobe                     | AttachTraceKprobeMulti           |                            |
 | kretprobe.multi       | Kprobe                     | AttachTraceKprobeMulti           |                            |

--- a/elf_reader_test.go
+++ b/elf_reader_test.go
@@ -1334,11 +1334,12 @@ func TestELFSectionProgramTypes(t *testing.T) {
 		{"cgroup/sysctl", CGroupSysctl, AttachCGroupSysctl, 0, ""},
 		{"cgroup/getsockopt", CGroupSockopt, AttachCGroupGetsockopt, 0, ""},
 		{"cgroup/setsockopt", CGroupSockopt, AttachCGroupSetsockopt, 0, ""},
-		// Bogus pattern means it never matched anything.
-		// {"struct_ops+", StructOps, AttachNone, 0, ""},
 		{"sk_lookup/", SkLookup, AttachSkLookup, 0, ""},
 		{"kprobe.multi", Kprobe, AttachTraceKprobeMulti, 0, ""},
 		{"kretprobe.multi", Kprobe, AttachTraceKprobeMulti, 0, ""},
+		{"struct_ops", StructOps, AttachNone, 0, ""},
+		{"struct_ops.s", StructOps, AttachNone, sys.BPF_F_SLEEPABLE, ""},
+		{"struct_ops/foo", StructOps, AttachNone, 0, ""},
 	}
 
 	for _, tc := range testcases {


### PR DESCRIPTION
Since we're introducing some breaking changes regarding XDP ELF loading in https://github.com/cilium/ebpf/pull/1919, this would be a good time to get rid of some section-related tech debt.

This PR deprecates the following section prefixes, bringing us back in line with libbpf:
- xdp.frags_devmap/
- xdp_devmap/
- xdp.frags_cpumap/
- xdp_cpumap/
- seccomp

For XDP, use the appropriate section names as documented in https://ebpf-go.dev/concepts/section-naming and https://docs.kernel.org/bpf/libbpf/program_types.html. For seccomp, change the section name to 'socket'.