### PR TITLE
docs: fix bpf2go installation for recent Go versions

### DIFF
--- a/cmd/bpf2go/README.md
+++ b/cmd/bpf2go/README.md
@@ -9,7 +9,7 @@ from `bpftool gen skeleton`.
 
 Add `bpf2go` as a tool dependency in your project's Go module:
 
-    go get -tool github.com/cilium/ebpf/cmd/bpf2go
+    go install github.com/cilium/ebpf/cmd/bpf2go@latest
 
 Invoke the tool using go generate:
 

--- a/docs/ebpf/guides/getting-started.md
+++ b/docs/ebpf/guides/getting-started.md
@@ -149,8 +149,8 @@ First, add `bpf2go` as a tool dependency to your Go module. This ensures the
 version of `bpf2go` used by the Go toolchain always matches your version of the
 library.
 
-```{ .shell-session data-copy="go get -tool github.com/cilium/ebpf/cmd/bpf2go" }
-% go get -tool github.com/cilium/ebpf/cmd/bpf2go
+```{ .shell-session data-copy="go install github.com/cilium/ebpf/cmd/bpf2go@latest" }
+% go install github.com/cilium/ebpf/cmd/bpf2go@latest
 ```
 
 Now we're ready to run `go generate`:


### PR DESCRIPTION
### Summary

Recent Go versions (1.17 and later) no longer support installing binaries
using `go get` outside of a Go module.
However, the current documentation still instructs users to install
`bpf2go` using `go get -tool`, which fails on modern Go toolchains.

This PR updates the documentation to reflect the recommended
`go install module@version` workflow.

### Changes

- Replace deprecated `go get -tool github.com/cilium/ebpf/cmd/bpf2go`
  instructions with `go install github.com/cilium/ebpf/cmd/bpf2go@version`
- Add a short note explaining the Go version compatibility change
- Provide an example with a pinned version to encourage reproducible builds

### Motivation

Users working with recent Go versions (including Go 1.20+)
encounter setup failures when following the existing instructions.
Updating the documentation improves developer experience and prevents
a common source of confusion for new contributors.

### Additional Notes

- This change is documentation-only and does not affect runtime behavior.
