### PR TITLE
Update getting started document

### DIFF
--- a/docs/ebpf/guides/getting-started.md
+++ b/docs/ebpf/guides/getting-started.md
@@ -214,6 +214,14 @@ standard library here.
    `CountPackets`) eBPF program with `eth0`. This returns a {{
    godoc('link/Link') }} abstraction.
 
+   Note: On virtualized environments or network interfaces whose drivers do not
+   support native XDP, attaching may fail with "operation not supported".
+   In such cases, you can use generic mode instead:
+
+       Flags: link.XDPGenericMode
+
+Generic mode has lower performance but works on a wider range of interfaces.
+
 1. Close the file descriptor of the Program-to-interface association. Note that
    this will stop the Program from executing on incoming packets if the Link was
    not {{ godoc('link/Link.Pin') }}ed to the bpf file system.

--- a/docs/ebpf/guides/getting-started.md
+++ b/docs/ebpf/guides/getting-started.md
@@ -220,7 +220,7 @@ standard library here.
 
        Flags: link.XDPGenericMode
 
-Generic mode has lower performance but works on a wider range of interfaces.
+   Generic mode has lower performance but works on a wider range of interfaces.
 
 1. Close the file descriptor of the Program-to-interface association. Note that
    this will stop the Program from executing on incoming packets if the Link was

--- a/docs/ebpf/guides/getting-started.md
+++ b/docs/ebpf/guides/getting-started.md
@@ -19,7 +19,7 @@ more.
     To follow along with the example, you'll need:
 
     * Linux kernel version 5.7 or later, for bpf_link support
-    * LLVM 11 or later [^1] (`clang` and `llvm`)
+    * LLVM 11 or later [^1] (`clang` and `llvm-strip`)
     * libbpf headers [^2]
     * Linux kernel headers [^3]
     * Go compiler version supported by {{ proj }}'s Go module
@@ -28,7 +28,8 @@ more.
     Use `clang --version` to check which version of LLVM you have installed.
     Refer to your distribution's package index to finding the right packages to
     install, as this tends to vary wildly across distributions. Some
-    distributions ship `clang` and `llvm` in separate packages.
+    distributions ship `clang` and `llvm-strip` in separate packages
+    (and `llvm-strip` would be included in `llvm` pacakge).
 
 [^2]:
     For Debian/Ubuntu, you'll typically need `libbpf-dev`. On Fedora, it's

--- a/docs/ebpf/guides/getting-started.md
+++ b/docs/ebpf/guides/getting-started.md
@@ -19,7 +19,7 @@ more.
     To follow along with the example, you'll need:
 
     * Linux kernel version 5.7 or later, for bpf_link support
-    * LLVM 11 or later [^1] (`clang` and `llvm-strip`)
+    * LLVM 11 or later [^1] (`clang` and `llvm`)
     * libbpf headers [^2]
     * Linux kernel headers [^3]
     * Go compiler version supported by {{ proj }}'s Go module
@@ -28,7 +28,7 @@ more.
     Use `clang --version` to check which version of LLVM you have installed.
     Refer to your distribution's package index to finding the right packages to
     install, as this tends to vary wildly across distributions. Some
-    distributions ship `clang` and `llvm-strip` in separate packages.
+    distributions ship `clang` and `llvm` in separate packages.
 
 [^2]:
     For Debian/Ubuntu, you'll typically need `libbpf-dev`. On Fedora, it's


### PR DESCRIPTION
Thank you for your grate product and effort.

* apt Package:

  https://packages.debian.org/search?keywords=llvm-strip&searchon=names&suite=all&section=all
  
  https://packages.ubuntu.com/search?keywords=llvm-strip&searchon=names&suite=all&section=all
  
  Both Debian and Ubuntu current versions don't have llvm-strip package and llvm seems to ship llvm-strip command.

* link option:

  I tried to run on UTM (macOS's virtual machine) with Ubuntu 25.10, I need to add flag to run.
