### PR TITLE
map: avoid misleading error message for storage maps

### DIFF
--- a/map.go
+++ b/map.go
@@ -673,7 +673,7 @@ func handleMapCreateError(attr sys.MapCreateAttr, spec *MapSpec, err error) erro
 		return fmt.Errorf("map create: %w (MEMLOCK may be too low, consider rlimit.RemoveMemlock)", err)
 	}
 	if errors.Is(err, unix.EINVAL) {
-		if spec.MaxEntries == 0 {
+		if spec.MaxEntries == 0 && !spec.Type.mustHaveZeroMaxEntries() {
 			return fmt.Errorf("map create: %w (MaxEntries may be incorrectly set to zero)", err)
 		}
 		if spec.Type == UnspecifiedMap {

--- a/types.go
+++ b/types.go
@@ -188,6 +188,16 @@ func (mt MapType) mustHaveNoPrealloc() bool {
 	return false
 }
 
+// mustHaveZeroMaxEntries returns true if the map type requires MaxEntries to be zero.
+func (mt MapType) mustHaveZeroMaxEntries() bool {
+	switch mt {
+	case CgroupStorage, CGroupStorage, PerCPUCGroupStorage, InodeStorage, TaskStorage, SkStorage:
+		return true
+	}
+
+	return false
+}
+
 // ProgramType of the eBPF program
 type ProgramType uint32
 


### PR DESCRIPTION
### Description
This PR improves error handling in handleMapCreateError when creating BPF maps with zero MaxEntries.

It fixes a misleading error message when creating maps that require MaxEntries to be zero (such as SkStorage, InodeStorage, TaskStorage, CgroupStorage, CGroupStorage, and PerCPUCGroupStorage). 

Previously, if map creation failed with EINVAL (e.g., due to missing BTF metadata) while MaxEntries was correctly set to 0, the error handler would wrongly suggest that MaxEntries may be incorrectly set to zero.

### Changes
* Added requiresZeroMaxEntries() to MapType in types.go to identify map types that require zero max entries (supporting CgroupStorage, CGroupStorage, PerCPUCGroupStorage, InodeStorage, TaskStorage, and SkStorage).
*Updated handleMapCreateError in map.go to exempt these map types from the MaxEntries == 0 check.
