### PR TITLE
ci: cache qemu-system-x86 dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,6 @@ jobs:
   cross-build:
     name: Cross build
     runs-on: ubuntu-22.04
-    needs: build-and-lint
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
@@ -125,7 +124,6 @@ jobs:
   test-on-prev-go:
     name: Run tests on previous stable Go
     runs-on: ubuntu-latest
-    needs: build-and-lint
     timeout-minutes: 15
     env:
       CI_KERNEL_SELFTESTS: '/usr/src/linux/tools/testing/selftests/bpf'
@@ -173,7 +171,6 @@ jobs:
   test-on-arm64:
     name: Run tests on arm64
     runs-on: ubuntu-24.04-arm64
-    needs: build-and-lint
     timeout-minutes: 15
     env:
       EBPF_TEST_IGNORE_VERSION: 'TestKprobeMulti,TestKprobeMultiErrors,TestKprobeMultiCookie,TestKprobeMultiProgramCall,TestHaveBPFLinkKprobeMulti,TestKprobeSession,TestHaveBPFLinkKprobeSession,TestHaveProgramType/LircMode2'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,10 +50,6 @@ jobs:
             exit 1
           fi
 
-      - name: Test bpf2go
-        run: |
-          go test -v ./cmd/bpf2go
-
       - name: Build
         run: go build -v ./...
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,11 @@ jobs:
 
       - run: go install lmb.io/vimto@latest
       - run: go install gotest.tools/gotestsum@v1.12.3
-      - run: sudo apt-get update && sudo apt-get install -y --no-install-recommends qemu-system-x86
+
+      - uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: qemu-system-x86
+
       - run: sudo chmod 0666 /dev/kvm
 
       - name: Test
@@ -236,7 +240,11 @@ jobs:
 
       - run: go install gotest.tools/gotestsum@v1.12.3
       - run: go install lmb.io/vimto@latest
-      - run: sudo apt-get update && sudo apt-get install -y --no-install-recommends qemu-system-x86
+
+      - uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: qemu-system-x86
+
       - run: sudo chmod 0666 /dev/kvm
 
       - name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,9 +153,6 @@ jobs:
         run: |
           gotestsum --raw-command --ignore-non-json-output-lines --junitfile junit.xml -- vimto -kernel :stable-selftests -- go test -race -timeout 5m -short -count 1 -json ./...
 
-      - name: Benchmark
-        run: vimto -kernel :stable-selftests -- go test -short -run '^$' -bench . -benchtime=1x ./...
-
       - name: Upload coredumps
         uses: actions/upload-artifact@v7
         if: ${{ failure() }}
@@ -252,6 +249,30 @@ jobs:
         with:
           name: Test Results (linux ${{ matrix.tag }})
           path: junit.xml
+
+  linux-benchmark:
+    name: Run benchmarks (Linux)
+    runs-on: ubuntu-latest
+    needs: build-and-lint
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '${{ env.go_version }}'
+
+      - run: go install lmb.io/vimto@latest
+
+      - uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: qemu-system-x86
+
+      - run: sudo chmod 0666 /dev/kvm
+
+      - name: Benchmark
+        run: vimto -kernel :stable-selftests -- go test -short -run '^$' -bench . -benchtime=1x ./...
 
   windows-test:
     name: Run tests (Windows)
@@ -454,6 +475,7 @@ jobs:
       - test-on-prev-go
       - test-on-arm64
       - linux-test
+      - linux-benchmark
       - windows-test
     if: always()
     steps:


### PR DESCRIPTION
This PR shuffles around some jobs to parallelize better and adds apt caching for more reliability.

- CI often hangs on apt-get installing qemu. Try caching the packages instead.
- Don't explicitly test bpf2go, it's included in `go test ./...` anyway
- Move Go benchmarks to run in parallel with tests
- Remove some dependencies on `build-and-lint` because that can take a while