### PR TITLE
linker: check ErrNotSupported too

### DIFF
--- a/linker.go
+++ b/linker.go
@@ -305,10 +305,12 @@ fixups:
 			return nil, fmt.Errorf("kfuncMetaKey doesn't contain kfuncMeta")
 		}
 
-		// findTargetInKernel returns btf.ErrNotFound if the input btf.Spec is nil.
+		// findTargetInKernel returns btf.ErrNotFound if the input btf.Spec is nil,
+		// and returns ErrNotSupported if the btf file is not located at the hard-coded locations.
+		// In both cases, we want to poison the call if it's weak, and error out if it's not.
 		target := btf.Type((*btf.Func)(nil))
 		spec, module, err := findTargetInKernel(kfm.Func.Name, &target, cache)
-		if errors.Is(err, btf.ErrNotFound) {
+		if errors.Is(err, btf.ErrNotFound) || errors.Is(err, ErrNotSupported) {
 			if kfm.Binding == elf.STB_WEAK {
 				if ins.IsKfuncCall() {
 					// If the kfunc call is weak and not found, poison the call. Use a


### PR DESCRIPTION
When we fixup kfuncs, we only check hard-coded paths for the BTF file. If we cannot find the BTF file in these paths, then we should poison the kfunc calls in order to allow loading the collection.

The fixup kfunc logic does not respect the KernelTypes *btf.Spec passed with ProgramOptions because kfunc support depends on CONFIG_DEBUG_INFO_BTF, which exposes /sys/kernel/btf/vmlinux. As such, we expect that file to exist and be available.

But if it's not available, findTargetInKernel will return ErrNotSupported, and we shouldn't refuse to load the collection.