### PR TITLE
prog: restore btf.ErrNotFound behaviour of findTargetInKernel

### DIFF
--- a/btf/kernel.go
+++ b/btf/kernel.go
@@ -36,8 +36,9 @@ func FlushKernelSpec() {
 
 // LoadKernelSpec returns the current kernel's BTF information.
 //
-// Defaults to /sys/kernel/btf/vmlinux and falls back to scanning the file system
-// for vmlinux ELFs. Returns an error wrapping ErrNotSupported if BTF is not enabled.
+// Defaults to /sys/kernel/btf/vmlinux and falls back to scanning the file
+// system for vmlinux ELFs. Returns an error wrapping [ErrNotSupported] if BTF
+// is not enabled.
 //
 // Consider using [Cache] instead.
 func LoadKernelSpec() (*Spec, error) {
@@ -261,6 +262,8 @@ func NewCache() *Cache {
 
 // Kernel is equivalent to [LoadKernelSpec], except that repeated calls do
 // not copy the Spec.
+//
+// Returns an error wrapping [ErrNotSupported] if BTF is not enabled.
 func (c *Cache) Kernel() (*Spec, error) {
 	if c.kernelTypes != nil {
 		return c.kernelTypes, nil

--- a/linker.go
+++ b/linker.go
@@ -305,7 +305,8 @@ fixups:
 			return nil, fmt.Errorf("kfuncMetaKey doesn't contain kfuncMeta")
 		}
 
-		// findTargetInKernel returns btf.ErrNotFound if the input btf.Spec is nil.
+		// findTargetInKernel returns [btf.ErrNotFound] if the target can't be found
+		// or if BTF is not enabled.
 		target := btf.Type((*btf.Func)(nil))
 		spec, module, err := findTargetInKernel(kfm.Func.Name, &target, cache)
 		if errors.Is(err, btf.ErrNotFound) {

--- a/prog.go
+++ b/prog.go
@@ -1178,12 +1178,12 @@ func findProgramTargetInKernel(name string, progType ProgramType, attachType Att
 // target will point at the found type after a successful call. Searches both
 // vmlinux and any loaded modules.
 //
-// Returns a non-nil handle if the type was found in a module, or btf.ErrNotFound
-// if the type wasn't found at all.
+// Returns a non-nil handle if the type was found in a module, [btf.ErrNotFound]
+// if the type wasn't found or if BTF is not enabled.
 func findTargetInKernel(typeName string, target *btf.Type, cache *btf.Cache) (*btf.Spec, *btf.Handle, error) {
 	kernelSpec, err := cache.Kernel()
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("load kernel spec: %w (%w)", btf.ErrNotFound, err)
 	}
 
 	err = kernelSpec.TypeByName(typeName, target)


### PR DESCRIPTION
Commit 7c861fdc removed one of the `btf.ErrNotFound` return sites that downstream callers relied on. Restore the behaviour and document the fact that (*Cache).Kernel returns ErrNotSupported as well.