### PR TITLE
bpf2go: improve duplicate type name error message

### DIFF
--- a/cmd/bpf2go/gen/output.go
+++ b/cmd/bpf2go/gen/output.go
@@ -221,7 +221,7 @@ func sortTypes(typeNames map[btf.Type]string) ([]btf.Type, error) {
 		}
 
 		if names[i] == name {
-			return nil, fmt.Errorf("type name %q is used multiple times", name)
+			return nil, fmt.Errorf("type name %q is used multiple times (remove its --type flag?)", name)
 		}
 
 		types = append(types[:i], append([]btf.Type{typ}, types[i:]...)...)


### PR DESCRIPTION
When --type T is used for a type that is already exported via a
variable or map k/v, bpf2go reports a confusing error about the
type name being used multiple times.

Update the error message to guide users toward the fix:
remove the redundant --type flag.

Fixes #1638