### PR TITLE
asm: fix wrong bpf call offset display for jited programs

### DIFF
--- a/asm/instruction.go
+++ b/asm/instruction.go
@@ -401,8 +401,14 @@ func (ins Instruction) Format(f fmt.State, c rune) {
 			fmt.Fprintf(f, "%v ", op)
 			switch ins.Src {
 			case PseudoCall:
-				// bpf-to-bpf call
-				fmt.Fprint(f, ins.Constant)
+				// bpf-to-bpf call. For JIT-compiled programs, the kernel stores
+				// the PC offset in the 'off' field (ins.Offset) rather than 'imm'
+				// (ins.Constant). See kernel bpf_insn_prepare_dump in verifier.c.
+				if ins.Offset != 0 {
+					fmt.Fprint(f, ins.Offset)
+				} else {
+					fmt.Fprint(f, ins.Constant)
+				}
 			case PseudoKfuncCall:
 				// kfunc call
 				fmt.Fprintf(f, "Kfunc(%d)", ins.Constant)


### PR DESCRIPTION
Fixes #1695

## What type of PR is this?

- bug

## What this PR does / why it is needed:

When the kernel JIT compiles a BPF program, it stores the PC offset of
bpf pseudo calls in the `off` field instead of `imm` (see
`bpf_insn_prepare_dump` in the Linux kernel). The `Instruction.Format`
function was always reading from `ins.Constant` (mapped from `imm`),
producing incorrect offsets for jited instruction dumps.

For example, `bpftool` shows `pc+2` for the same jited instruction,
but ebpf-go showed `pc+1` because it read the wrong field.

## Changes:

- In `asm/instruction.go`, check `ins.Offset` (mapped from `off`) first
  for `PseudoCall` instructions before falling back to `ins.Constant`
  (mapped from `imm`).
- This ensures correct PC offset display for both xlated and jited
  instruction streams returned by `ProgramInfo.Instructions()`.
