### PR TITLE
internal/kconfig: reject bool arrays for string values

### DIFF
--- a/internal/kconfig/kconfig.go
+++ b/internal/kconfig/kconfig.go
@@ -183,8 +183,8 @@ func putValueString(data []byte, typ btf.Type, value string) error {
 
 	// Any Int, which is not bool, of one byte could be used to store char:
 	// https://github.com/torvalds/linux/blob/1a5304fecee5/tools/lib/bpf/libbpf.c#L3637-L3638
-	if contentType.Size != 1 && contentType.Encoding != btf.Bool {
-		return fmt.Errorf("cannot add string value, expected array of btf.Int of size 1, got array of btf.Int of size: %v", contentType.Size)
+	if contentType.Size != 1 || contentType.Encoding == btf.Bool {
+		return fmt.Errorf("cannot add string value, expected array of non-bool btf.Int of size 1, got array of btf.Int with encoding %v and size %v", contentType.Encoding, contentType.Size)
 	}
 
 	if !strings.HasPrefix(value, `"`) || !strings.HasSuffix(value, `"`) {

--- a/internal/kconfig/kconfig_test.go
+++ b/internal/kconfig/kconfig_test.go
@@ -365,6 +365,7 @@ func TestPutValue(t *testing.T) {
 					Encoding: btf.Bool,
 				},
 			},
+			value:   `"foo"`,
 			comment: "Type is not btf.Array of btf.Int of size 1 which is not btf.Bool",
 		},
 		{


### PR DESCRIPTION
Fixes a tiny `.kconfig` type check footgun.

`putValueString` said string configs need a one-byte non-bool int array, but the check used `&&`. So `_Bool CONFIG_DEFAULT_HOSTNAME[1] __kconfig` could accept a string value and copy bytes into a bool array. Thats not a valid target type.

Repro:
1. Add a quoted value to the existing bool-array case in `TestPutValue`.
2. Run `go test ./internal/kconfig -run TestPutValue -count=1`.
3. Before this patch it fails because `PutValue` returns nil. After this patch it rejects it.

Checked:
- `go test ./internal/kconfig -count=1`
- `go test ./internal ./internal/linux ./internal/sysenc ./internal/platform ./internal/unix -count=1`