### PR TITLE
doc: clarify Address vs Offset on Uprobe/Uretprobe

### DIFF
--- a/link/uprobe.go
+++ b/link/uprobe.go
@@ -256,12 +256,15 @@ func (ex *Executable) Symbol(address uint64) (SymbolOffset, error) {
 //	ex, _ = OpenExecutable("/bin/bash")
 //	ex.Uprobe("main", prog, nil)
 //
-// When using symbols which belongs to shared libraries,
-// an offset must be provided via options:
+// When tracing a location for which no ELF symbol is available, or a shared
+// library symbol whose static address is zero, set UprobeOptions.Address to
+// the absolute file offset and pass an empty symbol:
 //
-//	up, err := ex.Uprobe("main", prog, &UprobeOptions{Offset: 0x123})
+//	up, err := ex.Uprobe("", prog, &UprobeOptions{Address: 0x123})
 //
-// Note: Setting the Offset field in the options supersedes the symbol's offset.
+// Address bypasses symbol lookup. Offset, if set, is added to the resolved
+// address (whether from symbol resolution or from Address); on its own it
+// does not replace symbol resolution.
 //
 // Losing the reference to the resulting Link (up) will close the Uprobe
 // and prevent further execution of prog. The Link must be Closed during
@@ -292,12 +295,15 @@ func (ex *Executable) Uprobe(symbol string, prog *ebpf.Program, opts *UprobeOpti
 //	ex, _ = OpenExecutable("/bin/bash")
 //	ex.Uretprobe("main", prog, nil)
 //
-// When using symbols which belongs to shared libraries,
-// an offset must be provided via options:
+// When tracing a location for which no ELF symbol is available, or a shared
+// library symbol whose static address is zero, set UprobeOptions.Address to
+// the absolute file offset and pass an empty symbol:
 //
-//	up, err := ex.Uretprobe("main", prog, &UprobeOptions{Offset: 0x123})
+//	up, err := ex.Uretprobe("", prog, &UprobeOptions{Address: 0x123})
 //
-// Note: Setting the Offset field in the options supersedes the symbol's offset.
+// Address bypasses symbol lookup. Offset, if set, is added to the resolved
+// address (whether from symbol resolution or from Address); on its own it
+// does not replace symbol resolution.
 //
 // Losing the reference to the resulting Link (up) will close the Uprobe
 // and prevent further execution of prog. The Link must be Closed during


### PR DESCRIPTION
The docstrings on `Executable.Uprobe` and `Executable.Uretprobe` carry a
note that doesn't match the code:

> Note: Setting the Offset field in the options supersedes the symbol's offset.

`(*Executable).address()` shows `Offset` is purely additive: it gets
added to either the resolved symbol address or to `Address`, and on its
own does not bypass symbol resolution.

```go
func (ex *Executable) address(symbol string, address, offset uint64) (uint64, error) {
    if address > 0 {
        return address + offset, nil
    }
    err := ex.lazyLoadSymbols()
    ...
    sym, ok := ex.cachedSymbols[symbol]
    if !ok {
        return 0, fmt.Errorf("symbol %s: %w", symbol, ErrNoSymbol)
    }
    ...
    return sym.addr + offset, nil
}
```

So `Uprobe("", prog, &UprobeOptions{Offset: X})` fails immediately with
`symbol : not found`. To attach at an absolute file offset without a
symbol you set `Address`, which short-circuits the symbol lookup.

The same blocks also tell users to pass `Offset` for shared-library
symbols. But for shared-lib symbols the code returns `ErrNotSupported`
and its own hint already says "consider providing UprobeOptions.Address"
(see `address()`, the `sym.addr == 0` branch). So the example is
inconsistent with the code path it claims to document.

This PR rewrites both docstring blocks to use `Address` with an empty
symbol, which is the supported path, and describes `Offset`'s
relationship to `Address` accurately.

No behaviour change; comments only.

Refs [discussion #1985](https://github.com/cilium/ebpf/discussions/1985)
where this misled a user.