### PR TITLE
ci: split workflows into build+lint and generate+fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -345,53 +345,48 @@ jobs:
               return
             }
 
-            // Get the latest successful scheduled run
-            const workflow_runs = await github.rest.actions.listWorkflowRuns({
-              owner: 'microsoft',
-              repo: 'ebpf-for-windows',
-              workflow_id: 'cicd.yml',
-              event: 'schedule',
-              branch: 'main',
-              status: 'completed',
-              conclusion: 'success',
-              per_page: 1
-            });
-
-            if (workflow_runs.data.workflow_runs.length === 0) {
-              core.setFailed('No successful scheduled workflow runs found');
-              return;
-            }
-
-            // Get artifacts from this run
-            const run_id = workflow_runs.data.workflow_runs[0].id;
-            const run_url = workflow_runs.data.workflow_runs[0].html_url;
-            console.log(`Using workflow run: ${run_url}`);
-
-            // Paginate through all artifacts
-            let allArtifacts = [];
-            let page = 1;
+            // Iterate through scheduled workflow runs (regardless of status) to find
+            // one that contains the Build-x64-Debug artifact.
+            let artifact = null;
+            let runs_page = 1;
+            outer:
             while (true) {
-              const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+              const workflow_runs = await github.rest.actions.listWorkflowRuns({
                 owner: 'microsoft',
                 repo: 'ebpf-for-windows',
-                run_id: run_id,
-                per_page: 100,
-                page: page
+                workflow_id: 'cicd.yml',
+                event: 'schedule',
+                branch: 'main',
+                per_page: 10,
+                page: runs_page
               });
 
-              allArtifacts = allArtifacts.concat(artifacts.data.artifacts);
+              if (workflow_runs.data.workflow_runs.length === 0) {
+                core.setFailed('No scheduled workflow runs found');
+                return;
+              }
 
-              // If we got fewer than 100, we've reached the last page
-              if (artifacts.data.artifacts.length < 100) break;
-              page++;
+              for (const run of workflow_runs.data.workflow_runs) {
+                console.log(`Attempting workflow run: ${run.html_url}`);
+
+                const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+                  owner: 'microsoft',
+                  repo: 'ebpf-for-windows',
+                  run_id: run.id,
+                  per_page: 100,
+                });
+
+                artifact = artifacts.data.artifacts.find(a => a.name === 'Build-x64-Debug');
+                if (artifact) {
+                  break outer;
+                }
+              }
+
+              runs_page++;
             }
 
-            // Find the specific artifact
-            const artifact = allArtifacts.find(a => a.name === 'Build-x64-Debug');
-
             if (!artifact) {
-              console.log('Available artifacts:', allArtifacts.map(a => a.name));
-              core.setFailed('Build-x64-Debug artifact not found in the workflow run');
+              core.setFailed('No scheduled workflow runs with Build-x64-Debug artifact found');
               return;
             }
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,20 +33,27 @@ jobs:
         with:
           go-version: '${{ env.go_version }}'
 
-      - name: Run go fix
-        run: |
-          ./scripts/go-fix.sh
-          if ! git diff --exit-code; then
-            echo "Found Go files that need fixing, run './scripts/go-fix.sh'" >&2
-            exit 1
-          fi
-
       - name: Run staticcheck
         run: |
           go tool staticcheck  ./...
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v9.2.0
+
+      - name: Build
+        run: go build -v ./...
+
+  generate-and-fix:
+    name: Generate and Fix
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '${{ env.go_version }}'
 
       - name: Generate and format code
         run: |
@@ -56,8 +63,13 @@ jobs:
             exit 1
           fi
 
-      - name: Build
-        run: go build -v ./...
+      - name: Run go fix
+        run: |
+          ./scripts/go-fix.sh
+          if ! git diff --exit-code; then
+            echo "Found Go files that need fixing, run './scripts/go-fix.sh'" >&2
+            exit 1
+          fi
 
   cross-build:
     name: Cross build
@@ -458,6 +470,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build-and-lint
+      - generate-and-fix
       - cross-build
       - build-docs
       - test-on-prev-go


### PR DESCRIPTION
Startup times have increased, so let's take generate and fix out of the critical path since those typically take the longest.