### PR TITLE
prog.go: cache BTF for CAP_SYS_ADMIN-less freplace

### DIFF
--- a/btf/handle.go
+++ b/btf/handle.go
@@ -175,6 +175,24 @@ func (h *Handle) FD() int {
 	return h.fd.Int()
 }
 
+// Clone creates a duplicate of the handle.
+//
+// Closing the duplicate does not affect the original, and vice versa.
+//
+// Cloning a nil Handle returns nil.
+func (h *Handle) Clone() (*Handle, error) {
+	if h == nil {
+		return nil, nil
+	}
+
+	dup, err := h.fd.Dup()
+	if err != nil {
+		return nil, fmt.Errorf("can't clone handle: %w", err)
+	}
+
+	return &Handle{dup, h.size, h.needsKernelBase}, nil
+}
+
 // Info returns metadata about the handle.
 func (h *Handle) Info() (*HandleInfo, error) {
 	return newHandleInfoFromFD(h.fd)

--- a/link/tracing_test.go
+++ b/link/tracing_test.go
@@ -12,6 +12,16 @@ import (
 func TestFreplace(t *testing.T) {
 	testutils.SkipOnOldKernel(t, "5.10", "freplace")
 
+	caps := []testutils.Capability{testutils.CAP_NET_ADMIN, testutils.CAP_BPF, testutils.CAP_PERFMON}
+
+	// Must succeed w/o CAP_SYS_ADMIN. Older kernels pre-CAP_BPF
+	// introduction lack freplace anyway.
+	testutils.WithCapabilities(t, caps, func() {
+		testFreplace(t)
+	})
+}
+
+func testFreplace(t *testing.T) {
 	file := testutils.NativeFile(t, "../testdata/freplace-%s.elf")
 	spec, err := ebpf.LoadCollectionSpec(file)
 	if err != nil {

--- a/prog.go
+++ b/prog.go
@@ -242,6 +242,8 @@ type Program struct {
 	name       string
 	pinnedPath string
 	typ        ProgramType
+
+	btf *btf.Handle
 }
 
 // NewProgram creates a new Program.
@@ -282,7 +284,7 @@ var (
 	kfuncBadCall = fmt.Appendf(nil, "invalid func unknown#%d\n", kfuncCallPoisonBase)
 )
 
-func newProgramWithOptions(spec *ProgramSpec, opts ProgramOptions, c *btf.Cache) (*Program, error) {
+func newProgramWithOptions(spec *ProgramSpec, opts ProgramOptions, c *btf.Cache) (result *Program, _ error) {
 	if len(spec.Instructions) == 0 {
 		return nil, errors.New("instructions cannot be empty")
 	}
@@ -356,12 +358,18 @@ func newProgramWithOptions(spec *ProgramSpec, opts ProgramOptions, c *btf.Cache)
 		attr.LineInfo = sys.SlicePointer(lib)
 	}
 
+	var handle *btf.Handle
 	if !b.Empty() {
-		handle, err := btf.NewHandle(&b)
+		var err error
+		handle, err = btf.NewHandle(&b)
 		if err != nil {
 			return nil, fmt.Errorf("load BTF: %w", err)
 		}
-		defer handle.Close()
+		defer func() {
+			if result == nil || result.btf != handle {
+				handle.Close()
+			}
+		}()
 
 		attr.ProgBtfFd = uint32(handle.FD())
 	}
@@ -471,7 +479,7 @@ func newProgramWithOptions(spec *ProgramSpec, opts ProgramOptions, c *btf.Cache)
 		// Loading with logging disabled should never retry.
 		fd, err = sys.ProgLoad(attr)
 		if err == nil {
-			return &Program{"", fd, spec.Name, "", spec.Type}, nil
+			return &Program{"", fd, spec.Name, "", spec.Type, handle}, nil
 		}
 	} else {
 		// Only specify log size if log level is also specified. Setting size
@@ -491,7 +499,7 @@ func newProgramWithOptions(spec *ProgramSpec, opts ProgramOptions, c *btf.Cache)
 
 			fd, err = sys.ProgLoad(attr)
 			if err == nil {
-				return &Program{unix.ByteSliceToString(logBuf), fd, spec.Name, "", spec.Type}, nil
+				return &Program{unix.ByteSliceToString(logBuf), fd, spec.Name, "", spec.Type, handle}, nil
 			}
 
 			if !retryLogAttrs(attr, opts.LogSizeStart, err) {
@@ -636,7 +644,7 @@ func newProgramFromFD(fd *sys.FD) (*Program, error) {
 		return nil, fmt.Errorf("discover program type: %w", err)
 	}
 
-	return &Program{"", fd, info.Name, "", info.Type}, nil
+	return &Program{"", fd, info.Name, "", info.Type, nil}, nil
 }
 
 func (p *Program) String() string {
@@ -671,6 +679,10 @@ func (p *Program) Stats() (*ProgramStats, error) {
 // Returns ErrNotSupported if the kernel has no BTF support, or if there is no
 // BTF associated with the program.
 func (p *Program) Handle() (*btf.Handle, error) {
+	if p.btf != nil {
+		return p.btf.Clone()
+	}
+
 	info, err := p.Info()
 	if err != nil {
 		return nil, err
@@ -682,6 +694,48 @@ func (p *Program) Handle() (*btf.Handle, error) {
 	}
 
 	return btf.NewHandleFromID(id)
+}
+
+// SetHandle caches program's type information so that subsequent
+// Handle() call doesn't need to query it from the kernel (requires
+// CAP_SYS_ADMIN).
+//
+// The caller remains responsible for closing the btf.Handle; SetHandle
+// makes a private copy.
+//
+// Type info is auto-cached for Programs loaded by the library itself.
+// Use SetHandle() with program references obtained via NewProgramFromFD
+// and LoadPinnedProgram.
+func (p *Program) SetHandle(h *btf.Handle) error {
+	if h == nil {
+		return fmt.Errorf("nil BTF handle")
+	}
+
+	info, err := p.Info()
+	if err != nil {
+		return err
+	}
+
+	handleInfo, err := h.Info()
+	if err != nil {
+		return err
+	}
+
+	if id, ok := info.BTFID(); !ok || id != handleInfo.ID {
+		return fmt.Errorf("program/BTF mismatch")
+	}
+
+	if p.btf != nil {
+		return nil
+	}
+
+	dup, err := h.Clone()
+	if err != nil {
+		return err
+	}
+
+	p.btf = dup
+	return nil
 }
 
 // FD gets the file descriptor of the Program.
@@ -701,12 +755,18 @@ func (p *Program) Clone() (*Program, error) {
 		return nil, nil
 	}
 
-	dup, err := p.fd.Dup()
+	btfClone, err := p.btf.Clone()
 	if err != nil {
 		return nil, fmt.Errorf("can't clone program: %w", err)
 	}
 
-	return &Program{p.VerifierLog, dup, p.name, "", p.typ}, nil
+	dup, err := p.fd.Dup()
+	if err != nil {
+		btfClone.Close()
+		return nil, fmt.Errorf("can't clone program: %w", err)
+	}
+
+	return &Program{p.VerifierLog, dup, p.name, "", p.typ, btfClone}, nil
 }
 
 // Pin persists the Program on the BPF virtual file system past the lifetime of
@@ -749,6 +809,10 @@ func (p *Program) IsPinned() bool {
 func (p *Program) Close() error {
 	if p == nil {
 		return nil
+	}
+
+	if err := p.btf.Close(); err != nil {
+		return err
 	}
 
 	return p.fd.Close()


### PR DESCRIPTION
Before the change, performing freplace with `cilium/ebpf` required `CAP_SYS_ADMIN`.

The subprogram to replace is specified via `AttachTarget` (`*Program`) and `AttachTo` (`string`) in the replacement `ProgramSpec`. Since the kernel expects a BTF type ID of the subprogram to replace, the library has to resolve the `AttachTo` string. It needs BTF of the `AttachTarget`. To obtain BTF from the kernel `CAP_SYS_ADMIN` is needed.

Extend Program with `btf` (`*btf.Handle`). It is populated for `Program`-s loaded by the library. Program's `.Handle()` leverages the cached BTF transparaently, enabling `CAP_SYS_ADMIN`-less freplace.

Add `SetHandle` method to `Program` to cover program references obtained via `NewProgramFromFD()`, and `LoadPinnedProgram()`. The intended usage is as follows:

 * a `CAP_SYS_ADMIN`-less user obtains a program reference and the corresponding BTF (e.g. both from a pin);

 * calls `.SetHandle()` on the `Program`;

 * freplace succeeds with the `Program` as `AttachTarget`.