### PR TITLE
fix: avoid rlimit side effect in docs example

### DIFF
--- a/docs/examples/rlimit_test.go
+++ b/docs/examples/rlimit_test.go
@@ -2,13 +2,10 @@
 
 package examples
 
-// DocRlimit {
 import "github.com/cilium/ebpf/rlimit"
 
-func init() {
+func DocRlimit() {
 	if err := rlimit.RemoveMemlock(); err != nil {
 		panic(err)
 	}
 }
-
-// }


### PR DESCRIPTION
## What
Move the rlimit docs snippet out of package init. Importing docs/examples should not try to raise RLIMIT_MEMLOCK.

## Repro
On an unprivileged shell:

```sh
go test ./... -run TestDoesNotExist
```

Before: docs/examples panics in init with `failed to set memlock rlimit: operation not permitted`.

After: passes, no test is selected. Small papercut

## Checks
```sh
go test ./docs/examples -run TestDoesNotExist
go test ./... -run TestDoesNotExist
go build ./...
go test -c -o /dev/null ./...
```