### PR TITLE
fix(map): defer haveBatchAPI check in BatchLookupCmd until syscall fails

### DIFF
--- a/map.go
+++ b/map.go
@@ -1355,10 +1355,6 @@ func (m *Map) batchLookupCmd(cmd sys.Cmd, cursor *MapBatchCursor, count int, key
 		return 0, errors.New("a cursor may not be reused across maps")
 	}
 
-	if err := haveBatchAPI(); err != nil {
-		return 0, err
-	}
-
 	keyBuf := sysenc.SyscallOutput(keysOut, count*int(m.keySize))
 
 	attr := sys.MapLookupBatchAttr{
@@ -1378,6 +1374,9 @@ func (m *Map) batchLookupCmd(cmd sys.Cmd, cursor *MapBatchCursor, count int, key
 	_, sysErr := sys.BPF(cmd, unsafe.Pointer(&attr), unsafe.Sizeof(attr))
 	sysErr = wrapMapError(sysErr)
 	if sysErr != nil && !errors.Is(sysErr, unix.ENOENT) {
+		if err := haveBatchAPI(); err != nil {
+			return 0, err
+		}
 		return 0, sysErr
 	}
 

--- a/map.go
+++ b/map.go
@@ -1374,8 +1374,8 @@ func (m *Map) batchLookupCmd(cmd sys.Cmd, cursor *MapBatchCursor, count int, key
 	_, sysErr := sys.BPF(cmd, unsafe.Pointer(&attr), unsafe.Sizeof(attr))
 	sysErr = wrapMapError(sysErr)
 	if sysErr != nil && !errors.Is(sysErr, unix.ENOENT) {
-		if err := haveBatchAPI(); err != nil {
-			return 0, err
+		if haveFeatErr := haveBatchAPI(); haveFeatErr != nil {
+			return 0, haveFeatErr
 		}
 		return 0, sysErr
 	}


### PR DESCRIPTION
fix(map): defer `haveBatchAPI()` check in `BatchLookupCmd()` until syscall fails

`BatchLookup()` called `haveBatchAPI()` indiscriminately, which creates a temporary BPF map implying support for CAP_BPF. `BatchDelete()` and `BatchUpdate()` were fixed in #1071 to only check for the batch API after a syscall failure, same pattern applied here.

Fixes #2013