### PR TITLE
ebpf: defer batch API probe for batch lookup

### DIFF
--- a/map.go
+++ b/map.go
@@ -1355,10 +1355,6 @@ func (m *Map) batchLookupCmd(cmd sys.Cmd, cursor *MapBatchCursor, count int, key
 		return 0, errors.New("a cursor may not be reused across maps")
 	}
 
-	if err := haveBatchAPI(); err != nil {
-		return 0, err
-	}
-
 	keyBuf := sysenc.SyscallOutput(keysOut, count*int(m.keySize))
 
 	attr := sys.MapLookupBatchAttr{
@@ -1378,6 +1374,9 @@ func (m *Map) batchLookupCmd(cmd sys.Cmd, cursor *MapBatchCursor, count int, key
 	_, sysErr := sys.BPF(cmd, unsafe.Pointer(&attr), unsafe.Sizeof(attr))
 	sysErr = wrapMapError(sysErr)
 	if sysErr != nil && !errors.Is(sysErr, unix.ENOENT) {
+		if haveFeatErr := haveBatchAPI(); haveFeatErr != nil {
+			return 0, haveFeatErr
+		}
 		return 0, sysErr
 	}
 

--- a/map_test.go
+++ b/map_test.go
@@ -202,6 +202,35 @@ func TestMapBatch(t *testing.T) {
 	}
 }
 
+func TestMapBatchUnprivileged(t *testing.T) {
+	arr := createMap(t, Array, 4)
+	hash := createMap(t, Hash, 4)
+
+	keys := []uint32{0, 1}
+	values := []uint32{42, 4242}
+	qt.Assert(t, qt.IsNil(hash.Update(keys[0], values[0], UpdateAny)))
+	qt.Assert(t, qt.IsNil(hash.Update(keys[1], values[1], UpdateAny)))
+
+	testutils.WithCapabilities(t, nil, func() {
+		tmp := make([]uint32, 2)
+
+		var cursor MapBatchCursor
+		_, err := arr.BatchLookup(&cursor, tmp, tmp, nil)
+		testutils.SkipIfNotSupported(t, err)
+		qt.Assert(t, qt.IsNil(err))
+
+		count, err := arr.BatchUpdate(keys, values, nil)
+		testutils.SkipIfNotSupported(t, err)
+		qt.Assert(t, qt.IsNil(err))
+		qt.Assert(t, qt.Equals(count, len(keys)))
+
+		count, err = hash.BatchDelete(keys, nil)
+		testutils.SkipIfNotSupported(t, err)
+		qt.Assert(t, qt.IsNil(err))
+		qt.Assert(t, qt.Equals(count, len(keys)))
+	})
+}
+
 func TestMapBatchCursorReuse(t *testing.T) {
 	arr1 := createMap(t, Array, 4)
 	arr2 := createMap(t, Array, 4)


### PR DESCRIPTION
Fixes #2013.

`BatchLookup()` and `BatchLookupAndDelete()` previously called `haveBatchAPI()` before attempting the actual batch lookup syscall. The feature probe creates a temporary map, which can require `CAP_BPF`, so a process that only needs to read from an already-open map could fail before trying the operation that would otherwise succeed.

This defers the batch API feature probe until after a non-`ENOENT` lookup syscall failure, matching the existing `BatchUpdate()` and `BatchDelete()` behavior. The normal end-of-iteration `ENOENT` path remains unchanged.

The regression test creates maps while privileged, drops all effective capabilities, then verifies batch lookup, update, and delete through the existing map FDs.

Tested:

- `go test -exec sudo -run '^(TestHaveBatchAPI|TestMapBatch|TestMapBatchUnprivileged|TestMapBatchCursorReuse)$' .`
- `git diff --check -- map.go map_test.go`