### PR TITLE
BTF: fixed panics during parsing of malformed input

### DIFF
--- a/btf/btf.go
+++ b/btf/btf.go
@@ -214,7 +214,7 @@ func loadRawSpec(btf []byte, base *Spec) (*Spec, error) {
 	}
 	btf = btf[header.HdrLen:]
 
-	if int(header.StringOff+header.StringLen) > len(btf) {
+	if uint64(header.StringOff)+uint64(header.StringLen) > uint64(len(btf)) {
 		return nil, fmt.Errorf("string table is out of bounds")
 	}
 	stringsSection := btf[header.StringOff : header.StringOff+header.StringLen]
@@ -224,7 +224,7 @@ func loadRawSpec(btf []byte, base *Spec) (*Spec, error) {
 		return nil, fmt.Errorf("read string section: %w", err)
 	}
 
-	if int(header.TypeOff+header.TypeLen) > len(btf) {
+	if uint64(header.TypeOff)+uint64(header.TypeLen) > uint64(len(btf)) {
 		return nil, fmt.Errorf("types section is out of bounds")
 	}
 	typesSection := btf[header.TypeOff : header.TypeOff+header.TypeLen]

--- a/btf/btf_types.go
+++ b/btf/btf_types.go
@@ -120,6 +120,10 @@ func parseBTFHeader(buf []byte) (*btfHeader, binary.ByteOrder, error) {
 		return nil, nil, errors.New("header length shorter than btfHeader size")
 	}
 
+	if len(buf) < int(remainder) {
+		return nil, nil, errors.New("header length exceeds available data")
+	}
+
 	for _, b := range buf[:remainder] {
 		if b != 0 {
 			return nil, nil, errors.New("header contains non-zero trailer")

--- a/btf/strings.go
+++ b/btf/strings.go
@@ -94,6 +94,9 @@ func (st *stringTable) lookupSlow(offset uint32) ([]byte, error) {
 	}
 
 	i := bytes.IndexByte(st.bytes[offset:], 0)
+	if i == -1 {
+		return nil, fmt.Errorf("string at offset %d is not null terminated", offset)
+	}
 	return st.bytes[offset : offset+uint32(i)], nil
 }
 


### PR DESCRIPTION
Bug reports and fuzzing found a few cases where our BTF parsing logic would panic instead of returning errors when presented with malformed input. This PR fixes the reported issue as well as the two, after these fixes no further issue were found with an hour of fuzzing.

Fixes: #2019