### PR TITLE
internal/testutils: Fix capability restoration in WithCapabilities

### DIFF
--- a/internal/testutils/cap.go
+++ b/internal/testutils/cap.go
@@ -59,11 +59,14 @@ func WithCapabilities(tb testing.TB, caps []Capability, f func()) {
 		tb.Fatal("Can't set capabilities:", err)
 	}
 
-	f()
+	// Defer here so that we restore the original capabilities even if `f` panics or calls `tb.Fatal`/`tb.Skip`.
+	defer func() {
+		if err := capset(orig); err != nil {
+			tb.Fatal("Can't restore capabilities:", err)
+		}
+	}()
 
-	if err := capset(orig); err != nil {
-		tb.Fatal("Can't restore capabilities:", err)
-	}
+	f()
 }
 
 type capUserData struct {


### PR DESCRIPTION
The `WithCapabilities` function has a flaw where it would not restore the original capabilities when `tb.Skip` was called inside of its callback.

This happens because `tb.Skip` calls `runtime.Goexit`, which terminates the current goroutine before the restoration logic can run. Because capabilities are per-thread, this means that the capabilities of other tests that run in the same thread after the skipped test will be affected, causing them to fail.

The same would also happen for panics and calls to `tb.Fatal`, which also call `runtime.Goexit`.

Fixed by moving the restoration logic into a `defer` statement, which ensures that it will run even if the callback panics or calls `tb.Fatal`/`tb.Skip`.