### PR TITLE
fix: reject variable offsets that overflow uint32 bounds

### DIFF
--- a/memory_unsafe.go
+++ b/memory_unsafe.go
@@ -243,7 +243,7 @@ func checkUnsafeMemory[T comparable](mm *Memory, off uint32) error {
 	}
 
 	vs, bs := uint32(size), uint32(len(mm.b))
-	if off+vs > bs {
+	if !mm.bounds(off, vs) {
 		return fmt.Errorf("%d-byte value at offset %d exceeds mmap size of %d bytes", vs, off, bs)
 	}
 

--- a/variable.go
+++ b/variable.go
@@ -125,7 +125,7 @@ type Variable struct {
 
 func newVariable(name string, offset, size uint32, t *btf.Var, mm *Memory) (*Variable, error) {
 	if mm != nil {
-		if offset+size > mm.Size() {
+		if !mm.bounds(offset, size) {
 			return nil, fmt.Errorf("offset %d(+%d) is out of bounds", offset, size)
 		}
 	}

--- a/variable_test.go
+++ b/variable_test.go
@@ -2,6 +2,7 @@ package ebpf
 
 import (
 	"encoding/binary"
+	"math"
 	"runtime"
 	"structs"
 	"sync/atomic"
@@ -295,6 +296,21 @@ func TestVariablePointerError(t *testing.T) {
 
 	_, err = VariablePointer[atomic.Uint32](obj.Atomic)
 	qt.Assert(t, qt.ErrorIs(err, ErrNotSupported))
+}
+
+func TestVariablePointerOffsetOverflow(t *testing.T) {
+	mm := &Memory{b: make([]byte, 8)}
+
+	// An offset whose end wraps around uint32 must be rejected rather than
+	// accepted and later used to index into the backing slice.
+	_, err := newVariable("overflow", math.MaxUint32-3, 4, nil, mm)
+	qt.Assert(t, qt.IsNotNil(err))
+
+	// Even if a Variable carries such an offset, taking a pointer to it returns
+	// an error instead of panicking with an out-of-range index.
+	v := &Variable{name: "overflow", offset: math.MaxUint32 - 3, size: 4, mm: mm}
+	_, err = VariablePointer[uint32](v)
+	qt.Assert(t, qt.IsNotNil(err))
 }
 
 func TestVariablePointerGC(t *testing.T) {


### PR DESCRIPTION
A variable offset whose `offset+size` wraps around uint32 slips past the bounds checks in `newVariable` and `checkUnsafeMemory`, so `VariablePointer` indexes the backing slice out of range and panics. Both checks now use the existing overflow-safe `Memory.bounds` helper and return an error instead. Fixes #2028.