### PR TITLE
rlimit: avoid performing the test and setting limit if its infinite

### DIFF
--- a/rlimit/rlimit_linux.go
+++ b/rlimit/rlimit_linux.go
@@ -43,6 +43,12 @@ func detectMemcgAccounting() error {
 		return fmt.Errorf("getting original memlock rlimit: %s", err)
 	}
 
+	// If the soft limit is already infinite there is nothing for RemoveMemlock
+	// to do.
+	if oldLimit.Cur == unix.RLIM_INFINITY {
+		return nil
+	}
+
 	// Drop the current limit to zero, maintaining the old Max value.
 	// This is always permitted by the kernel for unprivileged users.
 	// Retrieve a new copy of the old limit tuple to minimize the chances


### PR DESCRIPTION
If the current `rlimit` is infinity, raising it will be a no-op, so we can skip the init test and the later potential `rlimit` syscall to raise it to infinity.