### PR TITLE
link: expose syscall wrapper symbol helper

### DIFF
--- a/link/kprobe.go
+++ b/link/kprobe.go
@@ -50,6 +50,20 @@ func (ko *KprobeOptions) cookie() uint64 {
 	return ko.Cookie
 }
 
+// SyscallWrapper returns the platform-specific kernel wrapper symbol for
+// syscall. If syscall already has the current platform's prefix, it's returned
+// unchanged.
+//
+// For example, on amd64, an input of "sys_open" will return "__x64_sys_open".
+func SyscallWrapper(syscall string) string {
+	prefix := linux.PlatformPrefix()
+	if prefix == "" || strings.HasPrefix(syscall, prefix) {
+		return syscall
+	}
+
+	return prefix + syscall
+}
+
 // Kprobe attaches the given eBPF program to a perf event that fires when the
 // given kernel symbol starts executing. See /proc/kallsyms for available
 // symbols. For example, printk():

--- a/link/kprobe_multi_test.go
+++ b/link/kprobe_multi_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/features"
-	"github.com/cilium/ebpf/internal/linux"
 	"github.com/cilium/ebpf/internal/testutils"
 	"github.com/cilium/ebpf/internal/unix"
 )
@@ -127,9 +126,8 @@ func TestKprobeMultiProgramCall(t *testing.T) {
 
 	// Use actual syscall names with platform prefix.
 	// For simplicity, just assert the increment happens with any symbol in the array.
-	prefix := linux.PlatformPrefix()
 	opts := KprobeMultiOptions{
-		Symbols: []string{prefix + "sys_getpid", prefix + "sys_gettid"},
+		Symbols: []string{SyscallWrapper("sys_getpid"), SyscallWrapper("sys_gettid")},
 	}
 	km, err := KprobeMulti(p, opts)
 	if err != nil {

--- a/link/kprobe_test.go
+++ b/link/kprobe_test.go
@@ -27,6 +27,10 @@ var symTests = []string{
 	"unregister_kprobes.part.0", // function body that was split and partially inlined
 }
 
+func TestSyscallWrapper(t *testing.T) {
+	qt.Assert(t, qt.Not(qt.Equals(SyscallWrapper("sys_open"), "sys_open")))
+}
+
 func TestKprobe(t *testing.T) {
 	prog := mustLoadProgram(t, ebpf.Kprobe, 0, "")
 


### PR DESCRIPTION
Fixes #1891

I have exposed a small helper for deriving platform-specific syscall wrapper symbols, then use it from the kprobe_multi syscall attach test.

Kprobe/Kretprobe can retry syscall symbols with the platform prefix, but doing the same automatically for kprobe_multi is ambiguous because a multi-attach list can contain both syscall entrypoints and ordinary kernel functions. The helper lets callers opt in per symbol without changing KprobeMulti attach semantics.

Tests:

- [x] go test ./link -run '^TestSyscallWrapper$' -count=1
- [x] go test -exec sudo ./link -run '^TestKprobeMultiInput$' -count=1
- [x] go test -exec sudo ./link -run '^(TestKprobeMultiProgramCall|TestKprobeMulti|TestKprobeMultiErrors|TestKprobeMultiCookie)$' -count=1 -v
- [x] git diff --check -- link/kprobe.go link/kprobe_test.go link/kprobe_multi_test.go

Also attempted `go test -exec sudo ./...` in the Ubuntu VM. The focused link tests passed; the broad run hit unrelated `cmd/bpf2go` module-cache setup with `GOPROXY=off` and an unrelated `features/LircMode2` kernel capability failure.
