### PR TITLE
memory: use unsafe.Add to align unsafe memory instead of uintptr conversion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,19 +78,24 @@ TARGETS := \
 
 HEADERS := $(wildcard testdata/*.h)
 
-.PHONY: all clean container-all container-shell generate format
+.PHONY: all clean godirs container-all container-shell generate format
 
-.DEFAULT_TARGET = container-all
+.DEFAULT_GOAL = container-all
+
+# Make sure Go-related dirs exist before starting containerized builds,
+# otherwise podman will fail to start.
+godirs:
+	mkdir -p $(shell go env GOCACHE) $(shell go env GOPATH) $(shell go env GOMODCACHE)
 
 # Build all ELF binaries using a containerized LLVM toolchain.
-container-all:
+container-all: godirs
 	+${CONTAINER_ENGINE} run --rm -ti ${CONTAINER_RUN_ARGS} \
 		"${IMAGE}:${VERSION}" \
 		$(MAKE) all
 
 # (debug) Drop the user into a shell inside the container as root.
 # Set BPF2GO_ envs to make 'make generate' just work.
-container-shell:
+container-shell: godirs
 	${CONTAINER_ENGINE} run --rm -ti ${CONTAINER_RUN_ARGS} \
 		"${IMAGE}:${VERSION}"
 

--- a/memory_unsafe.go
+++ b/memory_unsafe.go
@@ -118,13 +118,10 @@ func allocate(size int) (unsafe.Pointer, error) {
 	// Allocate a new slice and store a pointer to its backing array.
 	alloc := unsafe.Pointer(unsafe.SliceData(make([]byte, size)))
 
-	// nolint:govet
-	//
 	// Align the pointer to a page boundary within the allocation. This may alias
-	// the initial pointer if it was already page-aligned. Ignore govet warnings
-	// since we're calling [runtime.KeepAlive] on the original Go memory.
-	aligned := unsafe.Pointer(internal.Align(uintptr(alloc), uintptr(os.Getpagesize())))
-	runtime.KeepAlive(alloc)
+	// the initial pointer if it was already page-aligned.
+	aligned := internal.Align(uintptr(alloc), uintptr(os.Getpagesize()))
+	alloc = unsafe.Add(alloc, aligned-uintptr(alloc))
 
 	// Return an aligned pointer into the backing array, losing the original
 	// reference. The runtime.SetFinalizer docs specify that its argument 'must be
@@ -142,7 +139,7 @@ func allocate(size int) (unsafe.Pointer, error) {
 	// pointer separately, which severely complicates finalizer setup and makes it
 	// prone to human error. For now, just bump the pointer and treat it as the
 	// new and only reference to the backing array.
-	return aligned, nil
+	return alloc, nil
 }
 
 // mapmap memory-maps the given file descriptor at the given address and sets a


### PR DESCRIPTION
This allows removing the `nolint:govet` statement which the vanilla `go vet` doesn't acknowledge to begin with.

Closes https://github.com/cilium/ebpf/issues/2027