### PR TITLE
ringbuf: add RawReader for zero-copy reading and commit batching

### DIFF
--- a/ringbuf/helper_other_test.go
+++ b/ringbuf/helper_other_test.go
@@ -10,26 +10,43 @@ import (
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/asm"
+	"github.com/cilium/ebpf/internal"
 )
 
+// mustOutputSamplesProg returns a BPF program that outputs the given sample
+// messages to a ringbuf.
 func mustOutputSamplesProg(tb testing.TB, sampleMessages ...sampleMessage) (*ebpf.Program, *ebpf.Map) {
 	tb.Helper()
+	return mustOutputSamplesProgN(tb, 1, sampleMessages...)
+}
+
+// mustOutputSamplesProgN returns a BPF program that outputs the given sample
+// messages to a ringbuf, sizing the map to fit the samples repeated N times.
+func mustOutputSamplesProgN(tb testing.TB, repeat int, sampleMessages ...sampleMessage) (*ebpf.Program, *ebpf.Map) {
+	tb.Helper()
+
+	var maxSampleSize, totalSize int
+	for _, sampleMessage := range sampleMessages {
+		if sampleMessage.size > maxSampleSize {
+			maxSampleSize = sampleMessage.size
+		}
+		totalSize += ringbufHeaderSize + internal.Align(sampleMessage.size, 8)
+	}
+	totalSize *= repeat
+
+	mapSize := os.Getpagesize()
+	for mapSize < totalSize {
+		mapSize *= 2
+	}
 
 	events, err := ebpf.NewMap(&ebpf.MapSpec{
 		Type:       ebpf.RingBuf,
-		MaxEntries: uint32(os.Getpagesize()),
+		MaxEntries: uint32(mapSize),
 	})
 	qt.Assert(tb, qt.IsNil(err))
 	tb.Cleanup(func() {
 		events.Close()
 	})
-
-	var maxSampleSize int
-	for _, sampleMessage := range sampleMessages {
-		if sampleMessage.size > maxSampleSize {
-			maxSampleSize = sampleMessage.size
-		}
-	}
 
 	insns := asm.Instructions{
 		asm.LoadImm(asm.R0, 0x0102030404030201, asm.DWord),

--- a/ringbuf/helper_test.go
+++ b/ringbuf/helper_test.go
@@ -2,6 +2,7 @@ package ringbuf
 
 import (
 	"testing"
+	"time"
 
 	"github.com/go-quicktest/qt"
 
@@ -26,4 +27,16 @@ func mustRun(tb testing.TB, prog *ebpf.Program) {
 	qt.Assert(tb, qt.IsNil(err))
 
 	qt.Assert(tb, qt.Equals(ret, uint32(0)))
+}
+
+func mustRunN(tb testing.TB, prog *ebpf.Program, repeat uint32) time.Duration {
+	tb.Helper()
+
+	ret, d, err := prog.Benchmark(internal.EmptyBPFContext, int(repeat), nil)
+	testutils.SkipIfNotSupported(tb, err)
+	qt.Assert(tb, qt.IsNil(err))
+
+	qt.Assert(tb, qt.Equals(ret, uint32(0)))
+
+	return d
 }

--- a/ringbuf/helper_windows_test.go
+++ b/ringbuf/helper_windows_test.go
@@ -7,26 +7,43 @@ import (
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/asm"
+	"github.com/cilium/ebpf/internal"
 )
 
+// mustOutputSamplesProg returns a BPF program that outputs the given sample
+// messages to a ringbuf.
 func mustOutputSamplesProg(tb testing.TB, sampleMessages ...sampleMessage) (*ebpf.Program, *ebpf.Map) {
 	tb.Helper()
+	return mustOutputSamplesProgN(tb, 1, sampleMessages...)
+}
+
+// mustOutputSamplesProgN returns a BPF program that outputs the given sample
+// messages to a ringbuf, sizing the map to fit the samples repeated N times.
+func mustOutputSamplesProgN(tb testing.TB, repeat int, sampleMessages ...sampleMessage) (*ebpf.Program, *ebpf.Map) {
+	tb.Helper()
+
+	var maxSampleSize, totalSize int
+	for _, sampleMessage := range sampleMessages {
+		if sampleMessage.size > maxSampleSize {
+			maxSampleSize = sampleMessage.size
+		}
+		totalSize += ringbufHeaderSize + internal.Align(sampleMessage.size, 8)
+	}
+	totalSize *= repeat
+
+	mapSize := 4096
+	for mapSize < totalSize {
+		mapSize *= 2
+	}
 
 	events, err := ebpf.NewMap(&ebpf.MapSpec{
 		Type:       ebpf.WindowsRingBuf,
-		MaxEntries: 4096,
+		MaxEntries: uint32(mapSize),
 	})
 	qt.Assert(tb, qt.IsNil(err))
 	tb.Cleanup(func() {
 		events.Close()
 	})
-
-	var maxSampleSize int
-	for _, sampleMessage := range sampleMessages {
-		if sampleMessage.size > maxSampleSize {
-			maxSampleSize = sampleMessage.size
-		}
-	}
 
 	insns := asm.Instructions{
 		asm.LoadImm(asm.R0, 0x0102030404030201, asm.DWord),

--- a/ringbuf/raw_reader.go
+++ b/ringbuf/raw_reader.go
@@ -1,0 +1,215 @@
+package ringbuf
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"runtime"
+	"sync/atomic"
+	"time"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/internal"
+)
+
+// RawReader reads raw samples submitted to a BPF ringbuf.
+//
+// RawReader exposes samples as slices backed by shared ring memory. Access to
+// that memory is scoped to a [Lease] obtained via [RawReader.WithLease].
+// Returned samples remain valid until the next call to [Lease.Commit] or
+// until the session ends.
+//
+// RawReader must not be used concurrently by multiple goroutines, except that
+// [RawReader.Close] and [RawReader.Flush] may be called from another goroutine
+// to interrupt a blocked read.
+//
+// Use [Reader] instead for a thread-safe alternative.
+type RawReader struct {
+	poller poller
+
+	ring       eventRing
+	deadline   time.Time
+	bufferSize int
+	drainErr   error
+
+	inflight, closed atomic.Bool
+}
+
+var errConcurrent = errors.New("concurrent use of RawReader")
+
+// enter marks the start of an in-flight lease. It returns an error if the
+// reader is already in-flight or closed. Every successful call to enter must be
+// paired with a call to [RawReader.leave].
+func (rr *RawReader) enter() error {
+	if !rr.inflight.CompareAndSwap(false, true) {
+		return errConcurrent
+	}
+
+	if rr.closed.Load() {
+		rr.leave()
+		return fmt.Errorf("ringbuf: %w", ErrClosed)
+	}
+
+	return nil
+}
+
+// leave resets the reader's in-flight state.
+func (rr *RawReader) leave() {
+	rr.inflight.Store(false)
+}
+
+// NewRawReader creates a new raw BPF ringbuf reader. The given Map must be of
+// type [ebpf.RingBuf] or [ebpf.WindowsRingBuf].
+func NewRawReader(m *ebpf.Map) (*RawReader, error) {
+	if m.Type() != ebpf.RingBuf && m.Type() != ebpf.WindowsRingBuf {
+		return nil, fmt.Errorf("invalid Map type: %s", m.Type())
+	}
+
+	maxEntries := int(m.MaxEntries())
+	if maxEntries == 0 || !internal.IsPow(maxEntries) {
+		return nil, fmt.Errorf("ringbuffer map size %d is zero or not a power of two", maxEntries)
+	}
+
+	poller, err := newPoller(m.FD())
+	if err != nil {
+		return nil, err
+	}
+
+	ring, err := newRingBufEventRing(m.FD(), maxEntries)
+	if err != nil {
+		poller.Close()
+		return nil, fmt.Errorf("failed to create ringbuf ring: %w", err)
+	}
+
+	return &RawReader{
+		poller:     poller,
+		ring:       ring,
+		bufferSize: ring.size(),
+	}, nil
+}
+
+// WithLease calls fn with exclusive access to rr.
+//
+// The provided Lease is only valid for the duration of fn. The callback may
+// call [Lease.ReadSample] multiple times before [Lease.Commit] to batch
+// consumer position updates.
+//
+// The callback must not call [RawReader.Close] on the same reader.
+func (rr *RawReader) WithLease(fn func(Lease) error) error {
+	if err := rr.enter(); err != nil {
+		return err
+	}
+	defer rr.leave()
+
+	return fn(Lease{rr: rr})
+}
+
+// Close frees resources used by the reader, unblocking any pending reads.
+//
+// When a read returns [os.ErrClosed], there are no more samples left in the
+// ring.
+func (rr *RawReader) Close() error {
+	if !rr.closed.CompareAndSwap(false, true) {
+		return nil
+	}
+
+	if err := rr.poller.Close(); err != nil && !errors.Is(err, os.ErrClosed) {
+		return fmt.Errorf("close poller: %w", err)
+	}
+
+	for rr.inflight.Load() {
+		runtime.Gosched()
+	}
+
+	return rr.ring.close()
+}
+
+// SetDeadline controls how long reads will block waiting for samples.
+//
+// Passing a zero time.Time will remove the deadline.
+func (rr *RawReader) SetDeadline(t time.Time) {
+	rr.deadline = t
+}
+
+// Lease provides exclusive access to a [RawReader] for the duration of a
+// [RawReader.WithLease] callback.
+//
+// A Lease is only valid during that callback and must not be used outside of
+// the scope of [RawReader.WithLease].
+type Lease struct {
+	rr *RawReader
+}
+
+// ReadSample blocks and reads the next sample from the BPF ringbuf. The
+// returned data aliases shared ring memory and is only valid until the next
+// call to [Lease.Commit] or until the surrounding [RawReader.WithLease]
+// callback returns.
+//
+// If the returned data is nil, the sample was discarded by the producer.
+//
+// If a nil error is returned, the reader's internal consumer position has
+// advanced and [Lease.Commit] should be called, e.g. when batching reads.
+//
+// Returns [os.ErrDeadlineExceeded] if a deadline was set and exceeded. Either
+// no samples were produced, or the producer used BPF_RB_NO_WAKEUP when
+// submitting samples and reading should continue.
+func (s Lease) ReadSample() (data []byte, remain int, err error) {
+	rr := s.rr
+
+	for {
+		// On Windows, the wait handle is only set when the reader is created, so we
+		// miss any wakeups that happened before. Do an opportunistic read to get
+		// any pending samples.
+		data, remain, err := rr.ring.readSample()
+		if err == nil {
+			return data, remain, nil
+		}
+
+		if err != errEOR {
+			return nil, 0, err
+		}
+
+		if err := rr.drainErr; err != nil {
+			rr.drainErr = nil
+			return nil, 0, err
+		}
+
+		err = rr.poller.Wait(rr.deadline)
+		if errors.Is(err, os.ErrDeadlineExceeded) || errors.Is(err, ErrFlushed) {
+			rr.drainErr = err
+			continue
+		}
+
+		if err != nil {
+			return nil, 0, err
+		}
+	}
+}
+
+// Commit pushes the reader's internal consumer position to shared kernel
+// memory.
+func (s Lease) Commit() {
+	s.rr.ring.commit()
+}
+
+// BufferSize returns the size in bytes of the ring buffer's data portion.
+func (rr *RawReader) BufferSize() int {
+	return rr.bufferSize
+}
+
+// Flush unblocks any pending reads. Successive reads will return any and all
+// samples left in the ring (e.g. previously submitted with BPF_RB_NO_WAKEUP).
+// When a read returns [ErrFlushed], there are no more samples left in the ring.
+func (rr *RawReader) Flush() error {
+	return rr.poller.Flush()
+}
+
+// AvailableBytes returns the amount of bytes submitted by the producer that are
+// not yet consumed by the reader, typically for monitoring purposes.
+//
+// Only tracks cursors committed to shared memory, ignoring the reader's local
+// consumer position. If the reader is batching commits, this may return an
+// inflated value.
+func (rr *RawReader) AvailableBytes() int {
+	return rr.ring.available()
+}

--- a/ringbuf/raw_reader_test.go
+++ b/ringbuf/raw_reader_test.go
@@ -1,0 +1,94 @@
+package ringbuf
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/cilium/ebpf/internal/testutils"
+)
+
+func BenchmarkRawReader(b *testing.B) {
+	testutils.SkipOnOldKernel(b, "5.8", "BPF ring buffer")
+
+	bench := func(b *testing.B, batch int, sampleSize int) {
+		b.Run(fmt.Sprintf("commit batch %d sample size %d", batch, sampleSize), func(b *testing.B) {
+			prog, events := mustOutputSamplesProgN(b, batch, sampleMessage{size: sampleSize})
+			rr, err := NewRawReader(events)
+			if err != nil {
+				b.Fatal(err)
+			}
+			defer rr.Close()
+
+			b.ResetTimer()
+			b.ReportAllocs()
+
+			// Manually track and report read time since the testing framework's
+			// calibration doesn't account for BPF prog run time if the timer is
+			// stopped during the run, causing it to scale to millions of b.N per run
+			// and hanging the benchmark.
+			var sysTime, bpfTime, readTime, commitTime time.Duration
+
+			for b.Loop() {
+				// PROG_RUN with a repeat value larger than 1 does not have a fast path
+				// and costs orders of magnitude more time (~10ms) than a single run
+				// would, even with low values (e.g. 2). [mustRunN] was chosen to ensure
+				// a stable amount of allocs even though [mustRun] would be much faster.
+				startSys := time.Now()
+				bpfTime += mustRunN(b, prog, uint32(batch)) * time.Duration(batch)
+				sysTime += time.Since(startSys)
+
+				if err := rr.WithLease(func(lease Lease) error {
+					for range batch {
+						startRead := time.Now()
+						data, _, err := lease.ReadSample()
+						readTime += time.Since(startRead)
+
+						if len(data) != sampleSize {
+							b.Fatal("Expected sample of size", sampleSize, "but got", len(data))
+						}
+						if err != nil {
+							return err
+						}
+					}
+
+					startCommit := time.Now()
+					lease.Commit()
+					commitTime += time.Since(startCommit)
+
+					return nil
+				}); err != nil {
+					b.Fatal(err)
+				}
+			}
+
+			// Read + commit is the majority of the time spent processing the batch,
+			// excluding filling the ring with samples. This can be compared to Read
+			// and ReadInto, so report as main metric.
+			b.ReportMetric(float64(readTime.Nanoseconds()+commitTime.Nanoseconds())/float64(b.N), "ns/op")
+			// Time spent executing the BPF program internally as reported by the
+			// kernel, ignoring syscall overhead.
+			b.ReportMetric(float64(bpfTime.Nanoseconds())/float64(b.N), "bpf_ns/op")
+			// Time spent committing reader position to kernel memory and
+			// synchronizing memory.
+			b.ReportMetric(float64(commitTime.Nanoseconds())/float64(b.N), "commit_ns/op")
+			// Time spent in [Lease.ReadSample], reading the producer position from
+			// shared memory.
+			b.ReportMetric(float64(readTime.Nanoseconds())/float64(b.N), "read_ns/op")
+			// Time spent in the BPF() syscall for filling the ring.
+			b.ReportMetric(float64(sysTime.Nanoseconds())/float64(b.N), "sys_ns/op")
+		})
+	}
+
+	bench(b, 1, 32)
+	bench(b, 2, 32)
+	bench(b, 10, 32)
+	bench(b, 100, 32)
+	bench(b, 1000, 32)
+
+	bench(b, 1, 256)
+	bench(b, 2, 256)
+	bench(b, 10, 256)
+	bench(b, 100, 256)
+	bench(b, 1000, 256)
+}

--- a/ringbuf/reader.go
+++ b/ringbuf/reader.go
@@ -31,9 +31,9 @@ type poller interface {
 // eventRing abstracts platform-specific ring buffer memory access.
 type eventRing interface {
 	size() int
-	AvailableBytes() uint64
+	available() int
 	readRecord(rec *Record) error
-	Close() error
+	close() error
 }
 
 // ringbufHeader from 'struct bpf_ringbuf_hdr' in kernel/bpf/ringbuf.c
@@ -133,7 +133,7 @@ func (r *Reader) Close() error {
 
 	var err error
 	if r.ring != nil {
-		err = r.ring.Close()
+		err = r.ring.close()
 		r.ring = nil
 	}
 
@@ -222,7 +222,5 @@ func (r *Reader) Flush() error {
 
 // AvailableBytes returns the amount of data available to read in the ring buffer in bytes.
 func (r *Reader) AvailableBytes() int {
-	// Don't need to acquire the lock here since the implementation of AvailableBytes
-	// performs atomic loads on the producer and consumer positions.
-	return int(r.ring.AvailableBytes())
+	return r.ring.available()
 }

--- a/ringbuf/reader.go
+++ b/ringbuf/reader.go
@@ -10,15 +10,12 @@ import (
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/internal"
-	"github.com/cilium/ebpf/internal/platform"
 	"github.com/cilium/ebpf/internal/sys"
 )
 
 var (
-	ErrClosed  = os.ErrClosed
-	errEOR     = errors.New("end of ring")
-	errBusy    = errors.New("sample not committed yet")
-	errDiscard = errors.New("sample should be discarded")
+	ErrClosed = os.ErrClosed
+	errEOR    = errors.New("end of ring")
 )
 
 // poller abstracts platform-specific event notification.
@@ -77,29 +74,28 @@ type Reader struct {
 	// mu protects read/write access to the Reader structure
 	mu         sync.Mutex
 	ring       eventRing
-	haveData   bool
 	deadline   time.Time
 	bufferSize int
-	pendingErr error
+	drainErr   error
 }
 
 // NewReader creates a new BPF ringbuf reader.
-func NewReader(ringbufMap *ebpf.Map) (*Reader, error) {
-	if ringbufMap.Type() != ebpf.RingBuf && ringbufMap.Type() != ebpf.WindowsRingBuf {
-		return nil, fmt.Errorf("invalid Map type: %s", ringbufMap.Type())
+func NewReader(m *ebpf.Map) (*Reader, error) {
+	if m.Type() != ebpf.RingBuf && m.Type() != ebpf.WindowsRingBuf {
+		return nil, fmt.Errorf("invalid Map type: %s", m.Type())
 	}
 
-	maxEntries := int(ringbufMap.MaxEntries())
-	if maxEntries == 0 || (maxEntries&(maxEntries-1)) != 0 {
+	maxEntries := int(m.MaxEntries())
+	if maxEntries == 0 || !internal.IsPow(maxEntries) {
 		return nil, fmt.Errorf("ringbuffer map size %d is zero or not a power of two", maxEntries)
 	}
 
-	poller, err := newPoller(ringbufMap.FD())
+	poller, err := newPoller(m.FD())
 	if err != nil {
 		return nil, err
 	}
 
-	ring, err := newRingBufEventRing(ringbufMap.FD(), maxEntries)
+	ring, err := newRingBufEventRing(m.FD(), maxEntries)
 	if err != nil {
 		poller.Close()
 		return nil, fmt.Errorf("failed to create ringbuf ring: %w", err)
@@ -109,10 +105,6 @@ func NewReader(ringbufMap *ebpf.Map) (*Reader, error) {
 		poller:     poller,
 		ring:       ring,
 		bufferSize: ring.size(),
-		// On Windows, the wait handle is only set when the reader is created,
-		// so we miss any wakeups that happened before.
-		// Do an opportunistic read to get any pending samples.
-		haveData: platform.IsWindows,
 	}, nil
 }
 
@@ -175,35 +167,39 @@ func (r *Reader) ReadInto(rec *Record) error {
 	}
 
 	for {
-		if !r.haveData {
-			if pe := r.pendingErr; pe != nil {
-				r.pendingErr = nil
-				return pe
-			}
-
-			err := r.poller.Wait(r.deadline)
-			if errors.Is(err, os.ErrDeadlineExceeded) || errors.Is(err, ErrFlushed) {
-				// Ignoring this for reading a valid entry after timeout or flush.
-				// This can occur if the producer submitted to the ring buffer
-				// with BPF_RB_NO_WAKEUP.
-				r.pendingErr = err
-			} else if err != nil {
-				return err
-			}
-			r.haveData = true
+		// On Windows, the wait handle is only set when the reader is created, so we
+		// miss any wakeups that happened before. Do an opportunistic read to get
+		// any pending samples.
+		err := r.ring.readRecord(rec)
+		if err == nil {
+			return nil
 		}
 
-		for {
-			err := r.ring.readRecord(rec)
-			// Not using errors.Is which is quite a bit slower
-			// For a tight loop it might make a difference
-			if err == errBusy || err == errDiscard {
-				continue
-			}
-			if err == errEOR {
-				r.haveData = false
-				break
-			}
+		// Avoid [errors.Is] for performance reasons.
+		if err != errEOR {
+			// Bubble up unrecoverable errors to the caller.
+			return err
+		}
+
+		// Ring is empty at this point.
+
+		// Flush any pending drain error from previous call or iteration.
+		if err := r.drainErr; err != nil {
+			r.drainErr = nil
+			return err
+		}
+
+		err = r.poller.Wait(r.deadline)
+		if errors.Is(err, os.ErrDeadlineExceeded) || errors.Is(err, ErrFlushed) {
+			// The poller was interrupted, but there may still be samples in the
+			// ring (e.g. one submitted with BPF_RB_NO_WAKEUP). Store the error
+			// to be able return it after we've drained the ring.
+			r.drainErr = err
+
+			continue
+		}
+
+		if err != nil {
 			return err
 		}
 	}

--- a/ringbuf/reader.go
+++ b/ringbuf/reader.go
@@ -29,7 +29,8 @@ type poller interface {
 type eventRing interface {
 	size() int
 	available() int
-	readRecord(rec *Record) error
+	readSample() (data []byte, remain int, err error)
+	commit()
 	close() error
 }
 
@@ -66,157 +67,110 @@ type Record struct {
 	Remaining int
 }
 
-// Reader allows reading bpf_ringbuf_output
-// from user space.
-type Reader struct {
-	poller poller
-
-	// mu protects read/write access to the Reader structure
-	mu         sync.Mutex
-	ring       eventRing
-	deadline   time.Time
-	bufferSize int
-	drainErr   error
-}
-
-// NewReader creates a new BPF ringbuf reader.
-func NewReader(m *ebpf.Map) (*Reader, error) {
-	if m.Type() != ebpf.RingBuf && m.Type() != ebpf.WindowsRingBuf {
-		return nil, fmt.Errorf("invalid Map type: %s", m.Type())
-	}
-
-	maxEntries := int(m.MaxEntries())
-	if maxEntries == 0 || !internal.IsPow(maxEntries) {
-		return nil, fmt.Errorf("ringbuffer map size %d is zero or not a power of two", maxEntries)
-	}
-
-	poller, err := newPoller(m.FD())
-	if err != nil {
-		return nil, err
-	}
-
-	ring, err := newRingBufEventRing(m.FD(), maxEntries)
-	if err != nil {
-		poller.Close()
-		return nil, fmt.Errorf("failed to create ringbuf ring: %w", err)
-	}
-
-	return &Reader{
-		poller:     poller,
-		ring:       ring,
-		bufferSize: ring.size(),
-	}, nil
-}
-
-// Close frees resources used by the reader.
+// Reader reads [Record]s submitted to a BPF ringbuf.
 //
-// It interrupts calls to Read.
-func (r *Reader) Close() error {
-	if err := r.poller.Close(); err != nil {
-		if errors.Is(err, os.ErrClosed) {
-			return nil
-		}
-		return err
-	}
-
-	// Acquire the lock. This ensures that Read isn't running.
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	var err error
-	if r.ring != nil {
-		err = r.ring.close()
-		r.ring = nil
-	}
-
-	return err
+// It is safe for concurrent use by multiple goroutines.
+type Reader struct {
+	mu  sync.Mutex
+	raw *RawReader
 }
 
-// SetDeadline controls how long Read and ReadInto will block waiting for samples.
+// NewReader creates a new BPF ringbuf reader. The given Map must be of type
+// [ebpf.RingBuf] or [ebpf.WindowsRingBuf].
+//
+// The returned Reader is safe for concurrent use by multiple goroutines.
+func NewReader(m *ebpf.Map) (*Reader, error) {
+	raw, err := NewRawReader(m)
+	if err != nil {
+		return nil, fmt.Errorf("create reader: %w", err)
+	}
+	return &Reader{raw: raw}, nil
+}
+
+// Close frees resources used by the reader, unblocking any pending reads.
+//
+// When a read returns [os.ErrClosed], there are no more samples left in the
+// ring.
+func (r *Reader) Close() error {
+	return r.raw.Close()
+}
+
+// SetDeadline controls how long reads will block waiting for samples.
 //
 // Passing a zero time.Time will remove the deadline.
 func (r *Reader) SetDeadline(t time.Time) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	r.deadline = t
+	r.raw.SetDeadline(t)
 }
 
 // Read the next record from the BPF ringbuf.
 //
-// Calling [Close] interrupts the method with [os.ErrClosed]. Calling [Flush]
-// makes it return all records currently in the ring buffer, followed by [ErrFlushed].
+// Returns [os.ErrDeadlineExceeded] if a deadline was set and exceeded. Either
+// no samples were produced, or the producer used BPF_RB_NO_WAKEUP when
+// submitting samples and reading should continue.
 //
-// Returns [os.ErrDeadlineExceeded] if a deadline was set and after all records
-// have been read from the ring.
-//
-// See [ReadInto] for a more efficient version of this method.
+// See [Reader.ReadInto] for a more efficient version of this method.
 func (r *Reader) Read() (Record, error) {
 	var rec Record
 	err := r.ReadInto(&rec)
 	return rec, err
 }
 
-// ReadInto is like Read except that it allows reusing Record and associated buffers.
+// ReadInto is like [Reader.Read], but allows reusing Record and associated
+// buffers.
 func (r *Reader) ReadInto(rec *Record) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	if r.ring == nil {
-		return fmt.Errorf("ringbuffer: %w", ErrClosed)
-	}
-
-	for {
-		// On Windows, the wait handle is only set when the reader is created, so we
-		// miss any wakeups that happened before. Do an opportunistic read to get
-		// any pending samples.
-		err := r.ring.readRecord(rec)
-		if err == nil {
-			return nil
-		}
-
-		// Avoid [errors.Is] for performance reasons.
-		if err != errEOR {
-			// Bubble up unrecoverable errors to the caller.
-			return err
-		}
-
-		// Ring is empty at this point.
-
-		// Flush any pending drain error from previous call or iteration.
-		if err := r.drainErr; err != nil {
-			r.drainErr = nil
-			return err
-		}
-
-		err = r.poller.Wait(r.deadline)
-		if errors.Is(err, os.ErrDeadlineExceeded) || errors.Is(err, ErrFlushed) {
-			// The poller was interrupted, but there may still be samples in the
-			// ring (e.g. one submitted with BPF_RB_NO_WAKEUP). Store the error
-			// to be able return it after we've drained the ring.
-			r.drainErr = err
-
-			continue
-		}
-
+	return r.raw.WithLease(func(s Lease) error {
+	retry:
+		data, remain, err := s.ReadSample()
 		if err != nil {
 			return err
 		}
-	}
+
+		if data == nil {
+			// Consumer needs to advance even if the producer discarded the sample,
+			// since space was reserved for it in the ring.
+			s.Commit()
+
+			// Sample was discarded, try to read the next one.
+			goto retry
+		}
+
+		if cap(rec.RawSample) < len(data) {
+			rec.RawSample = make([]byte, len(data))
+		} else {
+			rec.RawSample = rec.RawSample[:len(data)]
+		}
+
+		copy(rec.RawSample, data)
+		rec.Remaining = remain
+
+		// Advance the reader, invalidating the sample data.
+		s.Commit()
+
+		return nil
+	})
+
 }
 
-// BufferSize returns the size in bytes of the ring buffer
+// BufferSize returns the size in bytes of the ring buffer's data portion.
 func (r *Reader) BufferSize() int {
-	return r.bufferSize
+	return r.raw.BufferSize()
 }
 
-// Flush unblocks Read/ReadInto and successive Read/ReadInto calls will return pending samples at this point,
-// until you receive a ErrFlushed error.
+// Flush unblocks any pending reads. Successive reads will return any and all
+// samples left in the ring (e.g. previously submitted with BPF_RB_NO_WAKEUP).
+// When a read returns [ErrFlushed], there are no more samples left in the ring.
 func (r *Reader) Flush() error {
-	return r.poller.Flush()
+	return r.raw.Flush()
 }
 
-// AvailableBytes returns the amount of data available to read in the ring buffer in bytes.
+// AvailableBytes returns the amount of bytes submitted by the producer that are
+// not yet consumed by the reader, typically for monitoring purposes.
 func (r *Reader) AvailableBytes() int {
-	return r.ring.available()
+	return r.raw.AvailableBytes()
 }

--- a/ringbuf/reader.go
+++ b/ringbuf/reader.go
@@ -14,9 +14,10 @@ import (
 )
 
 var (
-	ErrClosed = os.ErrClosed
-	errEOR    = errors.New("end of ring")
-	errBusy   = errors.New("sample not committed yet")
+	ErrClosed  = os.ErrClosed
+	errEOR     = errors.New("end of ring")
+	errBusy    = errors.New("sample not committed yet")
+	errDiscard = errors.New("sample should be discarded")
 )
 
 // poller abstracts platform-specific event notification.
@@ -189,7 +190,7 @@ func (r *Reader) ReadInto(rec *Record) error {
 			err := r.ring.readRecord(rec)
 			// Not using errors.Is which is quite a bit slower
 			// For a tight loop it might make a difference
-			if err == errBusy {
+			if err == errBusy || err == errDiscard {
 				continue
 			}
 			if err == errEOR {

--- a/ringbuf/reader.go
+++ b/ringbuf/reader.go
@@ -9,6 +9,7 @@ import (
 	"unsafe"
 
 	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/internal"
 	"github.com/cilium/ebpf/internal/platform"
 	"github.com/cilium/ebpf/internal/sys"
 )
@@ -53,6 +54,12 @@ func (rh *ringbufHeader) isDiscard() bool {
 
 func (rh *ringbufHeader) dataLen() int {
 	return int(rh.Len & ^uint32(sys.BPF_RINGBUF_BUSY_BIT|sys.BPF_RINGBUF_DISCARD_BIT))
+}
+
+// dataLenAligned returns the length of the sample data as specified in the
+// header, aligned to an 8 byte boundary.
+func (rh *ringbufHeader) dataLenAligned() int {
+	return int(internal.Align(rh.dataLen(), 8))
 }
 
 type Record struct {

--- a/ringbuf/reader_test.go
+++ b/ringbuf/reader_test.go
@@ -2,6 +2,7 @@ package ringbuf
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -325,62 +326,139 @@ func TestReadAfterClose(t *testing.T) {
 func BenchmarkReader(b *testing.B) {
 	testutils.SkipOnOldKernel(b, "5.8", "BPF ring buffer")
 
-	prog, events := mustOutputSamplesProg(b, sampleMessage{size: 80})
+	bench := func(b *testing.B, batch int, sampleSize int) {
+		b.Run(fmt.Sprintf("read batch %d sample size %d", batch, sampleSize), func(b *testing.B) {
+			prog, events := mustOutputSamplesProgN(b, batch, sampleMessage{size: sampleSize})
 
-	rd, err := NewReader(events)
-	if err != nil {
-		b.Fatal(err)
+			rd, err := NewReader(events)
+			if err != nil {
+				b.Fatal(err)
+			}
+			defer rd.Close()
+
+			b.ResetTimer()
+			b.ReportAllocs()
+
+			// Manually track and report read time since the testing framework's
+			// calibration doesn't account for BPF prog run time if the timer is
+			// stopped during the run, causing it to scale to millions of b.N per run
+			// and hanging the benchmark.
+			var sysTime, bpfTime, readTime time.Duration
+
+			for b.Loop() {
+				// PROG_RUN with a repeat value larger than 1 does not have a fast path
+				// and costs orders of magnitude more time (~10ms) than a single run
+				// would, even with low values (e.g. 2). [mustRunN] was chosen to ensure
+				// a stable amount of allocs even though [mustRun] would be much faster.
+				startSys := time.Now()
+				bpfTime += mustRunN(b, prog, uint32(batch)) * time.Duration(batch)
+				sysTime += time.Since(startSys)
+
+				for range batch {
+					start := time.Now()
+					rec, err := rd.Read()
+					if err != nil {
+						b.Fatal("Can't read samples:", err)
+					}
+					readTime += time.Since(start)
+
+					if len(rec.RawSample) != sampleSize {
+						b.Fatal("Expected sample of size", sampleSize, "but got", len(rec.RawSample))
+					}
+				}
+			}
+
+			// ReadInto is where the majority of the time is spent processing the
+			// batch, excluding filling the ring with samples, so report as main
+			// metric.
+			b.ReportMetric(float64(readTime.Nanoseconds())/float64(b.N), "ns/op")
+			// Time spent executing the BPF program internally as reported by the
+			// kernel, ignoring syscall overhead.
+			b.ReportMetric(float64(bpfTime.Nanoseconds())/float64(b.N), "bpf_ns/op")
+			// Time spent in the BPF() syscall for filling the ring.
+			b.ReportMetric(float64(sysTime.Nanoseconds())/float64(b.N), "sys_ns/op")
+		})
 	}
-	defer rd.Close()
 
-	b.ResetTimer()
-	b.ReportAllocs()
+	bench(b, 1, 32)
+	bench(b, 2, 32)
+	bench(b, 10, 32)
+	bench(b, 100, 32)
+	bench(b, 1000, 32)
 
-	// Manually track and report read time since the testing framework's
-	// calibration doesn't account for BPF prog run time if the timer is
-	// stopped during the run, causing it to scale to millions of b.N per run
-	// and hanging the benchmark.
-	var readTime time.Duration
-
-	for b.Loop() {
-		mustRun(b, prog)
-
-		start := time.Now()
-		if _, err := rd.Read(); err != nil {
-			b.Fatal("Can't read samples:", err)
-		}
-		readTime += time.Since(start)
-	}
-
-	b.ReportMetric(float64(readTime.Nanoseconds())/float64(b.N), "ns/op")
+	bench(b, 1, 256)
+	bench(b, 2, 256)
+	bench(b, 10, 256)
+	bench(b, 100, 256)
+	bench(b, 1000, 256)
 }
 
 func BenchmarkReadInto(b *testing.B) {
 	testutils.SkipOnOldKernel(b, "5.8", "BPF ring buffer")
 
-	prog, events := mustOutputSamplesProg(b, sampleMessage{size: 80, flags: 0})
+	bench := func(b *testing.B, batch int, sampleSize int) {
+		b.Run(fmt.Sprintf("read batch %d sample size %d", batch, sampleSize), func(b *testing.B) {
+			prog, events := mustOutputSamplesProgN(b, batch, sampleMessage{size: sampleSize})
 
-	rd, err := NewReader(events)
-	if err != nil {
-		b.Fatal(err)
+			rd, err := NewReader(events)
+			if err != nil {
+				b.Fatal(err)
+			}
+			defer rd.Close()
+
+			b.ResetTimer()
+			b.ReportAllocs()
+
+			// Manually track and report read time since the testing framework's
+			// calibration doesn't account for BPF prog run time if the timer is
+			// stopped during the run, causing it to scale to millions of b.N per run
+			// and hanging the benchmark.
+			var sysTime, bpfTime, readTime time.Duration
+
+			var rec Record
+			for b.Loop() {
+				// PROG_RUN with a repeat value larger than 1 does not have a fast path
+				// and costs orders of magnitude more time (~10ms) than a single run
+				// would, even with low values (e.g. 2). [mustRunN] was chosen to ensure
+				// a stable amount of allocs even though [mustRun] would be much faster.
+				startSys := time.Now()
+				bpfTime += mustRunN(b, prog, uint32(batch)) * time.Duration(batch)
+				sysTime += time.Since(startSys)
+
+				for range batch {
+					start := time.Now()
+					if err := rd.ReadInto(&rec); err != nil {
+						b.Fatal("Can't read samples:", err)
+					}
+					readTime += time.Since(start)
+
+					if len(rec.RawSample) != sampleSize {
+						b.Fatal("Expected sample of size", sampleSize, "but got", len(rec.RawSample))
+					}
+				}
+			}
+
+			// ReadInto is where the majority of the time is spent processing the
+			// batch, excluding filling the ring with samples, so report as main
+			// metric.
+			b.ReportMetric(float64(readTime.Nanoseconds())/float64(b.N), "ns/op")
+			// Time spent executing the BPF program internally as reported by the
+			// kernel, ignoring syscall overhead.
+			b.ReportMetric(float64(bpfTime.Nanoseconds())/float64(b.N), "bpf_ns/op")
+			// Time spent in the BPF() syscall for filling the ring.
+			b.ReportMetric(float64(sysTime.Nanoseconds())/float64(b.N), "sys_ns/op")
+		})
 	}
-	defer rd.Close()
 
-	b.ResetTimer()
-	b.ReportAllocs()
+	bench(b, 1, 32)
+	bench(b, 2, 32)
+	bench(b, 10, 32)
+	bench(b, 100, 32)
+	bench(b, 1000, 32)
 
-	var readTime time.Duration
-
-	var rec Record
-	for b.Loop() {
-		mustRun(b, prog)
-
-		start := time.Now()
-		if err := rd.ReadInto(&rec); err != nil {
-			b.Fatal("Can't read samples:", err)
-		}
-		readTime += time.Since(start)
-	}
-
-	b.ReportMetric(float64(readTime.Nanoseconds())/float64(b.N), "ns/op")
+	bench(b, 1, 256)
+	bench(b, 2, 256)
+	bench(b, 10, 256)
+	bench(b, 100, 256)
+	bench(b, 1000, 256)
 }

--- a/ringbuf/reader_test.go
+++ b/ringbuf/reader_test.go
@@ -325,39 +325,34 @@ func TestReadAfterClose(t *testing.T) {
 func BenchmarkReader(b *testing.B) {
 	testutils.SkipOnOldKernel(b, "5.8", "BPF ring buffer")
 
-	readerBenchmarks := []struct {
-		name  string
-		flags int32
-	}{
-		{
-			name: "normal epoll with timeout -1",
-		},
+	prog, events := mustOutputSamplesProg(b, sampleMessage{size: 80})
+
+	rd, err := NewReader(events)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer rd.Close()
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	// Manually track and report read time since the testing framework's
+	// calibration doesn't account for BPF prog run time if the timer is
+	// stopped during the run, causing it to scale to millions of b.N per run
+	// and hanging the benchmark.
+	var readTime time.Duration
+
+	for b.Loop() {
+		mustRun(b, prog)
+
+		start := time.Now()
+		if _, err := rd.Read(); err != nil {
+			b.Fatal("Can't read samples:", err)
+		}
+		readTime += time.Since(start)
 	}
 
-	for _, bm := range readerBenchmarks {
-		b.Run(bm.name, func(b *testing.B) {
-			prog, events := mustOutputSamplesProg(b, sampleMessage{size: 80, flags: bm.flags})
-
-			rd, err := NewReader(events)
-			if err != nil {
-				b.Fatal(err)
-			}
-			defer rd.Close()
-
-			b.ReportAllocs()
-
-			for b.Loop() {
-				b.StopTimer()
-				mustRun(b, prog)
-				b.StartTimer()
-
-				_, err = rd.Read()
-				if err != nil {
-					b.Fatal("Can't read samples:", err)
-				}
-			}
-		})
-	}
+	b.ReportMetric(float64(readTime.Nanoseconds())/float64(b.N), "ns/op")
 }
 
 func BenchmarkReadInto(b *testing.B) {
@@ -371,16 +366,21 @@ func BenchmarkReadInto(b *testing.B) {
 	}
 	defer rd.Close()
 
+	b.ResetTimer()
 	b.ReportAllocs()
+
+	var readTime time.Duration
 
 	var rec Record
 	for b.Loop() {
-		b.StopTimer()
 		mustRun(b, prog)
-		b.StartTimer()
 
+		start := time.Now()
 		if err := rd.ReadInto(&rec); err != nil {
 			b.Fatal("Can't read samples:", err)
 		}
+		readTime += time.Since(start)
 	}
+
+	b.ReportMetric(float64(readTime.Nanoseconds())/float64(b.N), "ns/op")
 }

--- a/ringbuf/ring.go
+++ b/ringbuf/ring.go
@@ -10,53 +10,59 @@ import (
 	"github.com/cilium/ebpf/internal/sys"
 )
 
+// ringReader abstracts reading from a bpf ringbuf.
 type ringReader struct {
-	// These point into mmap'ed memory and must be accessed atomically.
-	prod_pos, cons_pos *uintptr
+	prod_pos, cons_pos *atomic.Uintptr
 
 	// Local consumer position to support reading multiple messages from the ring
 	// before committing.
 	localCons uintptr
 
+	// mask is the range of valid record start offsets, limited to the first half
+	// of the double-mapped data pages.
 	mask uintptr
-	ring []byte
+
+	// data contains the double-mapped data pages of the ringbuf.
+	data []byte
 }
 
-func newRingReader(cons_ptr, prod_ptr *uintptr, ring []byte) *ringReader {
+// newRingReader creates a new ringReader with the given producer and consumer
+// pointers and data pages.
+func newRingReader(cons_ptr, prod_ptr *atomic.Uintptr, data []byte) *ringReader {
 	return &ringReader{
 		prod_pos:  prod_ptr,
 		cons_pos:  cons_ptr,
-		localCons: *cons_ptr,
+		localCons: cons_ptr.Load(),
 		// cap is always a power of two
-		mask: uintptr(cap(ring)/2 - 1),
-		ring: ring,
+		mask: uintptr(cap(data)/2 - 1),
+		data: data,
 	}
 }
 
-// To be able to wrap around data, data pages in ring buffers are mapped twice in
-// a single contiguous virtual region.
-// Therefore the returned usable size is half the size of the mmaped region.
+// To be able to wrap around data, data pages in ring buffers are mapped twice
+// in a single contiguous virtual region. Therefore the returned usable size is
+// half the size of the mmaped region.
 func (rr *ringReader) size() int {
-	return cap(rr.ring) / 2
+	return cap(rr.data) / 2
 }
 
 // The amount of data available to read in the ring buffer. Only tracks
 // committed cursors.
 func (rr *ringReader) AvailableBytes() uint64 {
-	prod := atomic.LoadUintptr(rr.prod_pos)
-	cons := atomic.LoadUintptr(rr.cons_pos)
-	return uint64(prod - cons)
+	return uint64(rr.prod_pos.Load() - rr.cons_pos.Load())
 }
 
 // commit sets the consumer position in shared kernel memory to the local
 // consumer position.
 func (rr *ringReader) commit() {
-	atomic.StoreUintptr(rr.cons_pos, rr.localCons)
+	rr.cons_pos.Store(rr.localCons)
 }
 
 // Read a record from an event ring.
 func (rr *ringReader) readRecord(rec *Record) error {
-	prod := atomic.LoadUintptr(rr.prod_pos)
+	// Read kernel memory once per wakeup to avoid TOCTOU and unnecessary
+	// synchronization.
+	prod := rr.prod_pos.Load()
 	cons := rr.localCons
 
 	for {
@@ -71,7 +77,7 @@ func (rr *ringReader) readRecord(rec *Record) error {
 		// without BPF_RINGBUF_BUSY_BIT before the written data is visible.
 		// See https://github.com/torvalds/linux/blob/v6.8/kernel/bpf/ringbuf.c#L484
 		start := cons & rr.mask
-		len := atomic.LoadUint32((*uint32)(unsafe.Pointer(&rr.ring[start])))
+		len := atomic.LoadUint32((*uint32)(unsafe.Pointer(&rr.data[start])))
 		header := ringbufHeader{Len: len}
 
 		if header.isBusy() {
@@ -107,7 +113,7 @@ func (rr *ringReader) readRecord(rec *Record) error {
 			rec.RawSample = rec.RawSample[:n]
 		}
 
-		copy(rec.RawSample, rr.ring[start:])
+		copy(rec.RawSample, rr.data[start:])
 		rec.Remaining = int(prod - cons)
 
 		rr.localCons = cons

--- a/ringbuf/ring.go
+++ b/ringbuf/ring.go
@@ -6,7 +6,6 @@ import (
 	"sync/atomic"
 	"unsafe"
 
-	"github.com/cilium/ebpf/internal"
 	"github.com/cilium/ebpf/internal/sys"
 )
 
@@ -58,17 +57,25 @@ func (rr *ringReader) commit() {
 	rr.cons_pos.Store(rr.localCons)
 }
 
-// Read a record from an event ring.
-func (rr *ringReader) readRecord(rec *Record) error {
+// readSample returns the next sample from the ring buffer. data contains the
+// sample's bytes, remain is the remaining number of bytes in the buffer after
+// this sample.
+//
+// Returns [errEOR] if the end of the ring is reached. Any other errors indicate
+// an integrity issue with the ring and are unrecoverable, meaning the ring
+// should not be used further.
+//
+// If data and err are nil, the sample was discarded by the producer.
+func (rr *ringReader) readSample() (data []byte, remain int, err error) {
 	// Read kernel memory once per wakeup to avoid TOCTOU and unnecessary
 	// synchronization.
 	prod := rr.prod_pos.Load()
 	cons := rr.localCons
 
 	if remaining := prod - cons; remaining == 0 {
-		return errEOR
+		return nil, 0, errEOR
 	} else if remaining < sys.BPF_RINGBUF_HDR_SZ {
-		return fmt.Errorf("read record header: %w", io.ErrUnexpectedEOF)
+		return nil, 0, fmt.Errorf("read record header: %w", io.ErrUnexpectedEOF)
 	}
 
 	// read the len field of the header atomically to ensure a happens before
@@ -83,19 +90,18 @@ func (rr *ringReader) readRecord(rec *Record) error {
 		// the next sample in the ring is not committed yet so we
 		// exit without storing the reader/consumer position
 		// and start again from the same position.
-		return errBusy
+		return nil, 0, errBusy
 	}
 
 	cons += sys.BPF_RINGBUF_HDR_SZ
 
-	// Data is always padded to 8 byte alignment.
-	dataLenAligned := uintptr(internal.Align(header.dataLen(), 8))
-	if remaining := prod - cons; remaining < dataLenAligned {
-		return fmt.Errorf("read sample data: %w", io.ErrUnexpectedEOF)
+	aligned := uintptr(header.dataLenAligned())
+	if remaining := prod - cons; remaining < aligned {
+		return nil, 0, fmt.Errorf("read sample data: %w", io.ErrUnexpectedEOF)
 	}
 
 	start = cons & rr.mask
-	cons += dataLenAligned
+	cons += aligned
 
 	if header.isDiscard() {
 		// when the record header indicates that the data should be
@@ -103,19 +109,29 @@ func (rr *ringReader) readRecord(rec *Record) error {
 		// to the next record.
 		rr.localCons = cons
 		rr.commit()
-		return errDiscard
+		return nil, 0, errDiscard
 	}
-
-	if n := header.dataLen(); cap(rec.RawSample) < n {
-		rec.RawSample = make([]byte, n)
-	} else {
-		rec.RawSample = rec.RawSample[:n]
-	}
-
-	copy(rec.RawSample, rr.data[start:])
-	rec.Remaining = int(prod - cons)
 
 	rr.localCons = cons
 	rr.commit()
+
+	return rr.data[start : start+uintptr(header.dataLen())], int(prod - cons), nil
+}
+
+func (rr *ringReader) readRecord(rec *Record) error {
+	data, remain, err := rr.readSample()
+	if err != nil {
+		return err
+	}
+
+	if cap(rec.RawSample) < len(data) {
+		rec.RawSample = make([]byte, len(data))
+	} else {
+		rec.RawSample = rec.RawSample[:len(data)]
+	}
+
+	copy(rec.RawSample, data)
+	rec.Remaining = remain
+
 	return nil
 }

--- a/ringbuf/ring.go
+++ b/ringbuf/ring.go
@@ -3,6 +3,7 @@ package ringbuf
 import (
 	"fmt"
 	"io"
+	"runtime"
 	"sync/atomic"
 	"unsafe"
 
@@ -83,14 +84,19 @@ func (rr *ringReader) readSample() (data []byte, remain int, err error) {
 	// without BPF_RINGBUF_BUSY_BIT before the written data is visible.
 	// See https://github.com/torvalds/linux/blob/v6.8/kernel/bpf/ringbuf.c#L484
 	start := cons & rr.mask
-	len := atomic.LoadUint32((*uint32)(unsafe.Pointer(&rr.data[start])))
-	header := ringbufHeader{Len: len}
+	header := ringbufHeader{}
 
+retry:
+	header.Len = atomic.LoadUint32((*uint32)(unsafe.Pointer(&rr.data[start])))
 	if header.isBusy() {
-		// the next sample in the ring is not committed yet so we
-		// exit without storing the reader/consumer position
-		// and start again from the same position.
-		return nil, 0, errBusy
+		// Sample has not been committed by the bpf program yet but should be
+		// soon. Busypoll without advancing the consumer position.
+
+		// Yield the OS thread to give other goroutines a chance to run. The bpf
+		// side is copying memory into the sample.
+		runtime.Gosched()
+
+		goto retry
 	}
 
 	cons += sys.BPF_RINGBUF_HDR_SZ
@@ -103,25 +109,30 @@ func (rr *ringReader) readSample() (data []byte, remain int, err error) {
 	start = cons & rr.mask
 	cons += aligned
 
-	if header.isDiscard() {
-		// when the record header indicates that the data should be
-		// discarded, we skip it by just updating the consumer position
-		// to the next record.
-		rr.localCons = cons
-		rr.commit()
-		return nil, 0, errDiscard
-	}
-
 	rr.localCons = cons
 	rr.commit()
 
-	return rr.data[start : start+uintptr(header.dataLen())], int(prod - cons), nil
+	remain = int(prod - cons)
+	data = rr.data[start : start+uintptr(header.dataLen())]
+
+	if header.isDiscard() {
+		// Ringbuf space was reserved but then discarded. The consumer needs to
+		// advance, but the sample data should not be returned.
+		return nil, remain, nil
+	}
+
+	return data, remain, nil
 }
 
 func (rr *ringReader) readRecord(rec *Record) error {
+retry:
 	data, remain, err := rr.readSample()
 	if err != nil {
 		return err
+	}
+	if data == nil {
+		// Sample was discarded, try to read the next one.
+		goto retry
 	}
 
 	if cap(rec.RawSample) < len(data) {

--- a/ringbuf/ring.go
+++ b/ringbuf/ring.go
@@ -65,59 +65,57 @@ func (rr *ringReader) readRecord(rec *Record) error {
 	prod := rr.prod_pos.Load()
 	cons := rr.localCons
 
-	for {
-		if remaining := prod - cons; remaining == 0 {
-			return errEOR
-		} else if remaining < sys.BPF_RINGBUF_HDR_SZ {
-			return fmt.Errorf("read record header: %w", io.ErrUnexpectedEOF)
-		}
+	if remaining := prod - cons; remaining == 0 {
+		return errEOR
+	} else if remaining < sys.BPF_RINGBUF_HDR_SZ {
+		return fmt.Errorf("read record header: %w", io.ErrUnexpectedEOF)
+	}
 
-		// read the len field of the header atomically to ensure a happens before
-		// relationship with the xchg in the kernel. Without this we may see len
-		// without BPF_RINGBUF_BUSY_BIT before the written data is visible.
-		// See https://github.com/torvalds/linux/blob/v6.8/kernel/bpf/ringbuf.c#L484
-		start := cons & rr.mask
-		len := atomic.LoadUint32((*uint32)(unsafe.Pointer(&rr.data[start])))
-		header := ringbufHeader{Len: len}
+	// read the len field of the header atomically to ensure a happens before
+	// relationship with the xchg in the kernel. Without this we may see len
+	// without BPF_RINGBUF_BUSY_BIT before the written data is visible.
+	// See https://github.com/torvalds/linux/blob/v6.8/kernel/bpf/ringbuf.c#L484
+	start := cons & rr.mask
+	len := atomic.LoadUint32((*uint32)(unsafe.Pointer(&rr.data[start])))
+	header := ringbufHeader{Len: len}
 
-		if header.isBusy() {
-			// the next sample in the ring is not committed yet so we
-			// exit without storing the reader/consumer position
-			// and start again from the same position.
-			return errBusy
-		}
+	if header.isBusy() {
+		// the next sample in the ring is not committed yet so we
+		// exit without storing the reader/consumer position
+		// and start again from the same position.
+		return errBusy
+	}
 
-		cons += sys.BPF_RINGBUF_HDR_SZ
+	cons += sys.BPF_RINGBUF_HDR_SZ
 
-		// Data is always padded to 8 byte alignment.
-		dataLenAligned := uintptr(internal.Align(header.dataLen(), 8))
-		if remaining := prod - cons; remaining < dataLenAligned {
-			return fmt.Errorf("read sample data: %w", io.ErrUnexpectedEOF)
-		}
+	// Data is always padded to 8 byte alignment.
+	dataLenAligned := uintptr(internal.Align(header.dataLen(), 8))
+	if remaining := prod - cons; remaining < dataLenAligned {
+		return fmt.Errorf("read sample data: %w", io.ErrUnexpectedEOF)
+	}
 
-		start = cons & rr.mask
-		cons += dataLenAligned
+	start = cons & rr.mask
+	cons += dataLenAligned
 
-		if header.isDiscard() {
-			// when the record header indicates that the data should be
-			// discarded, we skip it by just updating the consumer position
-			// to the next record.
-			rr.localCons = cons
-			rr.commit()
-			continue
-		}
-
-		if n := header.dataLen(); cap(rec.RawSample) < n {
-			rec.RawSample = make([]byte, n)
-		} else {
-			rec.RawSample = rec.RawSample[:n]
-		}
-
-		copy(rec.RawSample, rr.data[start:])
-		rec.Remaining = int(prod - cons)
-
+	if header.isDiscard() {
+		// when the record header indicates that the data should be
+		// discarded, we skip it by just updating the consumer position
+		// to the next record.
 		rr.localCons = cons
 		rr.commit()
-		return nil
+		return errDiscard
 	}
+
+	if n := header.dataLen(); cap(rec.RawSample) < n {
+		rec.RawSample = make([]byte, n)
+	} else {
+		rec.RawSample = rec.RawSample[:n]
+	}
+
+	copy(rec.RawSample, rr.data[start:])
+	rec.Remaining = int(prod - cons)
+
+	rr.localCons = cons
+	rr.commit()
+	return nil
 }

--- a/ringbuf/ring.go
+++ b/ringbuf/ring.go
@@ -13,14 +13,20 @@ import (
 type ringReader struct {
 	// These point into mmap'ed memory and must be accessed atomically.
 	prod_pos, cons_pos *uintptr
-	mask               uintptr
-	ring               []byte
+
+	// Local consumer position to support reading multiple messages from the ring
+	// before committing.
+	localCons uintptr
+
+	mask uintptr
+	ring []byte
 }
 
 func newRingReader(cons_ptr, prod_ptr *uintptr, ring []byte) *ringReader {
 	return &ringReader{
-		prod_pos: prod_ptr,
-		cons_pos: cons_ptr,
+		prod_pos:  prod_ptr,
+		cons_pos:  cons_ptr,
+		localCons: *cons_ptr,
 		// cap is always a power of two
 		mask: uintptr(cap(ring)/2 - 1),
 		ring: ring,
@@ -34,17 +40,24 @@ func (rr *ringReader) size() int {
 	return cap(rr.ring) / 2
 }
 
-// The amount of data available to read in the ring buffer.
+// The amount of data available to read in the ring buffer. Only tracks
+// committed cursors.
 func (rr *ringReader) AvailableBytes() uint64 {
 	prod := atomic.LoadUintptr(rr.prod_pos)
 	cons := atomic.LoadUintptr(rr.cons_pos)
 	return uint64(prod - cons)
 }
 
+// commit sets the consumer position in shared kernel memory to the local
+// consumer position.
+func (rr *ringReader) commit() {
+	atomic.StoreUintptr(rr.cons_pos, rr.localCons)
+}
+
 // Read a record from an event ring.
 func (rr *ringReader) readRecord(rec *Record) error {
 	prod := atomic.LoadUintptr(rr.prod_pos)
-	cons := atomic.LoadUintptr(rr.cons_pos)
+	cons := rr.localCons
 
 	for {
 		if remaining := prod - cons; remaining == 0 {
@@ -58,7 +71,7 @@ func (rr *ringReader) readRecord(rec *Record) error {
 		// without BPF_RINGBUF_BUSY_BIT before the written data is visible.
 		// See https://github.com/torvalds/linux/blob/v6.8/kernel/bpf/ringbuf.c#L484
 		start := cons & rr.mask
-		len := atomic.LoadUint32((*uint32)((unsafe.Pointer)(&rr.ring[start])))
+		len := atomic.LoadUint32((*uint32)(unsafe.Pointer(&rr.ring[start])))
 		header := ringbufHeader{Len: len}
 
 		if header.isBusy() {
@@ -83,7 +96,8 @@ func (rr *ringReader) readRecord(rec *Record) error {
 			// when the record header indicates that the data should be
 			// discarded, we skip it by just updating the consumer position
 			// to the next record.
-			atomic.StoreUintptr(rr.cons_pos, cons)
+			rr.localCons = cons
+			rr.commit()
 			continue
 		}
 
@@ -95,7 +109,9 @@ func (rr *ringReader) readRecord(rec *Record) error {
 
 		copy(rec.RawSample, rr.ring[start:])
 		rec.Remaining = int(prod - cons)
-		atomic.StoreUintptr(rr.cons_pos, cons)
+
+		rr.localCons = cons
+		rr.commit()
 		return nil
 	}
 }

--- a/ringbuf/ring.go
+++ b/ringbuf/ring.go
@@ -125,29 +125,3 @@ retry:
 
 	return data, remain, nil
 }
-
-func (rr *ringReader) readRecord(rec *Record) error {
-retry:
-	data, remain, err := rr.readSample()
-	if err != nil {
-		return err
-	}
-
-	rr.commit()
-
-	if data == nil {
-		// Sample was discarded, try to read the next one.
-		goto retry
-	}
-
-	if cap(rec.RawSample) < len(data) {
-		rec.RawSample = make([]byte, len(data))
-	} else {
-		rec.RawSample = rec.RawSample[:len(data)]
-	}
-
-	copy(rec.RawSample, data)
-	rec.Remaining = remain
-
-	return nil
-}

--- a/ringbuf/ring.go
+++ b/ringbuf/ring.go
@@ -67,6 +67,9 @@ func (rr *ringReader) commit() {
 // should not be used further.
 //
 // If data and err are nil, the sample was discarded by the producer.
+//
+// [ringReader.commit] must be called to advance the consumer position after
+// every nil error, even if data is nil.
 func (rr *ringReader) readSample() (data []byte, remain int, err error) {
 	// Read kernel memory once per wakeup to avoid TOCTOU and unnecessary
 	// synchronization.
@@ -110,7 +113,6 @@ retry:
 	cons += aligned
 
 	rr.localCons = cons
-	rr.commit()
 
 	remain = int(prod - cons)
 	data = rr.data[start : start+uintptr(header.dataLen())]
@@ -130,6 +132,9 @@ retry:
 	if err != nil {
 		return err
 	}
+
+	rr.commit()
+
 	if data == nil {
 		// Sample was discarded, try to read the next one.
 		goto retry

--- a/ringbuf/ring.go
+++ b/ringbuf/ring.go
@@ -47,8 +47,8 @@ func (rr *ringReader) size() int {
 
 // The amount of data available to read in the ring buffer. Only tracks
 // committed cursors.
-func (rr *ringReader) AvailableBytes() uint64 {
-	return uint64(rr.prod_pos.Load() - rr.cons_pos.Load())
+func (rr *ringReader) available() int {
+	return int(rr.prod_pos.Load() - rr.cons_pos.Load())
 }
 
 // commit sets the consumer position in shared kernel memory to the local

--- a/ringbuf/ring_other.go
+++ b/ringbuf/ring_other.go
@@ -58,7 +58,7 @@ func newRingBufEventRing(mapFD, size int) (*mmapEventRing, error) {
 	return ring, nil
 }
 
-func (ring *mmapEventRing) Close() error {
+func (ring *mmapEventRing) close() error {
 	ring.cleanup.Stop()
 
 	prod, cons := ring.prod, ring.cons

--- a/ringbuf/ring_other.go
+++ b/ringbuf/ring_other.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"sync/atomic"
 	"unsafe"
 
 	"github.com/cilium/ebpf/internal/unix"
@@ -22,23 +23,31 @@ type mmapEventRing struct {
 }
 
 func newRingBufEventRing(mapFD, size int) (*mmapEventRing, error) {
+	// The kernel lays out the ring buffer as follows:
+	//
+	// | consumer page | producer page | data pages | double-mapped data pages |
+	//
+	// Double-mapping the data pages allows for contiguous reads when they wrap
+	// around the end of the buffer.
 	cons, err := unix.Mmap(mapFD, 0, os.Getpagesize(), unix.PROT_READ|unix.PROT_WRITE, unix.MAP_SHARED)
 	if err != nil {
 		return nil, fmt.Errorf("mmap consumer page: %w", err)
 	}
+	// Consumer position is a uint at the start of the consumer page.
+	cons_pos := (*atomic.Uintptr)(unsafe.Pointer(unsafe.SliceData(cons)))
 
-	prod, err := unix.Mmap(mapFD, (int64)(os.Getpagesize()), os.Getpagesize()+2*size, unix.PROT_READ, unix.MAP_SHARED)
+	prod, err := unix.Mmap(mapFD, int64(os.Getpagesize()), os.Getpagesize()+2*size, unix.PROT_READ, unix.MAP_SHARED)
 	if err != nil {
 		_ = unix.Munmap(cons)
 		return nil, fmt.Errorf("mmap data pages: %w", err)
 	}
-
-	cons_pos := (*uintptr)(unsafe.Pointer(&cons[0]))
-	prod_pos := (*uintptr)(unsafe.Pointer(&prod[0]))
+	// Producer position is a uint at the start of the producer page.
+	prod_pos := (*atomic.Uintptr)(unsafe.Pointer(unsafe.SliceData(prod)))
 
 	ring := &mmapEventRing{
-		prod:       prod,
-		cons:       cons,
+		prod: prod,
+		cons: cons,
+		// Data pages start after the first producer page.
 		ringReader: newRingReader(cons_pos, prod_pos, prod[os.Getpagesize():]),
 	}
 	ring.cleanup = runtime.AddCleanup(ring, func(*byte) {

--- a/ringbuf/ring_windows.go
+++ b/ringbuf/ring_windows.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"runtime"
+	"sync/atomic"
 	"unsafe"
 
 	"github.com/cilium/ebpf/internal/efw"
@@ -44,8 +45,8 @@ func newRingBufEventRing(mapFD, size int) (*windowsEventRing, error) {
 	}
 
 	// consPtr and prodPtr are guaranteed to be page size aligned.
-	consPos := (*uintptr)(unsafe.Pointer(consPtr))
-	prodPos := (*uintptr)(unsafe.Pointer(prodPtr))
+	consPos := (*atomic.Uintptr)(unsafe.Pointer(consPtr))
+	prodPos := (*atomic.Uintptr)(unsafe.Pointer(prodPtr))
 	data := unsafe.Slice(dataPtr, dataLen*2)
 
 	ring := &windowsEventRing{

--- a/ringbuf/ring_windows.go
+++ b/ringbuf/ring_windows.go
@@ -63,7 +63,7 @@ func newRingBufEventRing(mapFD, size int) (*windowsEventRing, error) {
 	return ring, nil
 }
 
-func (ring *windowsEventRing) Close() error {
+func (ring *windowsEventRing) close() error {
 	ring.cleanup.Stop()
 
 	return errors.Join(


### PR DESCRIPTION
This PR introduces a lower-level API, `ringbuf.RawReader`, to solve two main use cases: batching commits and zero-copy reading. The existing interfaces, Read() and ReadInto(), were rebased on top of the new RawReader for dogfooding and example purposes.

A few of the prior proposals that inspired this work:
- https://github.com/cilium/ebpf/pull/1979
- https://github.com/cilium/ebpf/pull/1981
- https://github.com/cilium/ebpf/pull/1968