### PR TITLE
Preserve verifier logs on EFAULT

### DIFF
--- a/prog.go
+++ b/prog.go
@@ -517,6 +517,10 @@ func newProgramWithOptions(spec *ProgramSpec, opts ProgramOptions, c *btf.Cache)
 		return nil, fmt.Errorf("load program: %w", err)
 	}
 
+	return nil, programLoadError(err, logBuf, spec)
+}
+
+func programLoadError(err error, logBuf []byte, spec *ProgramSpec) error {
 	end := bytes.IndexByte(logBuf, 0)
 	if end < 0 {
 		end = len(logBuf)
@@ -528,14 +532,16 @@ func newProgramWithOptions(spec *ProgramSpec, opts ProgramOptions, c *btf.Cache)
 		if len(logBuf) > 0 && logBuf[0] == 0 {
 			// EPERM due to RLIMIT_MEMLOCK happens before the verifier, so we can
 			// check that the log is empty to reduce false positives.
-			return nil, fmt.Errorf("load program: %w (MEMLOCK may be too low, consider rlimit.RemoveMemlock)", err)
+			return fmt.Errorf("load program: %w (MEMLOCK may be too low, consider rlimit.RemoveMemlock)", err)
 		}
 
 	case errors.Is(err, unix.EFAULT):
 		// EFAULT is returned when the kernel hits a verifier bug, and always
 		// overrides ENOSPC, defeating the buffer growth strategy. Warn the user
-		// that they may need to increase the buffer size manually.
-		return nil, fmt.Errorf("load program: %w (hit verifier bug, increase LogSizeStart to fit the log and check dmesg)", err)
+		// that they may need to increase the buffer size manually. Preserve the
+		// verifier log when it contains the actual rejection reason.
+		return fmt.Errorf("load program: %w (increase LogSizeStart to fit the log and check dmesg)",
+			internal.ErrorWithLog("hit verifier bug", err, logBuf))
 
 	case errors.Is(err, unix.EINVAL):
 		if bytes.Contains(tail, coreBadCall) {
@@ -557,11 +563,11 @@ func newProgramWithOptions(spec *ProgramSpec, opts ProgramOptions, c *btf.Cache)
 	if (errors.Is(err, unix.EINVAL) || errors.Is(err, unix.EPERM)) &&
 		hasFunctionReferences(spec.Instructions) {
 		if err := haveBPFToBPFCalls(); err != nil {
-			return nil, fmt.Errorf("load program: %w", err)
+			return fmt.Errorf("load program: %w", err)
 		}
 	}
 
-	return nil, internal.ErrorWithLog("load program", err, logBuf)
+	return internal.ErrorWithLog("load program", err, logBuf)
 }
 
 func retryLogAttrs(attr *sys.ProgLoadAttr, startSize uint32, err error) bool {

--- a/prog_test.go
+++ b/prog_test.go
@@ -462,6 +462,15 @@ func TestProgramVerifierLogRetry(t *testing.T) {
 	})
 }
 
+func TestProgramVerifierLogEFAULT(t *testing.T) {
+	err := programLoadError(unix.EFAULT, []byte("some\nmessage\000"), basicProgramSpec)
+
+	var ve *VerifierError
+	qt.Assert(t, qt.ErrorAs(err, &ve))
+	qt.Assert(t, qt.ErrorIs(err, unix.EFAULT))
+	qt.Assert(t, qt.HasLen(ve.Log, 2))
+}
+
 func TestProgramWithUnsatisfiedMap(t *testing.T) {
 	coll, err := LoadCollectionSpec("testdata/loader-el.elf")
 	if err != nil {


### PR DESCRIPTION
Fixes #2003

When program load fails with `EFAULT`, we currently drop verifier output and only return the generic hint.
That is kinda rough on older kernels, because the partial log can still show the real reject reason.

This keeps the hint, but if the verifier already wrote something we return it as `VerifierError` instead of hiding it.

How to repro

1. Use a kernel where verifier log growth gets short-circuited by `EFAULT`. The report in #2003 hit this on kernels starting at 5.4.
2. Load a program that trips this path. In #2003 the log already had `The sequence of 8193 jumps is too complex.`
3. Current output is only `load program: bad address (hit verifier bug, increase LogSizeStart to fit the log and check dmesg)`
4. With this patch you still get that hint, plus the captured verifier lines, so debugging is not blind anymore.
