### PR TITLE
link: add Info() support for Iter link type

### DIFF
--- a/internal/sys/syscall.go
+++ b/internal/sys/syscall.go
@@ -81,6 +81,10 @@ func (i *RawTracepointLinkInfo) info() (unsafe.Pointer, uint32) {
 	return unsafe.Pointer(i), uint32(unsafe.Sizeof(*i))
 }
 
+func (i *IterLinkInfo) info() (unsafe.Pointer, uint32) {
+	return unsafe.Pointer(i), uint32(unsafe.Sizeof(*i))
+}
+
 func (i *KprobeLinkInfo) info() (unsafe.Pointer, uint32) {
 	return unsafe.Pointer(i), uint32(unsafe.Sizeof(*i))
 }

--- a/link/iter.go
+++ b/link/iter.go
@@ -64,6 +64,20 @@ type Iter struct {
 	RawLink
 }
 
+func (it *Iter) Info() (*Info, error) {
+	var info sys.IterLinkInfo
+	name, err := queryInfoWithString(it.fd, &info, &info.TargetName, &info.TargetNameLen)
+	if err != nil {
+		return nil, err
+	}
+	return &Info{
+		info.Type,
+		info.Id,
+		ebpf.ProgramID(info.ProgId),
+		&IterInfo{TargetName: name},
+	}, nil
+}
+
 // Open creates a new instance of the iterator.
 //
 // Reading from the returned reader triggers the BPF program.

--- a/link/iter_test.go
+++ b/link/iter_test.go
@@ -6,9 +6,27 @@ import (
 	"io"
 	"testing"
 
+	"github.com/go-quicktest/qt"
+
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/internal/testutils"
 )
+
+func TestIterInfo(t *testing.T) {
+	testutils.SkipOnOldKernel(t, "5.9", "bpf_map iter")
+
+	prog := mustLoadProgram(t, ebpf.Tracing, ebpf.AttachTraceIter, "bpf_map")
+
+	it, err := AttachIter(IterOptions{Program: prog})
+	qt.Assert(t, qt.IsNil(err))
+	defer it.Close()
+
+	info, err := it.Info()
+	qt.Assert(t, qt.IsNil(err))
+	qt.Assert(t, qt.Equals(IterType, info.Type))
+	iterInfo := info.Iter()
+	qt.Assert(t, qt.Equals(iterInfo.TargetName, "bpf_map"))
+}
 
 func TestIter(t *testing.T) {
 	testutils.SkipOnOldKernel(t, "5.9", "bpf_map iter")

--- a/link/link_other.go
+++ b/link/link_other.go
@@ -152,6 +152,10 @@ type RawTracepointInfo struct {
 	Name string
 }
 
+type IterInfo struct {
+	TargetName string
+}
+
 type KprobeMultiInfo struct {
 	// Count is the number of addresses hooked by the kprobe.
 	Count   uint32
@@ -378,5 +382,13 @@ func (r Info) PerfEvent() *PerfEventInfo {
 // Returns nil if the type-specific link info isn't available.
 func (r Info) RawTracepoint() *RawTracepointInfo {
 	e, _ := r.extra.(*RawTracepointInfo)
+	return e
+}
+
+// Iter returns iter type-specific link info.
+//
+// Returns nil if the type-specific link info isn't available.
+func (r Info) Iter() *IterInfo {
+	e, _ := r.extra.(*IterInfo)
 	return e
 }


### PR DESCRIPTION
Implements Info() on the Iter link type, returning IterInfo with
the iterator's TargetName (e.g. "bpf_map", "task").

Also adds IterLinkInfo.info() to internal/sys to satisfy the
sys.Info interface required by queryInfoWithString.

Related to #506