### PR TITLE
fix: avoid arm64 flake in TestProgramStats

### DIFF
--- a/info_test.go
+++ b/info_test.go
@@ -458,6 +458,7 @@ func testStats(tb testing.TB, prog *Program) error {
 	tb.Helper()
 
 	in := internal.EmptyBPFContext
+	const minRepeatForRuntimeStats = 1024
 
 	stats, err := EnableStats(uint32(sys.BPF_STATS_RUN_TIME))
 	if err != nil {
@@ -466,8 +467,10 @@ func testStats(tb testing.TB, prog *Program) error {
 	defer stats.Close()
 
 	// Program execution with runtime statistics enabled.
+	// Run the program several times in one go to avoid flaking on architectures
+	// where a single execution may round down to 0ns in the kernel stats.
 	// Should increase both runtime and run counter.
-	mustRun(tb, prog, &RunOptions{Data: in})
+	mustRun(tb, prog, &RunOptions{Data: in, Repeat: minRepeatForRuntimeStats})
 
 	s1, err := prog.Stats()
 	qt.Assert(tb, qt.IsNil(err))


### PR DESCRIPTION
arm64 still flakes here.

`#1684` skipped the first arm64 runtime check, but `testStats()` still expects `Runtime != 0` after one run. `3ece212` moved that assertion into the helper, so the same edge case is still there.

This bumps the first stats-enabled run to `Repeat: 1024`. Same test intent, just a bit more signal so `0ns` stops sneaking through.

How to repro
1. Run arm64 CI a few times.
2. Or on an arm64 box run `go test -exec sudo . -run TestProgramStats -count=100`.
3. Watch for `expected runtime to be at least 1ns after first invocation`.

Related: #1683, #1460
