### PR TITLE
ci: clean up arm64 exceptions and add retries in TestProgramStats

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,7 +218,6 @@ jobs:
           path: junit.xml
 
       - name: Show dmesg
-        if: failure()
         run: |
           sudo dmesg
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,7 +191,7 @@ jobs:
     runs-on: ubuntu-24.04-arm64
     timeout-minutes: 15
     env:
-      EBPF_TEST_IGNORE_VERSION: 'TestKprobeMulti,TestKprobeMultiErrors,TestKprobeMultiCookie,TestKprobeMultiProgramCall,TestHaveBPFLinkKprobeMulti,TestKprobeSession,TestHaveBPFLinkKprobeSession,TestHaveProgramType/LircMode2'
+      EBPF_TEST_IGNORE_VERSION: 'TestHaveProgramType/LircMode2'
     steps:
       - uses: actions/checkout@v6
 

--- a/info_test.go
+++ b/info_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"reflect"
-	"runtime"
 	"strings"
 	"testing"
 
@@ -416,31 +415,11 @@ func TestProgramStats(t *testing.T) {
 
 	qt.Assert(t, qt.Equals(s.RunCount, 0))
 	qt.Assert(t, qt.Equals(s.RecursionMisses, 0))
-
-	if runtime.GOARCH != "arm64" {
-		// Runtime is flaky on arm64.
-		qt.Assert(t, qt.Equals(s.Runtime, 0))
-	}
+	qt.Assert(t, qt.Equals(s.Runtime, 0))
 
 	if err := testStats(t, prog); err != nil {
 		testutils.SkipIfNotSupportedOnOS(t, err)
 		t.Error(err)
-	}
-}
-
-// BenchmarkStats is a benchmark of TestStats. See testStats for details.
-func BenchmarkStats(b *testing.B) {
-	b.ReportAllocs()
-
-	testutils.SkipOnOldKernel(b, "5.8", "BPF_ENABLE_STATS")
-
-	prog := createBasicProgram(b)
-
-	for b.Loop() {
-		if err := testStats(b, prog); err != nil {
-			testutils.SkipIfNotSupportedOnOS(b, err)
-			b.Fatal(err)
-		}
 	}
 }
 
@@ -465,9 +444,12 @@ func testStats(tb testing.TB, prog *Program) error {
 	}
 	defer stats.Close()
 
-	// Program execution with runtime statistics enabled.
-	// Should increase both runtime and run counter.
-	mustRun(tb, prog, &RunOptions{Data: in})
+	// Program execution with runtime statistics enabled. Should increase both
+	// runtime and run counter.
+	//
+	// Run multiple times to avoid 0ns runtimes due to (potential) quantization
+	// errors on virtualized hardware.
+	mustRun(tb, prog, &RunOptions{Data: in, Repeat: 10})
 
 	s1, err := prog.Stats()
 	qt.Assert(tb, qt.IsNil(err))


### PR DESCRIPTION
According to Claude, there are multiple reasons why a zero runtime could be happening, but most likely this is due to timer resolution on CI machines not living up to the expectations.

__bpf_prog_run calls sched_clock(), runs the program, calls sched_clock() again and subtracts the second from the first. Fairly standard stuff. On arm64, the timer backing sched_clock() (CNTFRQ_EL0) is programmed by the firmware or hypervisor, and is allowed to be a smoothed, synthesized value based on a lower-resolution hardware clock. The likelyhood of timer coalescing in VMs, especially in CI environments, is pretty significant.

Even though our arm64 CI machines report a 1GHz clock:
```
sched_clock: 61 bits at 1000MHz, resolution 1ns, wraps every 4398046511103ns
```
That doesn't mean the hypervisor isn't allowed to update it more slowly under
stress.

Let's try with 10 repeats to reduce the likelihood of the timer not advancing during prog_run. Remove BenchmarkStats since it's completely skewed with the added repeats and doesn't add much value anyway. 10 consecutive CI re-runs did not yield a flake.

Also remove the exceptions for kprobe multi/session, and log dmesg on every CI run.

Closes https://github.com/cilium/ebpf/issues/1460
Closes https://github.com/cilium/ebpf/issues/1683
Supersedes https://github.com/cilium/ebpf/pull/2046