### PR TITLE
fix: unmarshal only returned batch lookup entries

### DIFF
--- a/map.go
+++ b/map.go
@@ -1301,7 +1301,7 @@ func (m *Map) batchLookup(cmd sys.Cmd, cursor *MapBatchCursor, keysOut, valuesOu
 		return 0, sysErr
 	}
 
-	err = valueBuf.Unmarshal(valuesOut)
+	err = unmarshalBatchSliceOutput(valuesOut, n, int(m.fullValueSize), valueBuf)
 	if err != nil {
 		return 0, err
 	}
@@ -1323,7 +1323,17 @@ func (m *Map) batchLookupPerCPU(cmd sys.Cmd, cursor *MapBatchCursor, keysOut, va
 	}
 
 	if bytesBuf := valueBuf.Bytes(); bytesBuf != nil {
-		err = unmarshalBatchPerCPUValue(valuesOut, count, int(m.valueSize), bytesBuf)
+		if n < count {
+			possibleCPUs, err := PossibleCPU()
+			if err != nil {
+				return 0, err
+			}
+
+			valuesOut = reflect.ValueOf(valuesOut).Slice(0, n*possibleCPUs).Interface()
+			bytesBuf = bytesBuf[:n*int(m.fullValueSize)]
+		}
+
+		err = unmarshalBatchPerCPUValue(valuesOut, n, int(m.valueSize), bytesBuf)
 		if err != nil {
 			return 0, err
 		}
@@ -1380,11 +1390,31 @@ func (m *Map) batchLookupCmd(cmd sys.Cmd, cursor *MapBatchCursor, count int, key
 		return 0, sysErr
 	}
 
-	if err := keyBuf.Unmarshal(keysOut); err != nil {
+	n := int(attr.Count)
+	if err := unmarshalBatchSliceOutput(keysOut, n, int(m.keySize), keyBuf); err != nil {
 		return 0, err
 	}
 
-	return int(attr.Count), sysErr
+	return n, sysErr
+}
+
+func unmarshalBatchSliceOutput(out any, count, elemSize int, buf sysenc.Buffer) error {
+	bytesBuf := buf.Bytes()
+	if bytesBuf == nil {
+		return nil
+	}
+
+	fullCount, err := sliceLen(out)
+	if err != nil {
+		return err
+	}
+
+	if count < fullCount {
+		out = reflect.ValueOf(out).Slice(0, count).Interface()
+		bytesBuf = bytesBuf[:count*elemSize]
+	}
+
+	return sysenc.Unmarshal(out, bytesBuf)
 }
 
 // BatchUpdate updates the map with multiple keys and values

--- a/map_test.go
+++ b/map_test.go
@@ -1046,6 +1046,25 @@ func (c customTestUnmarshaler) UnmarshalBinary(data []byte) error {
 	return nil
 }
 
+var (
+	customTestKeyUnmarshalSizes   []int
+	customTestValueUnmarshalSizes []int
+)
+
+type recordingKeyUnmarshaler []uint8
+
+func (r recordingKeyUnmarshaler) UnmarshalBinary(data []byte) error {
+	customTestKeyUnmarshalSizes = append(customTestKeyUnmarshalSizes, len(data))
+	return customTestUnmarshaler(r).UnmarshalBinary(data)
+}
+
+type recordingValueUnmarshaler []uint8
+
+func (r recordingValueUnmarshaler) UnmarshalBinary(data []byte) error {
+	customTestValueUnmarshalSizes = append(customTestValueUnmarshalSizes, len(data))
+	return customTestUnmarshaler(r).UnmarshalBinary(data)
+}
+
 func TestMapBatchLookupCustomUnmarshaler(t *testing.T) {
 	testutils.SkipIfNotSupported(t, haveBatchAPI())
 
@@ -1067,11 +1086,13 @@ func TestMapBatchLookupCustomUnmarshaler(t *testing.T) {
 		// map keys and values. Otherwise their memory is used as backing
 		// memory for the syscall directly and Unmarshal is a no-op.
 		// Use batch size that results in partial second lookup.
-		batchKeys   = make(customTestUnmarshaler, 2)
-		batchValues = make(customTestUnmarshaler, 2)
+		batchKeys   = make(recordingKeyUnmarshaler, 2)
+		batchValues = make(recordingValueUnmarshaler, 2)
 		keys        []uint8
 		values      []uint8
 	)
+	customTestKeyUnmarshalSizes = nil
+	customTestValueUnmarshalSizes = nil
 
 	_, err := m.BatchLookup(&cursor, batchKeys, batchValues, nil)
 	if err != nil {
@@ -1091,6 +1112,8 @@ func TestMapBatchLookupCustomUnmarshaler(t *testing.T) {
 
 	qt.Assert(t, qt.DeepEquals(keys, []uint8{0, 1, 2}))
 	qt.Assert(t, qt.DeepEquals(values, []uint8{3, 4, 5}))
+	qt.Assert(t, qt.DeepEquals(customTestKeyUnmarshalSizes, []int{8, 4}))
+	qt.Assert(t, qt.DeepEquals(customTestValueUnmarshalSizes, []int{8, 4}))
 }
 
 func TestMapIterateHashKeyOneByteFull(t *testing.T) {


### PR DESCRIPTION
last partial batches still get unmarshaled like they were full size. this narrows batch lookup decode to the count actually returned by the kernel, including the partial final batch case.

the test coverage focuses on the non-zero-copy partial batch path in `TestMapBatchLookupCustomUnmarshaler` and verifies that keys and values are only decoded for the entries returned by the kernel.

repro:
`go test -exec sudo . -run TestMapBatchLookupCustomUnmarshaler`

Fixes #1080
Related: #1741