### PR TITLE
btf: unexport decoder.TypesByName

### DIFF
--- a/btf/btf.go
+++ b/btf/btf.go
@@ -2,6 +2,7 @@ package btf
 
 import (
 	"debug/elf"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
@@ -43,10 +44,20 @@ type elfSymbol struct {
 // Spec allows querying a set of Types and loading the set into the
 // kernel.
 type Spec struct {
-	*decoder
+	d *decoder
 
 	// Additional data from ELF, may be nil.
 	elf *elfData
+}
+
+// byteOrder returns the byte order of the encoded BTF.
+func (s *Spec) byteOrder() binary.ByteOrder {
+	return s.d.byteOrder
+}
+
+// strings returns the string table of the encoded BTF.
+func (s *Spec) strings() *stringTable {
+	return s.d.strings
 }
 
 // LoadSpec opens file and calls LoadSpecFromReader on it.
@@ -179,8 +190,8 @@ func loadSpecFromELF(file *internal.SafeELFFile) (*Spec, error) {
 		return nil, err
 	}
 
-	if spec.decoder.byteOrder != file.ByteOrder {
-		return nil, fmt.Errorf("BTF byte order %s does not match ELF byte order %s", spec.decoder.byteOrder, file.ByteOrder)
+	if spec.byteOrder() != file.ByteOrder {
+		return nil, fmt.Errorf("BTF byte order %s does not match ELF byte order %s", spec.byteOrder(), file.ByteOrder)
 	}
 
 	spec.elf = &elfData{
@@ -200,8 +211,8 @@ func loadRawSpec(btf []byte, base *Spec) (*Spec, error) {
 	)
 
 	if base != nil {
-		baseDecoder = base.decoder
-		baseStrings = base.strings
+		baseDecoder = base.d
+		baseStrings = base.d.strings
 	}
 
 	header, _, bo, err := parseBTFHeader(btf)
@@ -350,7 +361,7 @@ func (s *Spec) Copy() *Spec {
 	}
 
 	cpy := &Spec{
-		s.decoder.Copy(),
+		s.d.copy(nil),
 		nil,
 	}
 
@@ -370,7 +381,7 @@ func (s *Spec) Copy() *Spec {
 // Returns an error wrapping ErrNotFound if a Type with the given ID
 // does not exist in the Spec.
 func (s *Spec) TypeByID(id TypeID) (Type, error) {
-	typ, err := s.decoder.TypeByID(id)
+	typ, err := s.d.typeByID(id)
 	if err != nil {
 		return nil, fmt.Errorf("inflate type: %w", err)
 	}
@@ -386,7 +397,7 @@ func (s *Spec) TypeByID(id TypeID) (Type, error) {
 //
 // Returns an error wrapping [ErrNotFound] if the type isn't part of the Spec.
 func (s *Spec) TypeID(typ Type) (TypeID, error) {
-	return s.decoder.TypeID(typ)
+	return s.d.typeID(typ)
 }
 
 // AnyTypesByName returns a list of BTF Types with the given name.
@@ -397,7 +408,7 @@ func (s *Spec) TypeID(typ Type) (TypeID, error) {
 //
 // Returns an error wrapping ErrNotFound if no matching Type exists in the Spec.
 func (s *Spec) AnyTypesByName(name string) ([]Type, error) {
-	types, err := s.TypesByName(newEssentialName(name))
+	types, err := s.d.typesByName(newEssentialName(name))
 	if err != nil {
 		return nil, err
 	}
@@ -533,7 +544,7 @@ func LoadSplitSpecFromReader(r io.ReaderAt, base *Spec) (*Spec, error) {
 // All iterates over all types.
 func (s *Spec) All() iter.Seq2[Type, error] {
 	return func(yield func(Type, error) bool) {
-		for id := s.firstTypeID; ; id++ {
+		for id := s.d.firstTypeID; ; id++ {
 			typ, err := s.TypeByID(id)
 			if errors.Is(err, ErrNotFound) {
 				return

--- a/btf/btf_test.go
+++ b/btf/btf_test.go
@@ -275,9 +275,8 @@ func BenchmarkIterateVmlinux(b *testing.B) {
 func TestParseCurrentKernelBTF(t *testing.T) {
 	spec := vmlinuxSpec(t)
 
-	if len(spec.offsets) == 0 {
-		t.Fatal("Empty kernel BTF")
-	}
+	_, err := spec.TypeByID(1)
+	qt.Assert(t, qt.IsNil(err))
 }
 
 func TestFindVMLinux(t *testing.T) {
@@ -293,8 +292,8 @@ func TestFindVMLinux(t *testing.T) {
 		t.Fatal("Can't load BTF:", err)
 	}
 
-	if len(spec.offsets) == 0 {
-		t.Fatal("Empty kernel BTF")
+	if _, err := spec.TypeByID(1); err != nil {
+		t.Fatal("Empty kernel BTF:", err)
 	}
 }
 

--- a/btf/core.go
+++ b/btf/core.go
@@ -210,8 +210,8 @@ func CORERelocate(relos []*CORERelocation, targets []*Spec, bo binary.ByteOrder,
 	resolveTargetTypeID := targets[0].TypeID
 
 	for _, target := range targets {
-		if bo != target.byteOrder {
-			return nil, fmt.Errorf("can't relocate %s against %s", bo, target.byteOrder)
+		if bo != target.byteOrder() {
+			return nil, fmt.Errorf("can't relocate %s against %s", bo, target.byteOrder())
 		}
 	}
 
@@ -264,7 +264,7 @@ func CORERelocate(relos []*CORERelocation, targets []*Spec, bo binary.ByteOrder,
 
 		var targetTypes []Type
 		for _, target := range targets {
-			namedTypes, err := target.TypesByName(essentialName)
+			namedTypes, err := target.d.typesByName(essentialName)
 			if errors.Is(err, ErrNotFound) {
 				continue
 			} else if err != nil {

--- a/btf/core_test.go
+++ b/btf/core_test.go
@@ -558,7 +558,7 @@ func TestCORERelocation(t *testing.T) {
 					relos = append(relos, reloInfo.Relo)
 				}
 
-				fixups, err := CORERelocate(relos, []*Spec{spec}, spec.byteOrder, spec.TypeID)
+				fixups, err := CORERelocate(relos, []*Spec{spec}, spec.byteOrder(), spec.TypeID)
 				if want := errs[name]; want != nil {
 					if !errors.Is(err, want) {
 						t.Fatal("Expected", want, "got", err)
@@ -696,7 +696,7 @@ func BenchmarkCORESkBuff(b *testing.B) {
 			b.ReportAllocs()
 
 			for b.Loop() {
-				_, err = CORERelocate([]*CORERelocation{relo}, []*Spec{spec}, spec.byteOrder, spec.TypeID)
+				_, err = CORERelocate([]*CORERelocation{relo}, []*Spec{spec}, spec.byteOrder(), spec.TypeID)
 				if err != nil {
 					b.Fatal(err)
 				}

--- a/btf/ext_info.go
+++ b/btf/ext_info.go
@@ -64,7 +64,7 @@ func loadExtInfos(r io.ReaderAt, bo binary.ByteOrder, spec *Spec) (*ExtInfos, er
 	}
 
 	buf := internal.NewBufferedSectionReader(r, extHeader.funcInfoStart(), int64(extHeader.FuncInfoLen))
-	btfFuncInfos, err := parseFuncInfos(buf, bo, spec.strings)
+	btfFuncInfos, err := parseFuncInfos(buf, bo, spec.strings())
 	if err != nil {
 		return nil, fmt.Errorf("parsing BTF function info: %w", err)
 	}
@@ -78,14 +78,14 @@ func loadExtInfos(r io.ReaderAt, bo binary.ByteOrder, spec *Spec) (*ExtInfos, er
 	}
 
 	buf = internal.NewBufferedSectionReader(r, extHeader.lineInfoStart(), int64(extHeader.LineInfoLen))
-	btfLineInfos, err := parseLineInfos(buf, bo, spec.strings)
+	btfLineInfos, err := parseLineInfos(buf, bo, spec.strings())
 	if err != nil {
 		return nil, fmt.Errorf("parsing BTF line info: %w", err)
 	}
 
 	lineInfos := make(map[string]LineOffsets, len(btfLineInfos))
 	for section, blis := range btfLineInfos {
-		lineInfos[section], err = newLineInfos(blis, spec.strings)
+		lineInfos[section], err = newLineInfos(blis, spec.strings())
 		if err != nil {
 			return nil, fmt.Errorf("section %s: line infos: %w", section, err)
 		}
@@ -97,14 +97,14 @@ func loadExtInfos(r io.ReaderAt, bo binary.ByteOrder, spec *Spec) (*ExtInfos, er
 
 	var btfCORERelos map[string][]bpfCORERelo
 	buf = internal.NewBufferedSectionReader(r, extHeader.coreReloStart(coreHeader), int64(coreHeader.COREReloLen))
-	btfCORERelos, err = parseCORERelos(buf, bo, spec.strings)
+	btfCORERelos, err = parseCORERelos(buf, bo, spec.strings())
 	if err != nil {
 		return nil, fmt.Errorf("parsing CO-RE relocation info: %w", err)
 	}
 
 	coreRelos := make(map[string]CORERelocationOffsets, len(btfCORERelos))
 	for section, brs := range btfCORERelos {
-		coreRelos[section], err = newRelocationInfos(brs, spec, spec.strings)
+		coreRelos[section], err = newRelocationInfos(brs, spec, spec.strings())
 		if err != nil {
 			return nil, fmt.Errorf("section %s: CO-RE relocations: %w", section, err)
 		}
@@ -526,7 +526,7 @@ func LoadLineInfos(reader io.Reader, bo binary.ByteOrder, recordNum uint32, spec
 		return LineOffsets{}, fmt.Errorf("parsing BTF line info: %w", err)
 	}
 
-	return newLineInfos(lis, spec.strings)
+	return newLineInfos(lis, spec.strings())
 }
 
 func newLineInfo(li bpfLineInfo, strings *stringTable) (LineOffset, error) {

--- a/btf/fuzz_test.go
+++ b/btf/fuzz_test.go
@@ -54,7 +54,7 @@ func FuzzExtInfo(f *testing.F) {
 		}
 
 		emptySpec := specFromTypes(t, nil)
-		emptySpec.strings = table
+		emptySpec.d.strings = table
 
 		info, err := loadExtInfos(bytes.NewReader(data), internal.NativeEndian, emptySpec)
 		if err != nil {

--- a/btf/kernel.go
+++ b/btf/kernel.go
@@ -52,7 +52,7 @@ func LoadKernelSpec() (*Spec, error) {
 			return nil, fmt.Errorf("load vmlinux: %w", err)
 		}
 
-		runtime.AddCleanup(spec.decoder.sharedBuf, func(b []byte) {
+		runtime.AddCleanup(spec.d.sharedBuf, func(b []byte) {
 			_ = unix.Munmap(b)
 		}, raw)
 

--- a/btf/marshal_test.go
+++ b/btf/marshal_test.go
@@ -123,7 +123,7 @@ limitTypes:
 	rebuilt, err := loadRawSpec(buf, nil)
 	qt.Assert(t, qt.IsNil(err), qt.Commentf("round tripping BTF failed"))
 
-	if n := len(rebuilt.offsets); n > math.MaxUint16 {
+	if n := rebuilt.d.len(); n > math.MaxUint16 {
 		t.Logf("Rebuilt BTF contains %d types which exceeds uint16, test may fail on older kernels", n)
 	}
 
@@ -281,7 +281,7 @@ func specFromTypes(tb testing.TB, types []Type) *Spec {
 func typesFromSpec(tb testing.TB, spec *Spec) []Type {
 	tb.Helper()
 
-	types := make([]Type, 0, len(spec.offsets))
+	types := make([]Type, 0, spec.d.len())
 
 	for typ, err := range spec.All() {
 		qt.Assert(tb, qt.IsNil(err))

--- a/btf/strings_test.go
+++ b/btf/strings_test.go
@@ -99,7 +99,7 @@ func TestStringTableBuilder(t *testing.T) {
 }
 
 func BenchmarkStringTableZeroLookup(b *testing.B) {
-	strings := vmlinuxTestdataSpec(b).strings
+	strings := vmlinuxTestdataSpec(b).strings()
 
 	for b.Loop() {
 		s, err := strings.Lookup(0)

--- a/btf/unmarshal.go
+++ b/btf/unmarshal.go
@@ -45,6 +45,12 @@ type decoder struct {
 	legacyBitfields map[TypeID][2]Bits // offset, size
 }
 
+// len returns the number of types in the decoder, including Void for
+// non-split BTF.
+func (d *decoder) len() int {
+	return len(d.offsets)
+}
+
 func newDecoder(raw []byte, bo binary.ByteOrder, strings *stringTable, base *decoder) (*decoder, error) {
 	firstTypeID := TypeID(0)
 	if base != nil {
@@ -56,7 +62,7 @@ func newDecoder(raw []byte, bo binary.ByteOrder, strings *stringTable, base *dec
 			return nil, fmt.Errorf("can't use split BTF as base")
 		}
 
-		firstTypeID = TypeID(len(base.offsets))
+		firstTypeID = TypeID(base.len())
 	}
 
 	var header btfType
@@ -174,15 +180,7 @@ func allBtfTypeOffsets(buf []byte, bo binary.ByteOrder, header *btfType) iter.Se
 	}
 }
 
-// Copy performs a deep copy of a decoder and its base.
-func (d *decoder) Copy() *decoder {
-	if d == nil {
-		return nil
-	}
-
-	return d.copy(nil)
-}
-
+// copy performs a deep copy of a decoder and its base.
 func (d *decoder) copy(copiedTypes map[Type]Type) *decoder {
 	if d == nil {
 		return nil
@@ -217,8 +215,8 @@ func (d *decoder) copy(copiedTypes map[Type]Type) *decoder {
 	}
 }
 
-// TypeID returns the ID for a Type previously obtained via [TypeByID].
-func (d *decoder) TypeID(typ Type) (TypeID, error) {
+// typeID returns the ID for a Type previously obtained via [TypeByID].
+func (d *decoder) typeID(typ Type) (TypeID, error) {
 	if _, ok := typ.(*Void); ok {
 		// Equality is weird for void, since it is a zero sized type.
 		return 0, nil
@@ -235,13 +233,13 @@ func (d *decoder) TypeID(typ Type) (TypeID, error) {
 	return id, nil
 }
 
-// TypesByName returns all types which have the given essential name.
+// typesByName returns all types which have the given essential name.
 //
 // Returns ErrNotFound if no matching Type exists.
-func (d *decoder) TypesByName(name essentialName) ([]Type, error) {
+func (d *decoder) typesByName(name essentialName) ([]Type, error) {
 	var types []Type
 	for id := range d.namedTypes.Find(string(name)) {
-		typ, err := d.TypeByID(id)
+		typ, err := d.typeByID(id)
 		if err != nil {
 			return nil, err
 		}
@@ -261,8 +259,8 @@ func (d *decoder) TypesByName(name essentialName) ([]Type, error) {
 	return types, nil
 }
 
-// TypeByID decodes a type and any of its descendants.
-func (d *decoder) TypeByID(id TypeID) (Type, error) {
+// typeByID decodes a type and any of its descendants.
+func (d *decoder) typeByID(id TypeID) (Type, error) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
@@ -356,7 +354,7 @@ func (d *decoder) inflateType(id TypeID) (typ Type, err error) {
 	}
 
 	idx := int(id - d.firstTypeID)
-	if idx >= len(d.offsets) {
+	if idx >= d.len() {
 		return nil, fmt.Errorf("type id %v: %w", id, ErrNotFound)
 	}
 


### PR DESCRIPTION
It looks like this had been exported by mistake in v0.19.0 and nobody noticed. The same happened to decoder.TypeByID and decoder.TypeID, but those were shadowed by their Spec equivalents.

@dylandreimerink WDYT? This is still inconsistent, not sure about committing to making it a named field instead.