### PR TITLE
feat: add unmarshal util to facilitate unit test

### DIFF
--- a/marshalers.go
+++ b/marshalers.go
@@ -208,3 +208,10 @@ func unmarshalBatchPerCPUValue(slice any, batchLen, elemLength int, buf []byte) 
 	}
 	return nil
 }
+
+// UnmarshalDataFromBytes unmarshals bytes to golang value
+// It is useful for testing
+// The original function is internal, which limits client to write unit test
+func UnmarshalDataFromBytes(data any, buf []byte) error {
+	return sysenc.Unmarshal(data, buf)
+}

--- a/marshalers_test.go
+++ b/marshalers_test.go
@@ -130,3 +130,16 @@ func makeFilledSlice(len int) []uint32 {
 	}
 	return slice
 }
+
+func TestUnmarshalDataFromBytes(t *testing.T) {
+	type Value struct {
+		X int16
+		Y int32
+		_ int16
+	}
+	got := Value{}
+	bytes := []byte{1, 0, 0, 1, 0, 0, 0, 0}
+	UnmarshalDataFromBytes(&got, bytes)
+	expected := Value{X: 1, Y: 256}
+	qt.Assert(t, qt.Equals(got, expected))
+}


### PR DESCRIPTION
# Background
- hard to write unit test for bpf map data unmarshal, becuse sysenc.Unmarshal() is in internal package
- integration testing is heavy and relies on linux syscall

# How
- add a wrapper to export internal function