### PR TITLE
platform: treat Android as Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,15 @@ jobs:
           go build -v ./...
           go test -c -o /dev/null ./... >/dev/null
 
+      - name: Cross build android
+        env:
+          CGO_ENABLED: 0
+          GOARCH: arm64
+          GOOS: android
+        run: |
+          go build -v ./...
+          go test -c -o /dev/null ./... >/dev/null
+
       - name: Cross build arm32
         env:
           GOARCH: arm

--- a/internal/feature.go
+++ b/internal/feature.go
@@ -75,9 +75,10 @@ type FeatureTestFn func() error
 // NewFeatureTest is a convenient way to create a single [FeatureTest].
 //
 // versions specifies in which version of a BPF runtime a feature appeared.
-// The format is "GOOS:Major.Minor[.Patch]". GOOS may be omitted when targeting
-// Linux. Returns [ErrNotSupportedOnOS] if there is no version specified for the
-// current OS.
+// The format is "Platform:Major.Minor[.Patch]", where Platform may identify
+// either the target GOOS or its native BPF platform. The platform may be
+// omitted when targeting Linux. Returns [ErrNotSupportedOnOS] if there is no
+// version specified for the current platform.
 func NewFeatureTest(name string, fn FeatureTestFn, versions ...string) func() error {
 	version, err := platform.SelectVersion(versions)
 	if err != nil {

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -11,28 +11,43 @@ const (
 	Windows = "windows"
 )
 
+// IsLinux and IsWindows identify the native BPF platform selected by the
+// current build. This may differ from runtime.GOOS, for example on Android,
+// which uses the Linux BPF platform.
 const (
 	IsLinux   = Native == Linux
-	IsWindows = runtime.GOOS == "windows"
+	IsWindows = Native == Windows
 )
 
-// SelectVersion extracts the platform-appropriate version from a list of strings like
-// `linux:6.1` or `windows:0.20.0`.
+// SelectVersion extracts the platform-appropriate version from a list of
+// strings like `linux:6.1` or `windows:0.20.0`. Prefixes may identify either
+// the target GOOS or its native BPF platform.
 //
 // Returns an empty string and nil if no version matched or an error if no strings were passed.
 func SelectVersion(versions []string) (string, error) {
-	const prefix = runtime.GOOS + ":"
+	return selectVersion(runtime.GOOS, Native, versions)
+}
 
+func selectVersion(goos, native string, versions []string) (string, error) {
 	if len(versions) == 0 {
 		return "", errors.New("no versions specified")
 	}
 
+	goosPrefix := goos + ":"
+	nativePrefix := native + ":"
+
 	for _, version := range versions {
-		if after, ok := strings.CutPrefix(version, prefix); ok {
+		if after, ok := strings.CutPrefix(version, goosPrefix); ok {
 			return after, nil
 		}
 
-		if IsLinux && !strings.ContainsRune(version, ':') {
+		if native != "" && native != goos {
+			if after, ok := strings.CutPrefix(version, nativePrefix); ok {
+				return after, nil
+			}
+		}
+
+		if native == Linux && !strings.ContainsRune(version, ':') {
 			// Allow version numbers without a GOOS prefix on Linux.
 			return version, nil
 		}

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -12,7 +12,7 @@ const (
 )
 
 const (
-	IsLinux   = runtime.GOOS == "linux"
+	IsLinux   = Native == Linux
 	IsWindows = runtime.GOOS == "windows"
 )
 

--- a/internal/platform/platform_test.go
+++ b/internal/platform/platform_test.go
@@ -1,0 +1,85 @@
+package platform
+
+import (
+	"testing"
+
+	"github.com/go-quicktest/qt"
+)
+
+func TestSelectVersion(t *testing.T) {
+	tests := []struct {
+		name     string
+		goos     string
+		native   string
+		versions []string
+		want     string
+		wantErr  bool
+	}{
+		{
+			name:    "no versions",
+			goos:    Linux,
+			native:  Linux,
+			wantErr: true,
+		},
+		{
+			name:     "android GOOS",
+			goos:     "android",
+			native:   Linux,
+			versions: []string{"android:14"},
+			want:     "14",
+		},
+		{
+			name:     "android native platform",
+			goos:     "android",
+			native:   Linux,
+			versions: []string{"linux:6.1"},
+			want:     "6.1",
+		},
+		{
+			name:     "android unprefixed Linux",
+			goos:     "android",
+			native:   Linux,
+			versions: []string{"6.1"},
+			want:     "6.1",
+		},
+		{
+			name:     "android ignores Windows",
+			goos:     "android",
+			native:   Linux,
+			versions: []string{"windows:0.20.0"},
+		},
+		{
+			name:     "Linux",
+			goos:     Linux,
+			native:   Linux,
+			versions: []string{"linux:6.1"},
+			want:     "6.1",
+		},
+		{
+			name:     "Windows",
+			goos:     Windows,
+			native:   Windows,
+			versions: []string{"windows:0.20.0"},
+			want:     "0.20.0",
+		},
+		{
+			name:     "other GOOS",
+			goos:     "darwin",
+			versions: []string{"darwin:14"},
+			want:     "14",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := selectVersion(test.goos, test.native, test.versions)
+			if test.wantErr {
+				qt.Assert(t, qt.IsNotNil(err))
+				return
+			}
+
+			qt.Assert(t, qt.IsNil(err))
+			qt.Assert(t, qt.Equals(got, test.want))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Derive `platform.IsLinux` from the native platform so Android follows the Linux path.
- Allow BPF token discovery to continue on Android instead of failing before the BPF syscall.

Related: #2062

## Test plan

- [x] `go test ./internal/platform ./internal/mountinfo`
- [x] `GOOS=android GOARCH=arm64 CGO_ENABLED=0 go build ./...`
- [x] `GOOS=android GOARCH=arm64 CGO_ENABLED=0 go test -exec=/usr/bin/true ./internal/platform ./internal/mountinfo ./internal/sys`
- [x] Verify map and program loading on an Android device
