### PR TITLE
asm: Allow StoreImm with DWord size

### DIFF
--- a/asm/instruction_test.go
+++ b/asm/instruction_test.go
@@ -469,3 +469,11 @@ func TestLongJumpPatching(t *testing.T) {
 		t.Errorf("Expected offset to be 3, got %d", insns[1].Constant)
 	}
 }
+
+func TestStoreImm(t *testing.T) {
+	qt.Assert(t, qt.Equals(StoreImm(R0, 1, math.MaxInt32, DWord).OpCode, 0x7a))
+	qt.Assert(t, qt.Equals(StoreImm(R0, 1, math.MinInt32, DWord).OpCode, 0x7a))
+
+	qt.Assert(t, qt.Equals(StoreImm(R0, 1, math.MaxInt32+1, DWord).OpCode, InvalidOpCode))
+	qt.Assert(t, qt.Equals(StoreImm(R0, 1, math.MinInt32-1, DWord).OpCode, InvalidOpCode))
+}

--- a/asm/load_store.go
+++ b/asm/load_store.go
@@ -313,7 +313,8 @@ func StoreImmOp(size Size) OpCode {
 
 // StoreImm emits `*(size *)(dst + offset) = value`.
 func StoreImm(dst Register, offset int16, value int64, size Size) Instruction {
-	if size == DWord {
+	// Immediate will be stored in 32 bits.
+	if int64(int32(value)) != value {
 		return Instruction{OpCode: InvalidOpCode}
 	}
 


### PR DESCRIPTION
Issue #1767 and commit 353dc6a "asm: return InvalidOpCode for StoreImm with DWord size" explicitly rejected StoreImm instructions with a DWord size, claiming there's no way to encode it in the ISA.

This isn't completely true: while there's no way to encode a StoreImm that stores a full 64 bit immediate, it's possible to use a 32 bit immediate, which is then sign extended to 64 bits.

https://docs.kernel.org/bpf/standardization/instruction-set.html#regular-load-and-store-operations says:

> Where ‘<size>’ is one of: B, H, W, or DW

The selftests also exercise this: https://elixir.bootlin.com/linux/v7.1.4/source/tools/testing/selftests/bpf/verifier/bpf_st_mem.c#L4