### PR TITLE
btf: fix exact name filtering

### DIFF
--- a/btf/btf.go
+++ b/btf/btf.go
@@ -402,15 +402,18 @@ func (s *Spec) AnyTypesByName(name string) ([]Type, error) {
 		return nil, err
 	}
 
-	for i := 0; i < len(types); i++ {
+	types = slices.DeleteFunc(types, func(typ Type) bool {
 		// Match against the full name, not just the essential one
 		// in case the type being looked up is a struct flavor.
-		if types[i].TypeName() != name {
-			types = slices.Delete(types, i, i+1)
-			continue
-		}
+		return typ.TypeName() != name
+	})
 
-		if err := s.elf.fixupDatasec(types[i]); err != nil {
+	if len(types) == 0 {
+		return nil, ErrNotFound
+	}
+
+	for _, typ := range types {
+		if err := s.elf.fixupDatasec(typ); err != nil {
 			return nil, err
 		}
 	}

--- a/btf/btf_test.go
+++ b/btf/btf_test.go
@@ -110,6 +110,39 @@ func TestAnyTypesByName(t *testing.T) {
 	})
 }
 
+func TestAnyTypesByNameExactMatch(t *testing.T) {
+	spec := specFromTypes(t, []Type{
+		&Int{Name: "foo___one", Size: 4},
+		&Int{Name: "foo___two", Size: 4},
+		&Int{Name: "foo", Size: 4},
+	})
+
+	types, err := spec.AnyTypesByName("foo")
+	qt.Assert(t, qt.IsNil(err))
+	qt.Assert(t, qt.HasLen(types, 1))
+	qt.Assert(t, qt.Equals(types[0].TypeName(), "foo"))
+}
+
+func TestAnyTypesByNameNoExactMatch(t *testing.T) {
+	spec := specFromTypes(t, []Type{
+		&Int{Name: "foo___flavour", Size: 4},
+	})
+
+	types, err := spec.AnyTypesByName("foo")
+	qt.Assert(t, qt.ErrorIs(err, ErrNotFound))
+	qt.Assert(t, qt.IsNil(types))
+}
+
+func TestAnyTypeByNameNoExactMatch(t *testing.T) {
+	spec := specFromTypes(t, []Type{
+		&Int{Name: "foo___flavour", Size: 4},
+	})
+
+	typ, err := spec.AnyTypeByName("foo")
+	qt.Assert(t, qt.ErrorIs(err, ErrNotFound))
+	qt.Assert(t, qt.IsNil(typ))
+}
+
 func TestTypeByNameAmbiguous(t *testing.T) {
 	testutils.Files(t, testutils.Glob(t, "testdata/relocs-*.elf"), func(t *testing.T, file string) {
 		spec := parseELFBTF(t, file)


### PR DESCRIPTION
Filter all essential-name candidates without skipping shifted entries. Return ErrNotFound when no exact match remains, preventing AnyTypeByName from indexing an empty result.

Found this while taking a peek at #2061