### PR TITLE
btf: parse BTF types in a single pass during decoder initialization

### DIFF
--- a/btf/unmarshal.go
+++ b/btf/unmarshal.go
@@ -66,33 +66,10 @@ func newDecoder(raw []byte, bo binary.ByteOrder, strings *stringTable, base *dec
 	}
 
 	var header btfType
-	var numTypes, numDeclTags, numNamedTypes int
 
-	for _, err := range allBtfTypeOffsets(raw, bo, &header) {
-		if err != nil {
-			return nil, err
-		}
-
-		numTypes++
-
-		if header.Kind() == kindDeclTag {
-			numDeclTags++
-		}
-
-		if header.NameOff != 0 {
-			numNamedTypes++
-		}
-	}
-
-	if firstTypeID == 0 {
-		// Allocate an extra slot for Void so we don't have to deal with
-		// constant off by one issues.
-		numTypes++
-	}
-
-	offsets := make([]int, 0, numTypes)
-	declTags := make(map[TypeID][]TypeID, numDeclTags)
-	namedTypes := newFuzzyStringIndex(numNamedTypes)
+	offsets := make([]int, 0, len(raw)/btfTypeSize)
+	declTags := make(map[TypeID][]TypeID)
+	namedTypes := newFuzzyStringIndex(0)
 
 	if firstTypeID == 0 {
 		// Add a sentinel for Void.
@@ -100,7 +77,11 @@ func newDecoder(raw []byte, bo binary.ByteOrder, strings *stringTable, base *dec
 	}
 
 	id := firstTypeID + TypeID(len(offsets))
-	for offset := range allBtfTypeOffsets(raw, bo, &header) {
+	for offset, err := range allBtfTypeOffsets(raw, bo, &header) {
+		if err != nil {
+			return nil, err
+		}
+
 		if id < firstTypeID {
 			return nil, fmt.Errorf("no more type IDs")
 		}


### PR DESCRIPTION
Fixes #2081

`newDecoder()` currently scans the raw BTF buffer twice: once to count the number of types and a second time to parse them into memory.

Since every BTF type header is at least 12 bytes (`btfTypeSize`), we can estimate the maximum possible number of types upfront (`len(raw) / btfTypeSize`) and parse all types in a single pass instead.

