### PR TITLE
features: fix FnSetRetval probe failure on kernel 7.2+

### DIFF
--- a/features/prog.go
+++ b/features/prog.go
@@ -246,14 +246,33 @@ func haveProgramHelper(pt ebpf.ProgramType, helper asm.BuiltinFunc) error {
 		return err
 	}
 
-	spec := &ebpf.ProgramSpec{
-		Type: pt,
-		Instructions: asm.Instructions{
+	insns := asm.Instructions{
+		helper.Call(),
+		asm.LoadImm(asm.R0, 0, asm.DWord),
+		asm.Return(),
+	}
+
+	// bpf_set_retval requires R1 to be a scalar value, not a context
+	// pointer. Since kernel 7.2 (commit "bpf: Add validation for
+	// bpf_set_retval argument"), the verifier rejects non-scalar R1
+	// with EINVAL. Pre-load R1 with an immediate so the probe tests
+	// helper availability rather than failing argument validation.
+	// The value 0 is within the allowed range [-MAX_ERRNO, 0] on 7.2+,
+	// and accepted as ARG_ANYTHING on older kernels.
+	switch helper {
+	case asm.FnSetRetval:
+		insns = asm.Instructions{
+			asm.Mov.Imm(asm.R1, 0),
 			helper.Call(),
 			asm.LoadImm(asm.R0, 0, asm.DWord),
 			asm.Return(),
-		},
-		License: "GPL",
+		}
+	}
+
+	spec := &ebpf.ProgramSpec{
+		Type:         pt,
+		Instructions: insns,
+		License:      "GPL",
 	}
 
 	switch pt {
@@ -305,6 +324,16 @@ func haveProgramHelper(pt ebpf.ProgramType, helper asm.BuiltinFunc) error {
 		wrongProgramType = wrongProgramType || logContainsAll(verr.Log, "unknown func")
 		if wrongProgramType {
 			return fmt.Errorf("program of this type cannot use helper: %w", ebpf.ErrNotSupported)
+		}
+
+		// The verifier didn't flag the helper as unknown or
+		// unsupported for this program type. If the helper's tag
+		// appears in the log, the verifier reached the call site
+		// and rejected it for argument validation reasons (e.g.
+		// kernel 7.2+ type checks on bpf_set_retval). The helper
+		// is available — treat like EACCES.
+		if logContainsAll(verr.Log, helperTag) {
+			err = nil
 		}
 	}
 


### PR DESCRIPTION
features: fix FnSetRetval probe failure on kernel 7.2+

Kernel 7.2 (commit "bpf: Add validation for bpf_set_retval argument" by Xu Kuohai) added explicit type checking for the first argument to bpf_set_retval in the BPF verifier. The helper now requires R1 to be SCALAR_VALUE in the range [-MAX_ERRNO, 0]. Previously, the argument type was ARG_ANYTHING with no validation.

The haveProgramHelper probe constructs a minimal BPF program that calls the helper as its first instruction, meaning R1 still holds PTR_TO_CTX from program entry. On kernel 7.2+, the verifier rejects this with EINVAL and the log message "R1 is not a scalar". This falls through the existing EINVAL handling (which only recognizes "invalid func" and "unknown func" as not-supported signals), causing features.HaveProgramHelper to return an unexpected error. In Cilium, this surfaces as a fatal startup failure when probing FnSetRetval for CGroupSock programs, blocking any configuration that depends on the probe (e.g. socketLB.hostNamespaceOnly=true for Kata Containers / gVisor compatibility).

This commit makes two changes: (1) Pre-load R1 with an immediate value of 0 before calling FnSetRetval in the probe program. The value 0 satisfies the new [-MAX_ERRNO, 0] range check on 7.2+ and is accepted as ARG_ANYTHING on older kernels, so the probe works on both. (2) In the EINVAL error handler, after exhausting the known "helper not found" patterns (invalid func, unknown func, wrong program type), check whether the helper's tag appears in the verifier log. If it does, the verifier reached and recognized the helper call — the EINVAL is from argument validation, not from the helper being unavailable. Treat this like EACCES (helper available, arguments wrong).

Refs: https://lore.kernel.org/bpf/20260605140243.664590-3-xukuohai@huaweicloud.com/
Refs: https://github.com/cilium/cilium/issues/48016

This is an AI contribution. The model that performed the change was opus-4.6, but I (the lowly human) reviewed and tested the change.
